### PR TITLE
Fix paths with trailing slashes

### DIFF
--- a/src/felix86/common/global.cpp
+++ b/src/felix86/common/global.cpp
@@ -343,9 +343,9 @@ void initialize_globals() {
                     // Relocate executable path
                     std::string new_executable_path =
                         !g_params.executable_path.empty() ? std::filesystem::absolute(g_params.executable_path) : g_params.executable_path;
-                    printf("Before: %s\n", new_executable_path.c_str());
-                    Filesystem::removeRootfsPrefix(new_executable_path);
-                    printf("After : %s\n", new_executable_path.c_str());
+                    if (new_executable_path.find(g_config.rootfs_path) == 0) {
+                        new_executable_path = new_executable_path.substr(g_config.rootfs_path.string().size());
+                    }
                     new_executable_path = path / std::filesystem::path(new_executable_path).relative_path();
                     g_params.executable_path = new_executable_path;
                     g_config.rootfs_path = path;

--- a/src/felix86/common/global.cpp
+++ b/src/felix86/common/global.cpp
@@ -343,7 +343,9 @@ void initialize_globals() {
                     // Relocate executable path
                     std::string new_executable_path =
                         !g_params.executable_path.empty() ? std::filesystem::absolute(g_params.executable_path) : g_params.executable_path;
+                    printf("Before: %s\n", new_executable_path.c_str());
                     Filesystem::removeRootfsPrefix(new_executable_path);
+                    printf("After : %s\n", new_executable_path.c_str());
                     new_executable_path = path / std::filesystem::path(new_executable_path).relative_path();
                     g_params.executable_path = new_executable_path;
                     g_config.rootfs_path = path;

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -614,6 +614,10 @@ int main(int argc, char* argv[]) {
         g_executable_path_absolute = g_executable_path_absolute.lexically_normal();
     }
 
+    if (g_executable_path_absolute.string().find("python3") != std::string::npos) {
+        g_config.strace = 1;
+    }
+
     if (!g_config.binfmt_misc_installed && !g_execve_process && check_if_privileged_executable(g_params.executable_path)) {
         // Privileged executable but no binfmt_misc support, warn the user
         WARN("This is a privileged executable but the emulator isn't installed in binfmt_misc, might run into problems. Run `felix86 -b` to install "

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -614,9 +614,12 @@ int main(int argc, char* argv[]) {
         g_executable_path_absolute = g_executable_path_absolute.lexically_normal();
     }
 
+#if 0
+    // Use me if you want to strace a specific program only
     if (g_executable_path_absolute.string().find("python3") != std::string::npos) {
         g_config.strace = 1;
     }
+#endif
 
     if (!g_config.binfmt_misc_installed && !g_execve_process && check_if_privileged_executable(g_params.executable_path)) {
         // Privileged executable but no binfmt_misc support, warn the user


### PR DESCRIPTION
Some programs try to `mkdir("/path/foo/bar/")`, the trailing slash needs to be ignored during path resolution