### PR TITLE
Don't deallocate on exit

### DIFF
--- a/src/felix86/emulator.cpp
+++ b/src/felix86/emulator.cpp
@@ -305,13 +305,6 @@ std::pair<ExitReason, int> Emulator::Start() {
     exit_reason = main_state->exit_reason;
     exit_code = main_state->exit_code;
 
-    munmap(stack, size);
-    munmap((void*)g_initial_brk, g_current_brk_size);
-    g_fs.reset();
-    g_breakpoints.clear();
-    ThreadState::Destroy(main_state);
-    pthread_setspecific(g_thread_state_key, nullptr);
-
     return {exit_reason, exit_code};
 }
 

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -634,5 +634,12 @@ int main(int argc, char* argv[]) {
         LOG("Execve process %d exited with reason: %s. Exit code: %d", getpid(), print_exit_reason(exit_reason), exit_code);
     }
 
-    return exit_code;
+    if (exit_reason == EXIT_REASON_EXIT_SYSCALL) {
+        syscall(SYS_exit, exit_code);
+    } else if (exit_reason == EXIT_REASON_EXIT_GROUP_SYSCALL) {
+        syscall(SYS_exit_group, exit_code);
+    } else {
+        WARN("Exiting with bad exit reason: %s", print_exit_reason(exit_reason));
+        syscall(SYS_exit, exit_code);
+    }
 }


### PR DESCRIPTION
Deallocating BRK and other stuff while used by other threads in the small window