### PR TITLE
ioctl_tty: `TCGETS` and `TIOCGWINSZ`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -113,6 +113,7 @@ set(FELIX86_HLE_SOURCES
     src/felix86/hle/ioctl/drm.cpp
     src/felix86/hle/ioctl/fat.cpp
     src/felix86/hle/ioctl/fs.cpp
+    src/felix86/hle/ioctl/tty.cpp
     src/felix86/hle/ioctl/radeon.cpp
 )
 

--- a/src/felix86/hle/ioctl/tty.cpp
+++ b/src/felix86/hle/ioctl/tty.cpp
@@ -8,6 +8,8 @@
 
 int ioctl32_tty(int fd, u32 cmd, u32 args) {
     switch (_IOC_NR(cmd)) {
+        SIMPLE_CASE(TCGETS);
+        SIMPLE_CASE(TIOCGWINSZ);
     default: {
         ERROR("Unknown TTY ioctl cmd: %x", cmd);
         return -1;

--- a/src/felix86/hle/ioctl/tty.cpp
+++ b/src/felix86/hle/ioctl/tty.cpp
@@ -1,0 +1,16 @@
+#include <asm/ioctl.h>
+#include <sys/ioctl.h>
+#include <termios.h>
+#include "felix86/common/log.hpp"
+#include "felix86/hle/guest_types.hpp"
+#include "felix86/hle/ioctl/common.hpp"
+#include "felix86/hle/ioctl/tty.hpp"
+
+int ioctl32_tty(int fd, u32 cmd, u32 args) {
+    switch (_IOC_NR(cmd)) {
+    default: {
+        ERROR("Unknown TTY ioctl cmd: %x", cmd);
+        return -1;
+    }
+    }
+}

--- a/src/felix86/hle/ioctl/tty.hpp
+++ b/src/felix86/hle/ioctl/tty.hpp
@@ -1,0 +1,6 @@
+
+#pragma once
+
+#include "felix86/common/types.hpp"
+
+int ioctl32_tty(int fd, u32 cmd, u32 args);

--- a/src/felix86/hle/ioctl32.cpp
+++ b/src/felix86/hle/ioctl32.cpp
@@ -10,6 +10,7 @@
 #include "felix86/hle/ioctl/drm.hpp"
 #include "felix86/hle/ioctl/fat.hpp"
 #include "felix86/hle/ioctl/fs.hpp"
+#include "felix86/hle/ioctl/tty.hpp"
 #include "felix86/hle/ioctl/radeon.hpp"
 
 int ioctl32_default(int fd, u32 cmd, u32 args) {
@@ -38,6 +39,9 @@ int ioctl32(int fd, u32 cmd, u32 args) {
     }
     case 'r': {
         return ioctl32_fat(fd, cmd, args);
+    }
+    case 'T': {
+        return ioctl32_tty(fd, cmd, args);
     }
     default: {
         return ioctl32_unknown(fd, cmd, args);


### PR DESCRIPTION
Handler structure same as `ioctl_fs` (first commit)

`TCGETS` arg0 is `struct termios`  https://elixir.bootlin.com/linux/v6.15/source/drivers/tty/tty_ioctl.c#L809
`TIOCGWINSZ` arg0 is `struct winsize`  https://elixir.bootlin.com/linux/v6.15/source/drivers/tty/tty_io.c#L2315

pls, check

also, mo ioctl errors when starting `wine explorer`
