### PR TITLE
Remove rootfs path from arguments

### DIFF
--- a/src/felix86/common/global.cpp
+++ b/src/felix86/common/global.cpp
@@ -271,14 +271,24 @@ void initialize_globals() {
         exit(1);
     }
 
-    if (g_config.rootfs_path.string().back() == '/') {
+    if (!std::filesystem::exists(g_config.rootfs_path)) {
+        ERROR("Rootfs path does not exist");
+    }
+
+    std::string srootfs_path = g_config.rootfs_path.string();
+    if (srootfs_path.size() == 1 && srootfs_path[0] == '/') {
+        ERROR("You selected the system root as the rootfs path, whiqch is wrong");
+    }
+
+    if (srootfs_path.back() == '/') {
         // User ended the path with '/', we need to remove it to make sure some of our comparisons
         // on whether a path is inside the rootfs continue to work
-        g_config.rootfs_path = g_config.rootfs_path.string().substr(0, g_config.rootfs_path.string().size() - 1);
+        g_config.rootfs_path = srootfs_path.substr(0, srootfs_path.size() - 1);
     }
     ASSERT(std::filesystem::exists(g_config.rootfs_path));
     ASSERT(std::filesystem::is_directory(g_config.rootfs_path));
     g_rootfs_fd = open(g_config.rootfs_path.c_str(), O_DIRECTORY);
+    ASSERT_MSG(g_rootfs_fd > 0, "Failed to open rootfs directory");
 
     const char* env_file = getenv("FELIX86_ENV_FILE");
     if (env_file) {

--- a/src/felix86/emulator.cpp
+++ b/src/felix86/emulator.cpp
@@ -223,6 +223,19 @@ std::pair<ExitReason, int> Emulator::Start(const StartParameters& config) {
     prctl(PR_RISCV_SET_ICACHE_FLUSH_CTX, PR_RISCV_CTX_SW_FENCEI_ON, PR_RISCV_SCOPE_PER_PROCESS);
 #endif
 
+    std::string path = g_params.executable_path;
+    ASSERT(path.find(g_config.rootfs_path.string()) == 0);
+    g_params.argv[0] = path;
+
+    for (auto& p : g_params.argv) {
+        // We need to remove any rootfs prefix from the arguments
+        if (p.find(g_config.rootfs_path) == 0) {
+            p = p.substr(g_config.rootfs_path.string().size());
+            ASSERT(!p.empty());
+            ASSERT(p[0] == '/');
+        }
+    }
+
     Elf::PeekResult peek = Elf::Peek(g_params.executable_path);
     std::filesystem::path script_path;
     bool is_script = false;
@@ -234,19 +247,6 @@ std::pair<ExitReason, int> Emulator::Start(const StartParameters& config) {
             script_path = g_params.executable_path;
             const std::filesystem::path& interpreter = script.GetInterpreter();
             const std::string& args = script.GetArgs();
-
-            std::string path = g_params.executable_path;
-            ASSERT(path.find(g_config.rootfs_path.string()) == 0);
-            g_params.argv[0] = path;
-
-            for (auto& p : g_params.argv) {
-                // We need to remove any rootfs prefix from the arguments
-                if (p.find(g_config.rootfs_path) == 0) {
-                    p = p.substr(g_config.rootfs_path.string().size());
-                    ASSERT(!p.empty());
-                    ASSERT(p[0] == '/');
-                }
-            }
 
             // Scripts start with a line that goes #! (usually) and that means
             // use the interpreter after #!. This can be bash, zsh, python, whatever.

--- a/src/felix86/emulator.cpp
+++ b/src/felix86/emulator.cpp
@@ -237,13 +237,16 @@ std::pair<ExitReason, int> Emulator::Start(const StartParameters& config) {
 
             std::string path = g_params.executable_path;
             ASSERT(path.find(g_config.rootfs_path.string()) == 0);
-
-            // We need to remove the rootfs prefix in the arguments, because the interpreter is going to see it
-            path = path.substr(g_config.rootfs_path.string().size());
-            ASSERT(!path.empty());
-            ASSERT(path[0] == '/');
-
             g_params.argv[0] = path;
+
+            for (auto& p : g_params.argv) {
+                // We need to remove any rootfs prefix from the arguments
+                if (p.find(g_config.rootfs_path) == 0) {
+                    p = p.substr(g_config.rootfs_path.string().size());
+                    ASSERT(!p.empty());
+                    ASSERT(p[0] == '/');
+                }
+            }
 
             // Scripts start with a line that goes #! (usually) and that means
             // use the interpreter after #!. This can be bash, zsh, python, whatever.

--- a/src/felix86/emulator.cpp
+++ b/src/felix86/emulator.cpp
@@ -227,10 +227,13 @@ std::pair<ExitReason, int> Emulator::Start(const StartParameters& config) {
     ASSERT(path.find(g_config.rootfs_path.string()) == 0);
     g_params.argv[0] = path;
 
-    for (auto& p : g_params.argv) {
+    for (int i = 0; i < g_params.argv.size(); i++) {
         // We need to remove any rootfs prefix from the arguments
+        auto& p = g_params.argv[i];
         if (p.find(g_config.rootfs_path) == 0) {
-            p = p.substr(g_config.rootfs_path.string().size());
+            auto new_p = p.substr(g_config.rootfs_path.string().size());
+            LOG("Renamed arg[%d] %s -> %s", i, p.c_str(), new_p.c_str());
+            p = new_p;
             ASSERT(!p.empty());
             ASSERT(p[0] == '/');
         }


### PR DESCRIPTION
Allows you to run
```
felix86 /rootfs/usr/bin/wine /rootfs/myfile.exe
```

The /rootfs/myfile.exe would cause problems before because the prefix wasn't removed before being passed to the guest