### PR TITLE
Add binfmt_misc detection and run execve'd apps through binfmt_misc if possible

### DIFF
--- a/src/felix86/common/config.inc
+++ b/src/felix86/common/config.inc
@@ -2,7 +2,7 @@
 X(General, std::filesystem::path, rootfs_path, "", FELIX86_ROOTFS, "Set the rootfs path, required for the emulator to work", true)
 X(General, std::filesystem::path, thunks_path, "", FELIX86_THUNKS, "Set the thunk libraries path", false)
 X(General, std::string, enabled_thunks, "none", FELIX86_ENABLED_THUNKS, "Set the enabled thunks, possible choices: \"vk, glx, wayland, egl\" or \"all\"", false)
-X(General, bool, binfmt_misc_installed, false, __FELIX86_DONT_SET_ME__, "Whether binfmt_misc is installed, do NOT change this manually unless if you know what you're doing -- install with `felix86 --binfmt-misc` instead", false)
+X(General, bool, binfmt_misc_installed, false, FELIX86_BINFMT_MISC_INSTALLED, "Whether binfmt_misc is installed, do NOT change this manually unless if you know what you're doing -- install with `felix86 --binfmt-misc` instead", false)
 
 X(Logging, bool, verbose, false, FELIX86_VERBOSE, "Enable verbose logging", false)
 X(Logging, bool, quiet, false, FELIX86_QUIET, "Disable all logging", false)

--- a/src/felix86/common/config.inc
+++ b/src/felix86/common/config.inc
@@ -2,7 +2,7 @@
 X(General, std::filesystem::path, rootfs_path, "", FELIX86_ROOTFS, "Set the rootfs path, required for the emulator to work", true)
 X(General, std::filesystem::path, thunks_path, "", FELIX86_THUNKS, "Set the thunk libraries path", false)
 X(General, std::string, enabled_thunks, "none", FELIX86_ENABLED_THUNKS, "Set the enabled thunks, possible choices: \"vk, glx, wayland, egl\" or \"all\"", false)
-X(General, bool, binfmt_misc_installed, false, __FELIX86__UNUSED__, "Whether binfmt_misc is installed, do NOT change this manually unless if you know what you're doing -- install with `felix86 --binfmt-misc` instead", false)
+X(General, bool, binfmt_misc_installed, false, __FELIX86_DONT_SET_ME__, "Whether binfmt_misc is installed, do NOT change this manually unless if you know what you're doing -- install with `felix86 --binfmt-misc` instead", false)
 
 X(Logging, bool, verbose, false, FELIX86_VERBOSE, "Enable verbose logging", false)
 X(Logging, bool, quiet, false, FELIX86_QUIET, "Disable all logging", false)

--- a/src/felix86/common/config.inc
+++ b/src/felix86/common/config.inc
@@ -2,6 +2,7 @@
 X(General, std::filesystem::path, rootfs_path, "", FELIX86_ROOTFS, "Set the rootfs path, required for the emulator to work", true)
 X(General, std::filesystem::path, thunks_path, "", FELIX86_THUNKS, "Set the thunk libraries path", false)
 X(General, std::string, enabled_thunks, "none", FELIX86_ENABLED_THUNKS, "Set the enabled thunks, possible choices: \"vk, glx, wayland, egl\" or \"all\"", false)
+X(General, bool, binfmt_misc_installed, false, __FELIX86__UNUSED__, "Whether binfmt_misc is installed, do NOT change this manually unless if you know what you're doing -- install with `felix86 --binfmt-misc` instead", false)
 
 X(Logging, bool, verbose, false, FELIX86_VERBOSE, "Enable verbose logging", false)
 X(Logging, bool, quiet, false, FELIX86_QUIET, "Disable all logging", false)

--- a/src/felix86/common/global.cpp
+++ b/src/felix86/common/global.cpp
@@ -43,7 +43,6 @@ StartParameters g_params{};
 int g_linux_major = 0;
 int g_linux_minor = 0;
 bool g_no_riscv_v_state{};
-bool g_binfmt_misc = false;
 
 // g_output_fd should be replaced upon connecting to the server, however if an error occurs before then we should at least log it
 int g_output_fd = STDERR_FILENO;

--- a/src/felix86/common/global.cpp
+++ b/src/felix86/common/global.cpp
@@ -43,6 +43,7 @@ StartParameters g_params{};
 int g_linux_major = 0;
 int g_linux_minor = 0;
 bool g_no_riscv_v_state{};
+bool g_binfmt_misc = false;
 
 // g_output_fd should be replaced upon connecting to the server, however if an error occurs before then we should at least log it
 int g_output_fd = STDERR_FILENO;

