### PR TITLE
[x87] Emulate FPATAN using atan2

### DIFF
--- a/src/felix86/common/utility.cpp
+++ b/src/felix86/common/utility.cpp
@@ -952,7 +952,7 @@ void felix86_fpatan(ThreadState* state) {
     double st0, st1;
     memcpy(&st0, &state->fp[0], sizeof(double));
     memcpy(&st1, &state->fp[1], sizeof(double));
-    double result = ::atan(st1 / st0);
+    double result = ::atan2(st1, st0);
     memcpy(&state->fp[1], &result, sizeof(double));
 }
 


### PR DESCRIPTION
The FPATAN instruction takes in 2 source operands in ST0 and ST1, corresponding to an X and Y coordinate respectively, and returns the angle between the positive X axis an (X, Y).

The resulting angle is in the range [-π, +π], which is in line with `atan2(y, x)`, as opposed to `atan(y / x)` which returns an angle in [-π/2, +π/2]. This means that any (X, Y) in the 2nd and 3rd quadrants currently return a wrong angle, potentially breaking 3D math in various games that use x87 instructions for trigonometry.

Should fix Portal 2.