### PR TITLE
Undo signal guard before execve

### DIFF
--- a/src/felix86/hle/signals.cpp
+++ b/src/felix86/hle/signals.cpp
@@ -768,7 +768,9 @@ SignalGuard::SignalGuard() {
 }
 
 SignalGuard::~SignalGuard() {
-    pthread_sigmask(SIG_SETMASK, &old_mask, nullptr);
+    if (!killed) {
+        pthread_sigmask(SIG_SETMASK, &old_mask, nullptr);
+    }
 }
 
 int Signals::sigprocmask(ThreadState* state, int how, sigset_t* set, sigset_t* oldset) {

--- a/src/felix86/hle/signals.hpp
+++ b/src/felix86/hle/signals.hpp
@@ -113,6 +113,12 @@ struct SignalGuard {
     SignalGuard(const SignalGuard&) = delete;
     SignalGuard& operator=(const SignalGuard&) = delete;
 
+    void kill() {
+        pthread_sigmask(SIG_SETMASK, &old_mask, nullptr);
+        killed = true;
+    }
+
 private:
     sigset_t old_mask;
+    bool killed = false;
 };

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -1395,6 +1395,9 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
 
         LOG("Running execve, wish me luck:%s", args.c_str());
 
+        // Undo signal guard so the child doesn't inherit the bad mask
+        guard.kill();
+
         syscall(SYS_execve, executable.c_str(), &argv[0], envp.data());
 
         ASSERT_MSG(false, "Error during execve: %s", strerror(errno));


### PR DESCRIPTION
The child would inherit our full signal mask on every execve