--- a/src/felix86/common/global.cpp
+++ b/src/felix86/common/global.cpp
@@ -268,8 +268,7 @@ void initialize_globals() {
     }
 
     if (g_config.rootfs_path.empty()) {
-        printf("Rootfs path is empty. Please set the FELIX86_ROOTFS environment variable or the rootfs_path variable in %s\n",
-               g_config.path().c_str());
+        printf("Rootfs path is empty. Please run `felix86 -s <rootfs_path>` or set the rootfs_path variable in %s\n", g_config.path().c_str());
 
         if (geteuid() == 0) {
             printf("\nI noticed you are running as root, did you forget to pass `-E` to sudo?\n");

--- a/src/felix86/common/global.hpp
+++ b/src/felix86/common/global.hpp
@@ -86,7 +86,6 @@ extern std::unique_ptr<GDBJIT> g_gdbjit;
 extern int g_linux_major;
 extern int g_linux_minor;
 extern bool g_no_riscv_v_state;
-extern bool g_binfmt_misc;
 
 bool parse_extensions(const char* ext);
 void initialize_globals();

--- a/src/felix86/common/global.hpp
+++ b/src/felix86/common/global.hpp
@@ -86,6 +86,7 @@ extern std::unique_ptr<GDBJIT> g_gdbjit;
 extern int g_linux_major;
 extern int g_linux_minor;
 extern bool g_no_riscv_v_state;
+extern bool g_binfmt_misc;
 
 bool parse_extensions(const char* ext);
 void initialize_globals();

--- a/src/felix86/common/perf.hpp
+++ b/src/felix86/common/perf.hpp
@@ -12,14 +12,16 @@ struct Perf {
             fd = fileno(f);
             ASSERT(fd > 0);
         } else if (g_config.perf_blocks || g_config.perf_libs || g_config.perf_global) {
+            // TODO: for some reason, running a setuid app through binfmt_misc after being forked
+            // loves failing the fopen and idk why, but game processes aren't setuid so we can perf them fine
             WARN("Failed to open perf map file for process %d", getpid());
-        } else {
-            WARN("File: %s", path.c_str());
         }
     }
 
     ~Perf() {
-        fclose(f);
+        if (f) {
+            fclose(f);
+        }
     }
 
     void addToFile(unsigned long address, unsigned long size, const std::string& symbol) {

--- a/src/felix86/common/perf.hpp
+++ b/src/felix86/common/perf.hpp
@@ -13,9 +13,6 @@ struct Perf {
             ASSERT(fd > 0);
         } else if (g_config.perf_blocks || g_config.perf_libs || g_config.perf_global) {
             WARN("Failed to open perf map file for process %d", getpid());
-            g_config.perf_blocks = false;
-            g_config.perf_libs = false;
-            g_config.perf_global = false;
         } else {
             WARN("File: %s", path.c_str());
         }
@@ -26,9 +23,11 @@ struct Perf {
     }
 
     void addToFile(unsigned long address, unsigned long size, const std::string& symbol) {
-        std::string full = fmt::format("{:x} {:x} {}\n", address, size, symbol);
-        int written = syscall(SYS_write, fd, full.data(), full.size());
-        ASSERT_MSG(written == (int)full.size(), "%lx != %lx (errno: %d)", written, full.size(), errno);
+        if (f) {
+            std::string full = fmt::format("{:x} {:x} {}\n", address, size, symbol);
+            int written = syscall(SYS_write, fd, full.data(), full.size());
+            ASSERT_MSG(written == (int)full.size(), "%lx != %lx (errno: %d)", written, full.size(), errno);
+        }
     }
 
 private:

--- a/src/felix86/common/perf.hpp
+++ b/src/felix86/common/perf.hpp
@@ -8,7 +8,7 @@ struct Perf {
     Perf() {
         std::string path = "/tmp/perf-" + std::to_string(getpid()) + ".map";
         f = fopen(path.c_str(), "a");
-        ASSERT(f);
+        ASSERT_MSG(f, "Failed to open perf file: %d", errno);
         fd = fileno(f);
         ASSERT(fd > 0);
     }

--- a/src/felix86/common/perf.hpp
+++ b/src/felix86/common/perf.hpp
@@ -8,9 +8,17 @@ struct Perf {
     Perf() {
         std::string path = "/tmp/perf-" + std::to_string(getpid()) + ".map";
         f = fopen(path.c_str(), "a");
-        ASSERT_MSG(f, "Failed to open perf file: %d", errno);
-        fd = fileno(f);
-        ASSERT(fd > 0);
+        if (f) {
+            fd = fileno(f);
+            ASSERT(fd > 0);
+        } else if (g_config.perf_blocks || g_config.perf_libs || g_config.perf_global) {
+            WARN("Failed to open perf map file for process %d", getpid());
+            g_config.perf_blocks = false;
+            g_config.perf_libs = false;
+            g_config.perf_global = false;
+        } else {
+            WARN("File: %s", path.c_str());
+        }
     }
 
     ~Perf() {

--- a/src/felix86/common/utility.cpp
+++ b/src/felix86/common/utility.cpp
@@ -1608,7 +1608,7 @@ bool unregister_binfmt_misc(const std::string& name) {
 
     for (auto& dir : dirs) {
         std::error_code ec;
-        std::filesystem::path path = dir / name;
+        std::filesystem::path path = dir / (name + ".conf");
         if (std::filesystem::exists(path, ec)) {
             std::filesystem::remove(path);
         }

--- a/src/felix86/common/utility.cpp
+++ b/src/felix86/common/utility.cpp
@@ -1595,7 +1595,26 @@ bool check_if_privileged_executable(const std::filesystem::path& path) {
     return false;
 }
 
-bool unregister_binfmt_misc(const std::filesystem::path& path) {
+bool unregister_binfmt_misc(const std::string& name) {
+    ASSERT(!name.empty());
+
+    // These are the directories systemd looks in
+    std::vector<std::filesystem::path> dirs = {
+        "/etc/binfmt.d",
+        "/run/binfmt.d",
+        "/usr/local/lib/binfmt.d",
+        "/usr/lib/binfmt.d",
+    };
+
+    for (auto& dir : dirs) {
+        std::error_code ec;
+        std::filesystem::path path = dir / name;
+        if (std::filesystem::exists(path, ec)) {
+            std::filesystem::remove(path);
+        }
+    }
+
+    std::filesystem::path path = std::filesystem::path("/proc/sys/fs/binfmt_misc") / name;
     if (!std::filesystem::exists(path)) {
         return false;
     }

--- a/src/felix86/common/utility.cpp
+++ b/src/felix86/common/utility.cpp
@@ -2,6 +2,7 @@
 #include <cstring>
 #include <fstream>
 #include <sys/ioctl.h>
+#include <sys/stat.h>
 #include "Zydis/Decoder.h"
 #include "Zydis/Disassembler.h"
 #include "felix86/common/elf.hpp"
@@ -1582,4 +1583,33 @@ const std::string& felix86_cpuinfo() {
     }();
     return cpuinfo;
 #undef ADD_FLAG
+}
+
+bool check_if_privileged_executable(const std::filesystem::path& path) {
+    struct stat st;
+    if (stat(path.c_str(), &st) == -1) {
+        if (st.st_mode & S_ISUID) {
+            return true;
+        }
+    }
+    return false;
+}
+
+bool unregister_binfmt_misc(const std::filesystem::path& path) {
+    if (!std::filesystem::exists(path)) {
+        return false;
+    }
+
+    FILE* fp = fopen(path.c_str(), "w");
+    if (!fp) {
+        return false;
+    }
+
+    if (fwrite("-1", 1, 2, fp) != 2) {
+        fclose(fp);
+        return false;
+    }
+
+    fclose(fp);
+    return true;
 }

--- a/src/felix86/common/utility.cpp
+++ b/src/felix86/common/utility.cpp
@@ -1587,7 +1587,7 @@ const std::string& felix86_cpuinfo() {
 
 bool check_if_privileged_executable(const std::filesystem::path& path) {
     struct stat st;
-    if (stat(path.c_str(), &st) == -1) {
+    if (stat(path.c_str(), &st) == 0) {
         if (st.st_mode & S_ISUID) {
             return true;
         }

--- a/src/felix86/common/utility.hpp
+++ b/src/felix86/common/utility.hpp
@@ -161,4 +161,4 @@ const std::string& felix86_cpuinfo();
 
 bool check_if_privileged_executable(const std::filesystem::path& path);
 
-bool unregister_binfmt_misc(const std::filesystem::path& path);
+bool unregister_binfmt_misc(const std::string& path);

--- a/src/felix86/common/utility.hpp
+++ b/src/felix86/common/utility.hpp
@@ -161,4 +161,5 @@ const std::string& felix86_cpuinfo();
 
 bool check_if_privileged_executable(const std::filesystem::path& path);
 
+// TODO: move me to new binfmt.hpp file along with binfmt_misc function
 bool unregister_binfmt_misc(const std::string& path);

--- a/src/felix86/common/utility.hpp
+++ b/src/felix86/common/utility.hpp
@@ -158,3 +158,7 @@ void felix86_fxam(ThreadState* state);
 
 std::string felix86_maps();
 const std::string& felix86_cpuinfo();
+
+bool check_if_privileged_executable(const std::filesystem::path& path);
+
+bool unregister_binfmt_misc(const std::filesystem::path& path);

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -1281,10 +1281,6 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
         // We need to tell the new process where the server is
         std::string log_env = std::string("__FELIX86_PIPE=") + Logger::getPipeName();
         envp.push_back("__FELIX86_EXECVE=1");
-        if (g_binfmt_misc) {
-            // Tell the execve process that we already detected binfmt_misc support
-            envp.push_back("__FELIX86_BINFMT_MISC=1");
-        }
         envp.push_back(log_env.c_str());
         envp.push_back(nullptr);
 

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -1207,7 +1207,7 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
         // Resolving this symlink helps gdb find the path
         std::filesystem::path executable;
 
-        if (!g_binfmt_misc) {
+        if (!g_config.binfmt_misc_installed) {
             executable = g_emulator_path;
             argv.push_back(executable.c_str());
             argv.push_back(path.c_str());

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -1205,12 +1205,34 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
         std::vector<const char*> envp;
 
         // Resolving this symlink helps gdb find the path
-        std::filesystem::path emulator = g_emulator_path;
-        argv.push_back(emulator.c_str());
+        std::filesystem::path executable;
+
+        if (!g_binfmt_misc) {
+            executable = g_emulator_path;
+            argv.push_back(executable.c_str());
+            argv.push_back(path.c_str());
+
+            struct stat st;
+            if (stat(path.c_str(), &st) == -1) {
+                if (st.st_mode & S_ISUID) {
+                    // If this bit is detected, it won't work out if we don't have binfmt_misc support
+                    // Because binfmt_misc would see that the binary has extra permissions and give the executable
+                    // those permissions as well. When we run it through the emulator manually however, we can't
+                    // do the same. So warn that this might end badly.
+                    WARN("About to run privileged executable %s, but there's no binfmt_misc support, so things may go wrong. Please enable "
+                         "binfmt_misc support by running `felix86 -b` and disabling it for any other x86/x86-64 emulators");
+                }
+            } else {
+                WARN("Couldn't stat %s?", path.c_str());
+            }
+        } else {
+            executable = path;
+            // Don't push the emulator, push just the executable and binfmt_misc will figure it out
+            argv.push_back(path.c_str());
+        }
 
         if (arg2) {
             u8* guest_argv = (u8*)arg2;
-            argv.push_back(path.c_str()); // push the resolved path instead of the path in argv[0];
             guest_argv += g_mode32 ? 4 : 8;
             while (true) {
                 u64 ptr = 0;
@@ -1224,8 +1246,6 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
             }
         } else {
             WARN("argv null during execve...?");
-            // Args shouldn't be null normally, but at least push the emulated executable here
-            argv.push_back(path.c_str());
         }
         argv.push_back(nullptr);
 
@@ -1266,6 +1286,10 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
         // We need to tell the new process where the server is
         std::string log_env = std::string("__FELIX86_PIPE=") + Logger::getPipeName();
         envp.push_back("__FELIX86_EXECVE=1");
+        if (g_binfmt_misc) {
+            // Tell the execve process that we already detected binfmt_misc support
+            envp.push_back("__FELIX86_BINFMT_MISC=1");
+        }
         envp.push_back(log_env.c_str());
         envp.push_back(nullptr);
 
@@ -1277,7 +1301,7 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
 
         LOG("Running execve, wish me luck:%s", args.c_str());
 
-        syscall(SYS_execve, emulator.c_str(), argv.data(), envp.data());
+        syscall(SYS_execve, executable.c_str(), argv.data(), envp.data());
 
         UNREACHABLE();
         break;

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -1220,7 +1220,9 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
                 WARN("About to run privileged executable %s, but there's no binfmt_misc support, so things may go wrong. Please enable "
                      "binfmt_misc support by running `felix86 -b` and disabling it for any other x86/x86-64 emulators");
             }
+            printf("BBBBBBBBBBBBBB\n");
         } else {
+            printf("AAAAAAAAAAAAAA\n");
             executable = path;
             // Don't push the emulator, push just the executable and binfmt_misc will figure it out
             argv.push_back(path.c_str());

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -1212,18 +1212,13 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
             argv.push_back(executable.c_str());
             argv.push_back(path.c_str());
 
-            struct stat st;
-            if (stat(path.c_str(), &st) == -1) {
-                if (st.st_mode & S_ISUID) {
-                    // If this bit is detected, it won't work out if we don't have binfmt_misc support
-                    // Because binfmt_misc would see that the binary has extra permissions and give the executable
-                    // those permissions as well. When we run it through the emulator manually however, we can't
-                    // do the same. So warn that this might end badly.
-                    WARN("About to run privileged executable %s, but there's no binfmt_misc support, so things may go wrong. Please enable "
-                         "binfmt_misc support by running `felix86 -b` and disabling it for any other x86/x86-64 emulators");
-                }
-            } else {
-                WARN("Couldn't stat %s?", path.c_str());
+            if (check_if_privileged_executable(path)) {
+                // If this is a privileged executable, it won't work out if we don't have binfmt_misc support
+                // Because binfmt_misc would see that the binary has extra permissions and give the emulator
+                // those permissions as well. When we run it through the emulator manually however, we can't
+                // do the same. So warn that this might end badly.
+                WARN("About to run privileged executable %s, but there's no binfmt_misc support, so things may go wrong. Please enable "
+                     "binfmt_misc support by running `felix86 -b` and disabling it for any other x86/x86-64 emulators");
             }
         } else {
             executable = path;

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -1220,9 +1220,7 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
                 WARN("About to run privileged executable %s, but there's no binfmt_misc support, so things may go wrong. Please enable "
                      "binfmt_misc support by running `felix86 -b` and disabling it for any other x86/x86-64 emulators");
             }
-            printf("BBBBBBBBBBBBBB\n");
         } else {
-            printf("AAAAAAAAAAAAAA\n");
             executable = path;
             // Don't push the emulator, push just the executable and binfmt_misc will figure it out
             argv.push_back(path.c_str());

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -145,6 +145,7 @@ bool detect_binfmt_misc() {
             env++;
         }
 
+        envs.push_back("ASDASDASD=1");
         envs.push_back("__FELIX86_TEST_BINFMT_MISC=1");
         envs.push_back(nullptr);
 

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -145,8 +145,8 @@ bool detect_binfmt_misc() {
             env++;
         }
 
-        envs.push_back("ASDASDASD=1");
         envs.push_back("__FELIX86_TEST_BINFMT_MISC=1");
+        envs.push_back("ASDASDASD=1");
         envs.push_back(nullptr);
 
         for (auto e : envs) {
@@ -425,6 +425,11 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
 static struct argp argp = {options, parse_opt, args_doc, doc};
 
 int main(int argc, char* argv[]) {
+    char** e = environ;
+    while (*e) {
+        printf("GOT: %s\n", *e);
+        e++;
+    }
     if (getenv("__FELIX86_TEST_BINFMT_MISC")) {
         // This shouldn't be printed as when we run /bin/env in detect_binfmt_misc we mute stdout and stderr
         WARN("__FELIX86_TEST_BINFMT_MISC was detected, if you see this then something is wrong");

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -150,8 +150,6 @@ bool detect_binfmt_misc() {
 
         std::vector<const char*> args = {
             path.c_str(),
-            "-n",
-            "\"\"",
             nullptr,
         };
 

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -132,7 +132,7 @@ bool detect_binfmt_misc() {
     // and thus binfmt_misc is correctly installed. If anything else is returned it means we didn't run it
     // through binfmt_misc thus it's not installed.
     std::error_code ec;
-    std::filesystem::path path = g_config.rootfs_path / "/bin/echo";
+    std::filesystem::path path = g_config.rootfs_path / "bin/echo";
     if (std::filesystem::exists(path, ec) && std::filesystem::is_regular_file(path, ec)) {
         pid_t pid;
         int status;

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -190,6 +190,7 @@ bool detect_binfmt_misc() {
     }
 }
 
+// TODO: Move me to binfmt.hpp file along with unregister_binfmt_misc
 void binfmt_misc(bool is_register) {
     if (!Sudo::hasPermissions()) {
         printf("I need root permissions to register/unregister felix86 in binfmt_misc, please re-run with root permissions\n");

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -132,7 +132,7 @@ bool detect_binfmt_misc() {
     // and thus binfmt_misc is correctly installed. If anything else is returned it means we didn't run it
     // through binfmt_misc thus it's not installed.
     std::error_code ec;
-    std::filesystem::path path = g_config.rootfs_path / "bin/echo";
+    std::filesystem::path path = g_config.rootfs_path / "bin/env";
     if (std::filesystem::exists(path, ec) && std::filesystem::is_regular_file(path, ec)) {
         pid_t pid;
         int status;
@@ -183,7 +183,7 @@ bool detect_binfmt_misc() {
         close(devnull);
         posix_spawn_file_actions_destroy(&actions);
 
-        // $ROOTFS/bin/echo was run through felix86, thus binfmt_misc is installed
+        // $ROOTFS/bin/env was run through felix86, thus binfmt_misc is installed
         return exit_status == 0x42;
     } else {
         return false;
@@ -256,7 +256,7 @@ void binfmt_misc(bool is_register) {
 
         if (!detect_binfmt_misc()) {
             printf(ANSI_COLOR_YELLOW
-                   "Even though I installed felix86 in binfmt_misc, I couldn't run a simple binary with it. Either /bin/echo is missing in rootfs or "
+                   "Even though I installed felix86 in binfmt_misc, I couldn't run a simple binary with it. Either /bin/env is missing in rootfs or "
                    "there's conflicting emulators in binfmt_misc which may make felix86 not work correctly" ANSI_COLOR_RESET "\n");
         }
 
@@ -423,7 +423,7 @@ static struct argp argp = {options, parse_opt, args_doc, doc};
 
 int main(int argc, char* argv[]) {
     if (getenv("__FELIX86_TEST_BINFMT_MISC")) {
-        // This shouldn't be printed as when we run /usr/bin/echo in detect_binfmt_misc we mute stdout and stderr
+        // This shouldn't be printed as when we run /bin/env in detect_binfmt_misc we mute stdout and stderr
         WARN("__FELIX86_TEST_BINFMT_MISC was detected, if you see this then something is wrong");
 
         // Magic value expected by detect_binfmt_misc

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -160,8 +160,8 @@ bool detect_binfmt_misc() {
 
         posix_spawn_file_actions_t actions;
         posix_spawn_file_actions_init(&actions);
-        posix_spawn_file_actions_adddup2(&actions, devnull, STDOUT_FILENO);
-        posix_spawn_file_actions_adddup2(&actions, devnull, STDERR_FILENO);
+        // posix_spawn_file_actions_adddup2(&actions, devnull, STDOUT_FILENO);
+        // posix_spawn_file_actions_adddup2(&actions, devnull, STDERR_FILENO);
 
         if (posix_spawn(&pid, path.c_str(), &actions, NULL, (char**)args.data(), (char**)envs.data()) != 0) {
             return false;

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -156,8 +156,8 @@ bool detect_binfmt_misc() {
 
         posix_spawn_file_actions_t actions;
         posix_spawn_file_actions_init(&actions);
-        posix_spawn_file_actions_adddup2(&actions, devnull, STDOUT_FILENO);
-        posix_spawn_file_actions_adddup2(&actions, devnull, STDERR_FILENO);
+        // posix_spawn_file_actions_adddup2(&actions, devnull, STDOUT_FILENO);
+        // posix_spawn_file_actions_adddup2(&actions, devnull, STDERR_FILENO);
 
         if (posix_spawn(&pid, path.c_str(), &actions, NULL, (char**)args.data(), (char**)envs.data()) != 0) {
             return false;
@@ -186,7 +186,14 @@ bool detect_binfmt_misc() {
 
 void binfmt_misc(bool is_register) {
     if (!Sudo::hasPermissions()) {
-        PLAIN("I need root permissions to register/unregister felix86 in binfmt_misc, please re-run with root permissions");
+        printf("I need root permissions to register/unregister felix86 in binfmt_misc, please re-run with root permissions\n");
+        exit(1);
+    }
+
+    Config::initialize();
+    if (g_config.rootfs_path.empty()) {
+        printf("Rootfs path is not set, did you not pass the environment variables when running with sudo? Try `sudo -E felix86 --binfmt-misc` or "
+               "set the rootfs path\n");
         exit(1);
     }
 
@@ -213,7 +220,6 @@ void binfmt_misc(bool is_register) {
             printf("Unregistered felix86 from binfmt_misc for i386 apps");
         }
 
-        Config::initialize();
         g_config.binfmt_misc_installed = false;
         Config::save(g_config.path(), g_config);
         printf("felix86 successfully unregistered from binfmt_misc\n");
@@ -239,9 +245,7 @@ void binfmt_misc(bool is_register) {
         unregister_binfmt_misc("qemu-x86_64");
         unregister_binfmt_misc("qemu-i386");
 
-        Config::initialize();
         g_config.binfmt_misc_installed = true;
-        printf("Path: %s\n", g_config.path().c_str());
         Config::save(g_config.path(), g_config);
 
         if (!detect_binfmt_misc()) {

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -164,6 +164,7 @@ bool detect_binfmt_misc() {
         // posix_spawn_file_actions_adddup2(&actions, devnull, STDERR_FILENO);
 
         if (posix_spawn(&pid, path.c_str(), &actions, NULL, (char**)args.data(), (char**)envs.data()) != 0) {
+            WARN("posix_spawn failed");
             return false;
         }
 
@@ -181,9 +182,12 @@ bool detect_binfmt_misc() {
         close(devnull);
         posix_spawn_file_actions_destroy(&actions);
 
+        printf("exit: %d\n", exit_status);
+
         // $ROOTFS/bin/env was run through felix86, thus binfmt_misc is installed
         return exit_status == 0x42;
     } else {
+        WARN("rootfs/bin/env not found?");
         return false;
     }
 }

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -161,12 +161,11 @@ bool detect_binfmt_misc() {
 
         posix_spawn_file_actions_t actions;
         posix_spawn_file_actions_init(&actions);
-        // posix_spawn_file_actions_adddup2(&actions, devnull, STDOUT_FILENO);
-        // posix_spawn_file_actions_adddup2(&actions, devnull, STDERR_FILENO);
+        posix_spawn_file_actions_adddup2(&actions, devnull, STDOUT_FILENO);
+        posix_spawn_file_actions_adddup2(&actions, devnull, STDERR_FILENO);
 
-        printf("Path: %s\n", path.c_str());
         if (posix_spawn(&pid, path.c_str(), &actions, NULL, (char**)args.data(), (char**)envs.data()) != 0) {
-            WARN("posix_spawn failed %d", errno);
+            WARN("posix_spawn failed: %d", errno);
             return false;
         }
 
@@ -183,8 +182,6 @@ bool detect_binfmt_misc() {
 
         close(devnull);
         posix_spawn_file_actions_destroy(&actions);
-
-        printf("exit: %d\n", exit_status);
 
         // $ROOTFS/bin/env was run through felix86, thus binfmt_misc is installed
         return exit_status == 0x42;

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -146,12 +146,7 @@ bool detect_binfmt_misc() {
         }
 
         envs.push_back("__FELIX86_TEST_BINFMT_MISC=1");
-        envs.push_back("ASDASDASD=1");
         envs.push_back(nullptr);
-
-        for (auto e : envs) {
-            printf("PUSHING: %s\n", e);
-        }
 
         std::vector<const char*> args = {
             path.c_str(),
@@ -165,8 +160,8 @@ bool detect_binfmt_misc() {
 
         posix_spawn_file_actions_t actions;
         posix_spawn_file_actions_init(&actions);
-        // posix_spawn_file_actions_adddup2(&actions, devnull, STDOUT_FILENO);
-        // posix_spawn_file_actions_adddup2(&actions, devnull, STDERR_FILENO);
+        posix_spawn_file_actions_adddup2(&actions, devnull, STDOUT_FILENO);
+        posix_spawn_file_actions_adddup2(&actions, devnull, STDERR_FILENO);
 
         if (posix_spawn(&pid, path.c_str(), &actions, NULL, (char**)args.data(), (char**)envs.data()) != 0) {
             return false;
@@ -222,17 +217,21 @@ void binfmt_misc(bool is_register) {
 
     if (!is_register) {
         if (unregister_binfmt_misc("/proc/sys/fs/binfmt_misc/felix86-x86_64")) {
-            printf("Unregistered felix86 from binfmt_misc for x86-64 apps");
+            printf("Unregistered felix86 from binfmt_misc for x86-64 apps\n");
         }
 
         if (unregister_binfmt_misc("/proc/sys/fs/binfmt_misc/felix86-i386")) {
-            printf("Unregistered felix86 from binfmt_misc for i386 apps");
+            printf("Unregistered felix86 from binfmt_misc for i386 apps\n");
         }
 
         g_config.binfmt_misc_installed = false;
         Config::save(g_config.path(), g_config);
         printf("felix86 successfully unregistered from binfmt_misc\n");
     } else {
+        // Unregister if already registered
+        unregister_binfmt_misc("/proc/sys/fs/binfmt_misc/felix86-x86_64");
+        unregister_binfmt_misc("/proc/sys/fs/binfmt_misc/felix86-i386");
+
         FILE* fp = fopen("/proc/sys/fs/binfmt_misc/register", "w");
 
         if (!fp) {
@@ -425,11 +424,6 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
 static struct argp argp = {options, parse_opt, args_doc, doc};
 
 int main(int argc, char* argv[]) {
-    char** e = environ;
-    while (*e) {
-        printf("GOT: %s\n", *e);
-        e++;
-    }
     if (getenv("__FELIX86_TEST_BINFMT_MISC")) {
         // This shouldn't be printed as when we run /bin/env in detect_binfmt_misc we mute stdout and stderr
         WARN("__FELIX86_TEST_BINFMT_MISC was detected, if you see this then something is wrong");

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -162,8 +162,8 @@ bool detect_binfmt_misc() {
 
         posix_spawn_file_actions_t actions;
         posix_spawn_file_actions_init(&actions);
-        posix_spawn_file_actions_adddup2(&actions, devnull, STDOUT_FILENO);
-        posix_spawn_file_actions_adddup2(&actions, devnull, STDERR_FILENO);
+        // posix_spawn_file_actions_adddup2(&actions, devnull, STDOUT_FILENO);
+        // posix_spawn_file_actions_adddup2(&actions, devnull, STDERR_FILENO);
 
         if (posix_spawn(&pid, path.c_str(), &actions, NULL, (char**)args.data(), (char**)envs.data()) != 0) {
             return false;

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -420,6 +420,11 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
 static struct argp argp = {options, parse_opt, args_doc, doc};
 
 int main(int argc, char* argv[]) {
+    char** e = environ;
+    while (*e) {
+        printf("%s\n", *e);
+        e++;
+    }
     if (getenv("__FELIX86_TEST_BINFMT_MISC")) {
         // This shouldn't be printed as when we run /bin/env in detect_binfmt_misc we mute stdout and stderr
         WARN("__FELIX86_TEST_BINFMT_MISC was detected, if you see this then something is wrong");

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -163,6 +163,7 @@ bool detect_binfmt_misc() {
         // posix_spawn_file_actions_adddup2(&actions, devnull, STDOUT_FILENO);
         // posix_spawn_file_actions_adddup2(&actions, devnull, STDERR_FILENO);
 
+        printf("Path: %s\n", path.c_str());
         if (posix_spawn(&pid, path.c_str(), &actions, NULL, (char**)args.data(), (char**)envs.data()) != 0) {
             WARN("posix_spawn failed");
             return false;

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -137,10 +137,16 @@ bool detect_binfmt_misc() {
         pid_t pid;
         int status;
 
-        std::vector<const char*> envs = {
-            "__FELIX86_TEST_BINFMT_MISC=1",
-            nullptr,
-        };
+        std::vector<const char*> envs;
+
+        char** env = environ;
+        while (*env) {
+            envs.push_back(*env);
+            env++;
+        }
+
+        envs.push_back("__FELIX86_TEST_BINFMT_MISC=1");
+        envs.push_back(nullptr);
 
         std::vector<const char*> args = {
             path.c_str(),
@@ -156,8 +162,8 @@ bool detect_binfmt_misc() {
 
         posix_spawn_file_actions_t actions;
         posix_spawn_file_actions_init(&actions);
-        // posix_spawn_file_actions_adddup2(&actions, devnull, STDOUT_FILENO);
-        // posix_spawn_file_actions_adddup2(&actions, devnull, STDERR_FILENO);
+        posix_spawn_file_actions_adddup2(&actions, devnull, STDOUT_FILENO);
+        posix_spawn_file_actions_adddup2(&actions, devnull, STDERR_FILENO);
 
         if (posix_spawn(&pid, path.c_str(), &actions, NULL, (char**)args.data(), (char**)envs.data()) != 0) {
             return false;

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -41,6 +41,7 @@ static struct argp_option options[] = {
     {"set-rootfs", 's', "DIR", 0, "Set the rootfs path in config.toml"},
     {"set-thunks", 'S', "DIR", 0, "Set the thunks path in config.toml"},
     {"binfmt-misc", 'b', 0, 0, "Register the emulator in binfmt_misc so that x86-64 executables can run without prepending the emulator path"},
+    {"unregister-binfmt-misc", 'u', 0, 0, "Unregister the emulator from binfmt_misc"},
     {0}};
 
 int guest_arg_start_index = -1;
@@ -125,7 +126,7 @@ error:
     return ok;
 }
 
-void binfmt_misc() {
+void binfmt_misc(bool is_register) {
     if (!Sudo::hasPermissions()) {
         PLAIN("I need root permissions to register/unregister felix86 in binfmt_misc, please re-run with root permissions");
         exit(1);
@@ -145,28 +146,14 @@ void binfmt_misc() {
         R"!(:felix86-i386:M:0:\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x03\x00:\xff\xff\xff\xff\xff\xfe\xfe\x00\x00\x00\x00\xff\xff\xff\xff\xff\xfe\xff\xff\xff:{}:OCF)!",
         exe_path);
 
-    // Running felix86 -b either registers or unregisters if they already exist
-    if (std::filesystem::exists("/proc/sys/fs/binfmt_misc/felix86-x86_64") || std::filesystem::exists("/proc/sys/fs/binfmt_misc/felix86-i386")) {
-        auto unregister = [](const char* path) {
-            if (!std::filesystem::exists(path)) {
-                return;
-            }
+    if (!is_register) {
+        if (unregister_binfmt_misc("/proc/sys/fs/binfmt_misc/felix86-x86_64")) {
+            printf("Unregistered felix86 from binfmt_misc for x86-64 apps");
+        }
 
-            FILE* fp = fopen(path, "w");
-            if (!fp) {
-                ERROR("Failed to fopen %s", path);
-            }
-
-            if (fwrite("-1", 1, 2, fp) != 2) {
-                fclose(fp);
-                ERROR("Failed to write -1 to %s", path);
-            }
-
-            fclose(fp);
-        };
-
-        unregister("/proc/sys/fs/binfmt_misc/felix86-x86_64");
-        unregister("/proc/sys/fs/binfmt_misc/felix86-i386");
+        if (unregister_binfmt_misc("/proc/sys/fs/binfmt_misc/felix86-i386")) {
+            printf("Unregistered felix86 from binfmt_misc for i386 apps");
+        }
 
         printf("felix86 successfully unregistered from binfmt_misc\n");
     } else {
@@ -188,7 +175,10 @@ void binfmt_misc() {
             ERROR("Failed to register for i386");
         }
 
-        printf("felix86 successfully registered to binfmt_misc\nTo unregister run `felix86 -b`\n");
+        printf("felix86 successfully registered to binfmt_misc\nTo unregister run `felix86 -u`\n");
+
+        unregister_binfmt_misc("qemu-x86_64");
+        unregister_binfmt_misc("qemu-i386");
     }
 }
 
@@ -342,7 +332,12 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
         break;
     }
     case 'b': {
-        binfmt_misc();
+        binfmt_misc(true);
+        exit(0);
+        break;
+    }
+    case 'u': {
+        binfmt_misc(false);
         exit(0);
         break;
     }
@@ -614,6 +609,12 @@ int main(int argc, char* argv[]) {
             ERROR("Executable path is not a regular file");
             return 1;
         }
+    }
+
+    if (!g_binfmt_misc && !g_execve_process && check_if_privileged_executable(params.executable_path)) {
+        // Privileged executable but no binfmt_misc support, warn the user
+        WARN("This is a privileged executable but the emulator isn't installed in binfmt_misc, might run into problems. Run `felix86 -b` to install "
+             "it, make sure to remove other x86/x86-64 emulators from binfmt_misc");
     }
 
     SIGLOG("New felix86 instance with PID %d and executable path %s", getpid(), params.executable_path.c_str());

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -218,11 +218,11 @@ void binfmt_misc(bool is_register) {
         exe_path);
 
     if (!is_register) {
-        if (unregister_binfmt_misc("/proc/sys/fs/binfmt_misc/felix86-x86_64")) {
+        if (unregister_binfmt_misc("felix86-x86_64")) {
             printf("Unregistered felix86 from binfmt_misc for x86-64 apps\n");
         }
 
-        if (unregister_binfmt_misc("/proc/sys/fs/binfmt_misc/felix86-i386")) {
+        if (unregister_binfmt_misc("felix86-i386")) {
             printf("Unregistered felix86 from binfmt_misc for i386 apps\n");
         }
 
@@ -231,8 +231,8 @@ void binfmt_misc(bool is_register) {
         printf("felix86 successfully unregistered from binfmt_misc\n");
     } else {
         // Unregister if already registered
-        unregister_binfmt_misc("/proc/sys/fs/binfmt_misc/felix86-x86_64");
-        unregister_binfmt_misc("/proc/sys/fs/binfmt_misc/felix86-i386");
+        unregister_binfmt_misc("felix86-x86_64");
+        unregister_binfmt_misc("felix86-i386");
 
         FILE* fp = fopen("/proc/sys/fs/binfmt_misc/register", "w");
 
@@ -255,6 +255,52 @@ void binfmt_misc(bool is_register) {
         }
 
         fclose(fp);
+
+        // /proc/sys/fs stuff makes it temporary, we need to install it here to make it permanent via systemd
+        // Register it in the first available directory in this order
+        std::vector<std::filesystem::path> dirs = {
+            "/etc/binfmt.d",
+            "/usr/lib/binfmt.d",
+            "/usr/local/lib/binfmt.d",
+            "/run/binfmt.d",
+        };
+
+        bool registered = false;
+        for (auto& dir : dirs) {
+            if (std::filesystem::exists(dir)) {
+                {
+                    std::filesystem::path x64path = dir / "felix86-x86_64.conf";
+                    FILE* fp = fopen(x64path.c_str(), "w");
+                    if (!fp) {
+                        ERROR("Failed to open %s", x64path.c_str());
+                    }
+                    if (fwrite(registration_string_x64.c_str(), 1, registration_string_x64.size(), fp) != registration_string_x64.size()) {
+                        fclose(fp);
+                        ERROR("Failed to register in binfmt.d for x86-64");
+                    }
+                    fclose(fp);
+                }
+                {
+                    std::filesystem::path i386path = dir / "felix86-i386.conf";
+                    FILE* fp = fopen(i386path.c_str(), "w");
+                    if (!fp) {
+                        ERROR("Failed to open %s", i386path.c_str());
+                    }
+                    if (fwrite(registration_string_i386.c_str(), 1, registration_string_i386.size(), fp) != registration_string_i386.size()) {
+                        fclose(fp);
+                        ERROR("Failed to register in binfmt.d for i386");
+                    }
+                    fclose(fp);
+                }
+
+                registered = true;
+                break;
+            }
+        }
+
+        if (!registered) {
+            printf("Failed to find a binfmt.d directory to put felix86.conf in\n");
+        }
 
         unregister_binfmt_misc("qemu-x86_64");
         unregister_binfmt_misc("qemu-i386");

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -137,7 +137,7 @@ bool detect_binfmt_misc() {
         pid_t pid;
         int status;
 
-        std::vector<const char*> envs;
+        std::vector<char*> envs;
 
         char** env = environ;
         while (*env) {
@@ -145,7 +145,8 @@ bool detect_binfmt_misc() {
             env++;
         }
 
-        envs.push_back("__FELIX86_TEST_BINFMT_MISC=1");
+        char buf[256] = "__FELIX86_TEST_BINFMT_MISC=1";
+        envs.push_back(buf);
         envs.push_back(nullptr);
 
         std::vector<const char*> args = {
@@ -165,7 +166,7 @@ bool detect_binfmt_misc() {
 
         printf("Path: %s\n", path.c_str());
         if (posix_spawn(&pid, path.c_str(), &actions, NULL, (char**)args.data(), (char**)envs.data()) != 0) {
-            WARN("posix_spawn failed");
+            WARN("posix_spawn failed %d", errno);
             return false;
         }
 
@@ -460,7 +461,6 @@ int main(int argc, char* argv[]) {
 
     Config::initialize();
     initialize_globals();
-    g_binfmt_misc = detect_binfmt_misc();
 
     std::filesystem::path xauthority_path;
     const char* xauth_env = getenv("XAUTHORITY");
@@ -637,7 +637,7 @@ int main(int argc, char* argv[]) {
         }
     }
 
-    if (!g_binfmt_misc && !g_execve_process && check_if_privileged_executable(params.executable_path)) {
+    if (!g_config.binfmt_misc_installed && !g_execve_process && check_if_privileged_executable(params.executable_path)) {
         // Privileged executable but no binfmt_misc support, warn the user
         WARN("This is a privileged executable but the emulator isn't installed in binfmt_misc, might run into problems. Run `felix86 -b` to install "
              "it, make sure to remove other x86/x86-64 emulators from binfmt_misc");

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -241,6 +241,7 @@ void binfmt_misc(bool is_register) {
 
         Config::initialize();
         g_config.binfmt_misc_installed = true;
+        printf("Path: %s\n", g_config.path().c_str());
         Config::save(g_config.path(), g_config);
 
         if (!detect_binfmt_misc()) {

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -148,6 +148,10 @@ bool detect_binfmt_misc() {
         envs.push_back("__FELIX86_TEST_BINFMT_MISC=1");
         envs.push_back(nullptr);
 
+        for (auto e : envs) {
+            printf("PUSHING: %s\n", e);
+        }
+
         std::vector<const char*> args = {
             path.c_str(),
             nullptr,
@@ -420,11 +424,6 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
 static struct argp argp = {options, parse_opt, args_doc, doc};
 
 int main(int argc, char* argv[]) {
-    char** e = environ;
-    while (*e) {
-        printf("%s\n", *e);
-        e++;
-    }
     if (getenv("__FELIX86_TEST_BINFMT_MISC")) {
         // This shouldn't be printed as when we run /bin/env in detect_binfmt_misc we mute stdout and stderr
         WARN("__FELIX86_TEST_BINFMT_MISC was detected, if you see this then something is wrong");

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -127,10 +127,9 @@ error:
 }
 
 bool detect_binfmt_misc() {
-    // Run `echo -n ""` which will print nothing. We also set __FELIX86_TEST_BINFMT_MISC which will
-    // make felix86 immediately return 0x42. If the return value is 0x42 that means felix86 was invoked
-    // and thus binfmt_misc is correctly installed. If anything else is returned it means we didn't run it
-    // through binfmt_misc thus it's not installed.
+    // Run an x86-64 program and set __FELIX86_TEST_BINFMT_MISC which will make felix86 immediately return 0x42.
+    // If the return value is 0x42 that means felix86 was invoked and thus binfmt_misc is correctly installed.
+    // If anything else is returned it means we didn't run it through binfmt_misc thus it's not installed.
     std::error_code ec;
     std::filesystem::path path = g_config.rootfs_path / "bin/env";
     if (std::filesystem::exists(path, ec) && std::filesystem::is_regular_file(path, ec)) {

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -192,6 +192,69 @@ void binfmt_misc() {
     }
 }
 
+bool detect_binfmt_misc() {
+    // This is set during execve if we previously detected binfmt_misc support
+    if (getenv("__FELIX86_BINFMT_MISC")) {
+        return true;
+    } else {
+        // Run `echo -n ""` which will print nothing. We also set __FELIX86_TEST_BINFMT_MISC which will
+        // make felix86 immediately return 0x42. If the return value is 0x42 that means felix86 was invoked
+        // and thus binfmt_misc is correctly installed. If anything else is returned it means we didn't run it
+        // through binfmt_misc thus it's not installed.
+        std::error_code ec;
+        std::filesystem::path path = g_config.rootfs_path / "usr/bin/echo";
+        if (std::filesystem::exists(path, ec) && std::filesystem::is_regular_file(path, ec)) {
+            pid_t pid;
+            int status;
+
+            std::vector<const char*> envs = {
+                "__FELIX86_TEST_BINFMT_MISC=1",
+                nullptr,
+            };
+
+            std::vector<const char*> args = {
+                path.c_str(),
+                "-n",
+                "\"\"",
+                nullptr,
+            };
+
+            int devnull = open("/dev/null", O_WRONLY);
+            if (devnull == -1) {
+                return false;
+            }
+
+            posix_spawn_file_actions_t actions;
+            posix_spawn_file_actions_init(&actions);
+            posix_spawn_file_actions_adddup2(&actions, devnull, STDOUT_FILENO);
+            posix_spawn_file_actions_adddup2(&actions, devnull, STDERR_FILENO);
+
+            if (posix_spawn(&pid, path.c_str(), &actions, NULL, (char**)args.data(), (char**)envs.data()) != 0) {
+                return false;
+            }
+
+            int exit_status = 0;
+            if (waitpid(pid, &status, 0) == -1) {
+                exit_status = -1;
+            } else {
+                if (WIFEXITED(status)) {
+                    exit_status = WEXITSTATUS(status);
+                } else {
+                    exit_status = -1;
+                }
+            }
+
+            close(devnull);
+            posix_spawn_file_actions_destroy(&actions);
+
+            // $ROOTFS/usr/bin/echo was run through felix86, thus binfmt_misc is installed
+            return exit_status == 0x42;
+        } else {
+            return false;
+        }
+    }
+}
+
 void kill_all() {
     DIR* proc_dir;
     struct dirent* entry;
@@ -345,6 +408,14 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
 static struct argp argp = {options, parse_opt, args_doc, doc};
 
 int main(int argc, char* argv[]) {
+    if (getenv("__FELIX86_TEST_BINFMT_MISC")) {
+        // This shouldn't be printed as when we run /usr/bin/echo in detect_binfmt_misc we mute stdout and stderr
+        WARN("__FELIX86_TEST_BINFMT_MISC was detected, if you see this then something is wrong");
+
+        // Magic value expected by detect_binfmt_misc
+        return 0x42;
+    }
+
 #ifdef __x86_64__
     WARN("You're running an x86-64 executable version of felix86, get ready for a crash soon");
 #endif
@@ -368,6 +439,7 @@ int main(int argc, char* argv[]) {
 
     Config::initialize();
     initialize_globals();
+    g_binfmt_misc = detect_binfmt_misc();
 
     std::filesystem::path xauthority_path;
     const char* xauth_env = getenv("XAUTHORITY");

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -249,12 +249,16 @@ void binfmt_misc(bool is_register) {
             ERROR("Failed to register for x86-64");
         }
 
+        fclose(fp);
+
         fp = fopen("/proc/sys/fs/binfmt_misc/register", "w");
 
         if (fwrite(registration_string_i386.c_str(), 1, registration_string_i386.size(), fp) != registration_string_i386.size()) {
             fclose(fp);
             ERROR("Failed to register for i386");
         }
+
+        fclose(fp);
 
         unregister_binfmt_misc("qemu-x86_64");
         unregister_binfmt_misc("qemu-i386");

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -126,6 +126,64 @@ error:
     return ok;
 }
 
+bool detect_binfmt_misc() {
+    // Run `echo -n ""` which will print nothing. We also set __FELIX86_TEST_BINFMT_MISC which will
+    // make felix86 immediately return 0x42. If the return value is 0x42 that means felix86 was invoked
+    // and thus binfmt_misc is correctly installed. If anything else is returned it means we didn't run it
+    // through binfmt_misc thus it's not installed.
+    std::error_code ec;
+    std::filesystem::path path = g_config.rootfs_path / "/bin/echo";
+    if (std::filesystem::exists(path, ec) && std::filesystem::is_regular_file(path, ec)) {
+        pid_t pid;
+        int status;
+
+        std::vector<const char*> envs = {
+            "__FELIX86_TEST_BINFMT_MISC=1",
+            nullptr,
+        };
+
+        std::vector<const char*> args = {
+            path.c_str(),
+            "-n",
+            "\"\"",
+            nullptr,
+        };
+
+        int devnull = open("/dev/null", O_WRONLY);
+        if (devnull == -1) {
+            return false;
+        }
+
+        posix_spawn_file_actions_t actions;
+        posix_spawn_file_actions_init(&actions);
+        posix_spawn_file_actions_adddup2(&actions, devnull, STDOUT_FILENO);
+        posix_spawn_file_actions_adddup2(&actions, devnull, STDERR_FILENO);
+
+        if (posix_spawn(&pid, path.c_str(), &actions, NULL, (char**)args.data(), (char**)envs.data()) != 0) {
+            return false;
+        }
+
+        int exit_status = 0;
+        if (waitpid(pid, &status, 0) == -1) {
+            exit_status = -1;
+        } else {
+            if (WIFEXITED(status)) {
+                exit_status = WEXITSTATUS(status);
+            } else {
+                exit_status = -1;
+            }
+        }
+
+        close(devnull);
+        posix_spawn_file_actions_destroy(&actions);
+
+        // $ROOTFS/bin/echo was run through felix86, thus binfmt_misc is installed
+        return exit_status == 0x42;
+    } else {
+        return false;
+    }
+}
+
 void binfmt_misc(bool is_register) {
     if (!Sudo::hasPermissions()) {
         PLAIN("I need root permissions to register/unregister felix86 in binfmt_misc, please re-run with root permissions");
@@ -155,6 +213,9 @@ void binfmt_misc(bool is_register) {
             printf("Unregistered felix86 from binfmt_misc for i386 apps");
         }
 
+        Config::initialize();
+        g_config.binfmt_misc_installed = false;
+        Config::save(g_config.path(), g_config);
         printf("felix86 successfully unregistered from binfmt_misc\n");
     } else {
         FILE* fp = fopen("/proc/sys/fs/binfmt_misc/register", "w");
@@ -175,73 +236,20 @@ void binfmt_misc(bool is_register) {
             ERROR("Failed to register for i386");
         }
 
-        printf("felix86 successfully registered to binfmt_misc\nTo unregister run `felix86 -u`\n");
-
         unregister_binfmt_misc("qemu-x86_64");
         unregister_binfmt_misc("qemu-i386");
-    }
-}
 
-bool detect_binfmt_misc() {
-    // This is set during execve if we previously detected binfmt_misc support
-    if (getenv("__FELIX86_BINFMT_MISC")) {
-        return true;
-    } else {
-        // Run `echo -n ""` which will print nothing. We also set __FELIX86_TEST_BINFMT_MISC which will
-        // make felix86 immediately return 0x42. If the return value is 0x42 that means felix86 was invoked
-        // and thus binfmt_misc is correctly installed. If anything else is returned it means we didn't run it
-        // through binfmt_misc thus it's not installed.
-        std::error_code ec;
-        std::filesystem::path path = g_config.rootfs_path / "usr/bin/echo";
-        if (std::filesystem::exists(path, ec) && std::filesystem::is_regular_file(path, ec)) {
-            pid_t pid;
-            int status;
+        Config::initialize();
+        g_config.binfmt_misc_installed = true;
+        Config::save(g_config.path(), g_config);
 
-            std::vector<const char*> envs = {
-                "__FELIX86_TEST_BINFMT_MISC=1",
-                nullptr,
-            };
-
-            std::vector<const char*> args = {
-                path.c_str(),
-                "-n",
-                "\"\"",
-                nullptr,
-            };
-
-            int devnull = open("/dev/null", O_WRONLY);
-            if (devnull == -1) {
-                return false;
-            }
-
-            posix_spawn_file_actions_t actions;
-            posix_spawn_file_actions_init(&actions);
-            posix_spawn_file_actions_adddup2(&actions, devnull, STDOUT_FILENO);
-            posix_spawn_file_actions_adddup2(&actions, devnull, STDERR_FILENO);
-
-            if (posix_spawn(&pid, path.c_str(), &actions, NULL, (char**)args.data(), (char**)envs.data()) != 0) {
-                return false;
-            }
-
-            int exit_status = 0;
-            if (waitpid(pid, &status, 0) == -1) {
-                exit_status = -1;
-            } else {
-                if (WIFEXITED(status)) {
-                    exit_status = WEXITSTATUS(status);
-                } else {
-                    exit_status = -1;
-                }
-            }
-
-            close(devnull);
-            posix_spawn_file_actions_destroy(&actions);
-
-            // $ROOTFS/usr/bin/echo was run through felix86, thus binfmt_misc is installed
-            return exit_status == 0x42;
-        } else {
-            return false;
+        if (!detect_binfmt_misc()) {
+            printf(ANSI_COLOR_YELLOW
+                   "Even though I installed felix86 in binfmt_misc, I couldn't run a simple binary with it. Either /bin/echo is missing in rootfs or "
+                   "there's conflicting emulators in binfmt_misc which may make felix86 not work correctly" ANSI_COLOR_RESET "\n");
         }
+
+        printf("felix86 successfully registered to binfmt_misc\n");
     }
 }
 

--- a/src/felix86/tools/install.sh
+++ b/src/felix86/tools/install.sh
@@ -122,7 +122,9 @@ if [ "$choice" -eq 1 ]; then
     UBUNTU_2404_LINK=$(curl -s https://felix86.com/rootfs/ubuntu.txt)
     echo "Downloading Ubuntu 24.04 rootfs..."
     mkdir -p $NEW_ROOTFS
-    curl -L $UBUNTU_2404_LINK | tar -xmz -C $NEW_ROOTFS
+
+    # Important we untar with --same-owner so that sudo/mount/fusermount keep their setuid bits
+    curl -L $UBUNTU_2404_LINK | sudo tar --same-owner -xz -C $NEW_ROOTFS
     echo "Rootfs was downloaded and extracted in $NEW_ROOTFS"
     felix86 --set-rootfs $NEW_ROOTFS
 elif [ "$choice" -eq 2 ]; then

--- a/src/felix86/tools/install.sh
+++ b/src/felix86/tools/install.sh
@@ -132,4 +132,7 @@ elif [ "$choice" -eq 2 ]; then
     felix86 --set-rootfs $line
 fi
 
+# Finally register felix86 to binfmt_misc
+sudo felix86 --binfmt-misc
+
 echo "felix86 installed successfully"

--- a/src/felix86/tools/install.sh
+++ b/src/felix86/tools/install.sh
@@ -134,7 +134,7 @@ elif [ "$choice" -eq 2 ]; then
     felix86 --set-rootfs $line
 fi
 
-# Finally register felix86 to binfmt_misc
-sudo felix86 --binfmt-misc
+# Finally register felix86 in binfmt_misc
+sudo -E felix86 --binfmt-misc
 
 echo "felix86 installed successfully"

--- a/src/felix86/tools/install.sh
+++ b/src/felix86/tools/install.sh
@@ -26,6 +26,11 @@ if [ -z "$HOME" ] || [ ! -d "$HOME" ]; then
     exit 1
 fi
 
+if [ -z "$USER" ]; then
+    echo "\$USER is not set"
+    exit 1
+fi
+
 INSTALLATION_DIR="/opt/felix86"
 FILE="$INSTALLATION_DIR/felix86"
 FELIX86_LINK="https://nightly.link/OFFTKP/felix86/workflows/unit-tests/master/Linux%20executable.zip"
@@ -125,6 +130,8 @@ if [ "$choice" -eq 1 ]; then
 
     # Important we untar with --same-owner so that sudo/mount/fusermount keep their setuid bits
     curl -L $UBUNTU_2404_LINK | sudo tar --same-owner -xz -C $NEW_ROOTFS
+    echo "Changing 
+    sudo chown -R "$USER":"$USER" "$NEW_ROOTFS"
     echo "Rootfs was downloaded and extracted in $NEW_ROOTFS"
     felix86 --set-rootfs $NEW_ROOTFS
 elif [ "$choice" -eq 2 ]; then
@@ -140,7 +147,7 @@ sudo -E felix86 --binfmt-misc
 
 # Check that $ROOTFS/usr/bin/mount has setuid bit set, warn otherwise
 perm=$(stat -c "%f" "$NEW_ROOTFS/usr/bin/mount")
-if [ $(( (0x$perm & 0x800) )) -e 0 ]; then
+if [ $(( (0x$perm & 0x800) ) -e 0 ]; then
     echo "/usr/bin/mount doesn't have setuid bit set, some things like AppImages may not work correctly"
 fi
 

--- a/src/felix86/tools/install.sh
+++ b/src/felix86/tools/install.sh
@@ -130,8 +130,10 @@ if [ "$choice" -eq 1 ]; then
 
     # Important we untar with --same-owner so that sudo/mount/fusermount keep their setuid bits
     curl -L $UBUNTU_2404_LINK | sudo tar --same-owner -xz -C $NEW_ROOTFS
-    echo "Changing 
-    sudo chown -R "$USER":"$USER" "$NEW_ROOTFS"
+    echo "Changing permissions for $NEW_ROOTFS to $USER"
+
+    # Chown the directory so we can add stuff inside, but not recursively as to not ruin setuid stuff
+    sudo chown "$USER":"$USER" "$NEW_ROOTFS"
     echo "Rootfs was downloaded and extracted in $NEW_ROOTFS"
     felix86 --set-rootfs $NEW_ROOTFS
 elif [ "$choice" -eq 2 ]; then
@@ -144,11 +146,5 @@ fi
 
 # Finally register felix86 in binfmt_misc
 sudo -E felix86 --binfmt-misc
-
-# Check that $ROOTFS/usr/bin/mount has setuid bit set, warn otherwise
-perm=$(stat -c "%f" "$NEW_ROOTFS/usr/bin/mount")
-if [ $(( (0x$perm & 0x800) ) -e 0 ]; then
-    echo "/usr/bin/mount doesn't have setuid bit set, some things like AppImages may not work correctly"
-fi
 
 echo "felix86 installed successfully"

--- a/src/felix86/tools/install.sh
+++ b/src/felix86/tools/install.sh
@@ -132,9 +132,16 @@ elif [ "$choice" -eq 2 ]; then
     echo "Please specify the absolute path to your rootfs"
     read line
     felix86 --set-rootfs $line
+    NEW_ROOTFS=$line
 fi
 
 # Finally register felix86 in binfmt_misc
 sudo -E felix86 --binfmt-misc
+
+# Check that $ROOTFS/usr/bin/mount has setuid bit set, warn otherwise
+perm=$(stat -c "%f" "$NEW_ROOTFS/usr/bin/mount")
+if [ $(( (0x$perm & 0x800) )) -e 0 ]; then
+    echo "/usr/bin/mount doesn't have setuid bit set, some things like AppImages may not work correctly"
+fi
 
 echo "felix86 installed successfully"

--- a/src/felix86/tools/install.sh
+++ b/src/felix86/tools/install.sh
@@ -141,7 +141,6 @@ elif [ "$choice" -eq 2 ]; then
     echo "Please specify the absolute path to your rootfs"
     read line
     felix86 --set-rootfs $line
-    NEW_ROOTFS=$line
 fi
 
 # Finally register felix86 in binfmt_misc

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -72,12 +72,6 @@ Recompiler::Recompiler() : code_cache(allocateCodeCache()), as(code_cache, code_
     }
 
     if (g_config.perf_blocks || g_config.perf_global || g_config.perf_libs) {
-        std::string path = "/tmp/perf-" + std::to_string(getpid()) + ".map";
-        FILE* file = fopen(path.c_str(), "a");
-        ASSERT(file);
-        perf_fd = fileno(file);
-        ASSERT(perf_fd > 0);
-
         u64 end = (u64)as.GetCursorPointer();
         u64 size = end - (u64)enter_dispatcher;
         g_process_globals.perf->addToFile((u64)enter_dispatcher, size, "felix86 dispatcher");


### PR DESCRIPTION
Some executables like sudo, mount, ... have special permissions. When we emulate them, our emulator doesn't have those special permissions that were given to them.

A way to get those permissions is to run them through binfmt_misc. There's a flag:
```
C - credentials

    Currently, the behavior of binfmt_misc is to calculate the credentials and security token of the new process according to the interpreter. When this flag is included, these attributes are calculated according to the binary. It also implies the O flag. This feature should be used with care as the interpreter will run with root permissions when a setuid binary owned by root is run with binfmt_misc.
```
which accomplishes exactly our needs

Since currently execve would run `felix86 <executable> <args>` we instead detect for binfmt_misc using a config flag set by `felix86 --binfmt-misc`. If there's binfmt_misc support we execve `<executable> <args>` instead. Otherwise we run the emulator manually but some apps may not work.