### PR TITLE
syscall: add `accept4` and fix `accept`

### DIFF
--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -353,7 +353,7 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
         break;
     }
     case felix86_riscv64_accept: {
-        result = SYSCALL(accept, arg1, arg2, arg3, arg4, arg5, arg6);
+        result = SYSCALL(accept, arg1, arg2, arg3);
         break;
     }
     case felix86_riscv64_accept4: {

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -356,6 +356,10 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
         result = SYSCALL(accept, arg1, arg2, arg3, arg4, arg5, arg6);
         break;
     }
+    case felix86_riscv64_accept4: {
+        result = SYSCALL(accept4, arg1, arg2, arg3, arg4);
+        break;
+    }
     case felix86_riscv64_socketpair: {
         result = SYSCALL(socketpair, arg1, arg2, arg3, arg4, arg5, arg6);
         break;


### PR DESCRIPTION
`accept4` required for `osu!`