### PR TITLE
Don't run scripts natively when binfmt_misc is active

### DIFF
--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -1295,8 +1295,6 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
         envp.push_back(log_env.c_str());
         envp.push_back(nullptr);
 
-        VERBOSE("Passing %s", guest_envs.c_str());
-
         std::string args = "";
         for (auto arg : argv) {
             args += " ";

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -1259,6 +1259,12 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
 
         std::string guest_envs = "__FELIX86_GUEST_ENVS=";
         if (arg3) {
+            // Add our own environment
+            for (const std::string& env : g_params.envp) {
+                guest_envs += env;
+                guest_envs += ",";
+            }
+
             u8* guest_envp = (u8*)arg3;
             while (true) {
                 u64 ptr = 0;

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -1259,12 +1259,6 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
 
         std::string guest_envs = "__FELIX86_GUEST_ENVS=";
         if (arg3) {
-            // Add our own environment
-            for (const std::string& env : g_params.envp) {
-                guest_envs += env;
-                guest_envs += ",";
-            }
-
             u8* guest_envp = (u8*)arg3;
             while (true) {
                 u64 ptr = 0;
@@ -1293,6 +1287,8 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
         envp.push_back("__FELIX86_EXECVE=1");
         envp.push_back(log_env.c_str());
         envp.push_back(nullptr);
+
+        VERBOSE("Passing %s", guest_envs.c_str());
 
         std::string args = "";
         for (auto arg : argv) {


### PR DESCRIPTION
Because of the way we pass guest environment variables with __FELIX86_GUEST_ENVS, running a script natively would not get the correct environment variables.

In the future we can modify this to pass the environment variables correctly and run scripts natively.