### PR TITLE
Optimize sign flag emulation

### DIFF
--- a/counts/Base.json
+++ b/counts/Base.json
@@ -1,6 +1,6 @@
 {
     "00da": {
-        "instruction_count": 30,
+        "instruction_count": 29,
         "expected_asm": [
             "ANDI            t1, s0, 0xff(255)",
             "ANDI            t3, a2, 0xff(255)",
@@ -18,8 +18,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "OR              s9, t3, t1",
             "XORI            t4, ra, 0xffffffff(-1)",
             "AND             s9, t4, s9",
@@ -36,7 +35,7 @@
         "disassembly": "add dl, bl"
     },
     "00fa": {
-        "instruction_count": 31,
+        "instruction_count": 30,
         "expected_asm": [
             "SRLI            t1, s0, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -55,8 +54,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "OR              s9, t3, t1",
             "XORI            t4, ra, 0xffffffff(-1)",
             "AND             s9, t4, s9",
@@ -73,7 +71,7 @@
         "disassembly": "add dl, bh"
     },
     "00de": {
-        "instruction_count": 33,
+        "instruction_count": 32,
         "expected_asm": [
             "ANDI            t1, s0, 0xff(255)",
             "SRLI            t3, a2, 0x8(8)",
@@ -92,8 +90,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "OR              s9, t3, t1",
             "XORI            t4, ra, 0xffffffff(-1)",
             "AND             s9, t4, s9",
@@ -112,7 +109,7 @@
         "disassembly": "add dh, bl"
     },
     "00fe": {
-        "instruction_count": 34,
+        "instruction_count": 33,
         "expected_asm": [
             "SRLI            t1, s0, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -132,8 +129,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "OR              s9, t3, t1",
             "XORI            t4, ra, 0xffffffff(-1)",
             "AND             s9, t4, s9",
@@ -152,7 +148,7 @@
         "disassembly": "add dh, bh"
     },
     "6601da": {
-        "instruction_count": 31,
+        "instruction_count": 30,
         "expected_asm": [
             "ZEXT.H          t1, s0",
             "ZEXT.H          t3, a2",
@@ -170,8 +166,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "OR              s9, t3, t1",
             "XORI            t4, ra, 0xffffffff(-1)",
             "AND             s9, t4, s9",
@@ -189,7 +184,7 @@
         "disassembly": "add dx, bx"
     },
     "01da": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "ADD.UW          t1, s0, zero",
             "ADD.UW          t3, a2, zero",
@@ -207,8 +202,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "OR              s9, t3, t1",
             "XORI            t4, ra, 0xffffffff(-1)",
             "AND             s9, t4, s9",
@@ -223,7 +217,7 @@
         "disassembly": "add edx, ebx"
     },
     "4801da": {
-        "instruction_count": 19,
+        "instruction_count": 18,
         "expected_asm": [
             "ADD             ra, a2, s0",
             "ADDI            s5, ra, 0x0(0)",
@@ -239,7 +233,6 @@
             "SB              t1, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, ra, a2",
             "SLTI            t1, s0, 0x0(0)",
             "XOR             s9, s9, t1",
@@ -248,7 +241,7 @@
         "disassembly": "add rdx, rbx"
     },
     "0217": {
-        "instruction_count": 30,
+        "instruction_count": 29,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "ANDI            t4, a2, 0xff(255)",
@@ -266,8 +259,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "OR              s9, t4, t1",
             "XORI            t2, ra, 0xffffffff(-1)",
             "AND             s9, t2, s9",
@@ -284,7 +276,7 @@
         "disassembly": "add dl, [rdi]"
     },
     "0237": {
-        "instruction_count": 33,
+        "instruction_count": 32,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "SRLI            t4, a2, 0x8(8)",
@@ -303,8 +295,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "OR              s9, t4, t1",
             "XORI            t2, ra, 0xffffffff(-1)",
             "AND             s9, t2, s9",
@@ -323,7 +314,7 @@
         "disassembly": "add dh, [rdi]"
     },
     "660317": {
-        "instruction_count": 31,
+        "instruction_count": 30,
         "expected_asm": [
             "LHU             t1, a0, 0x0(0)",
             "ZEXT.H          t4, a2",
@@ -341,8 +332,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "OR              s9, t4, t1",
             "XORI            t2, ra, 0xffffffff(-1)",
             "AND             s9, t2, s9",
@@ -360,7 +350,7 @@
         "disassembly": "add dx, [rdi]"
     },
     "0317": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "LWU             t1, a0, 0x0(0)",
             "ADD.UW          t4, a2, zero",
@@ -378,8 +368,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "OR              s9, t4, t1",
             "XORI            t2, ra, 0xffffffff(-1)",
             "AND             s9, t2, s9",
@@ -394,7 +383,7 @@
         "disassembly": "add edx, [rdi]"
     },
     "480317": {
-        "instruction_count": 20,
+        "instruction_count": 19,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "ADD             ra, a2, t1",
@@ -411,7 +400,6 @@
             "SB              t4, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, ra, a2",
             "SLTI            t4, t1, 0x0(0)",
             "XOR             s9, s9, t4",
@@ -420,7 +408,7 @@
         "disassembly": "add rdx, [rdi]"
     },
     "0017": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "ANDI            t1, a2, 0xff(255)",
             "LBU             t3, a0, 0x0(0)",
@@ -438,8 +426,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "OR              s9, t3, t1",
             "XORI            t2, ra, 0xffffffff(-1)",
             "AND             s9, t2, s9",
@@ -454,7 +441,7 @@
         "disassembly": "add [rdi], dl"
     },
     "0037": {
-        "instruction_count": 29,
+        "instruction_count": 28,
         "expected_asm": [
             "SRLI            t1, a2, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -473,8 +460,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "OR              s9, t3, t1",
             "XORI            t2, ra, 0xffffffff(-1)",
             "AND             s9, t2, s9",
@@ -489,7 +475,7 @@
         "disassembly": "add [rdi], dh"
     },
     "660117": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "ZEXT.H          t1, a2",
             "LHU             t3, a0, 0x0(0)",
@@ -507,8 +493,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "OR              s9, t3, t1",
             "XORI            t2, ra, 0xffffffff(-1)",
             "AND             s9, t2, s9",
@@ -523,7 +508,7 @@
         "disassembly": "add [rdi], dx"
     },
     "0117": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "ADD.UW          t1, a2, zero",
             "LWU             t3, a0, 0x0(0)",
@@ -541,8 +526,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "OR              s9, t3, t1",
             "XORI            t2, ra, 0xffffffff(-1)",
             "AND             s9, t2, s9",
@@ -557,7 +541,7 @@
         "disassembly": "add [rdi], edx"
     },
     "480117": {
-        "instruction_count": 20,
+        "instruction_count": 19,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "ADD             ra, t1, a2",
@@ -574,7 +558,6 @@
             "SB              t4, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, ra, t1",
             "SLTI            t4, a2, 0x0(0)",
             "XOR             s9, s9, t4",
@@ -583,7 +566,7 @@
         "disassembly": "add [rdi], rdx"
     },
     "80c201": {
-        "instruction_count": 30,
+        "instruction_count": 29,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "ANDI            t3, a2, 0xff(255)",
@@ -601,8 +584,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "OR              s9, t3, t1",
             "XORI            t4, ra, 0xffffffff(-1)",
             "AND             s9, t4, s9",
@@ -619,7 +601,7 @@
         "disassembly": "add dl, 0x01"
     },
     "80c2ff": {
-        "instruction_count": 30,
+        "instruction_count": 29,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "ANDI            t3, a2, 0xff(255)",
@@ -637,8 +619,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "OR              s9, t3, t1",
             "XORI            t4, ra, 0xffffffff(-1)",
             "AND             s9, t4, s9",
@@ -655,7 +636,7 @@
         "disassembly": "add dl, 0xFF"
     },
     "80c601": {
-        "instruction_count": 33,
+        "instruction_count": 32,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "SRLI            t3, a2, 0x8(8)",
@@ -674,8 +655,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "OR              s9, t3, t1",
             "XORI            t4, ra, 0xffffffff(-1)",
             "AND             s9, t4, s9",
@@ -694,7 +674,7 @@
         "disassembly": "add dh, 0x01"
     },
     "80c6ff": {
-        "instruction_count": 33,
+        "instruction_count": 32,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "SRLI            t3, a2, 0x8(8)",
@@ -713,8 +693,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "OR              s9, t3, t1",
             "XORI            t4, ra, 0xffffffff(-1)",
             "AND             s9, t4, s9",
@@ -733,7 +712,7 @@
         "disassembly": "add dh, 0xFF"
     },
     "6683c201": {
-        "instruction_count": 31,
+        "instruction_count": 30,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "ZEXT.H          t3, a2",
@@ -751,8 +730,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "OR              s9, t3, t1",
             "XORI            t4, ra, 0xffffffff(-1)",
             "AND             s9, t4, s9",
@@ -770,7 +748,7 @@
         "disassembly": "add dx, 0x01"
     },
     "6683c2ff": {
-        "instruction_count": 31,
+        "instruction_count": 30,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "ZEXT.H          t3, a2",
@@ -788,8 +766,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "OR              s9, t3, t1",
             "XORI            t4, ra, 0xffffffff(-1)",
             "AND             s9, t4, s9",
@@ -807,7 +784,7 @@
         "disassembly": "add dx, 0xFFFF"
     },
     "83c201": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "ADD.UW          t3, a2, zero",
@@ -825,8 +802,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "OR              s9, t3, t1",
             "XORI            t4, ra, 0xffffffff(-1)",
             "AND             s9, t4, s9",
@@ -841,7 +817,7 @@
         "disassembly": "add edx, 0x01"
     },
     "83c2ff": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "ADD.UW          t3, a2, zero",
@@ -859,8 +835,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "OR              s9, t3, t1",
             "XORI            t4, ra, 0xffffffff(-1)",
             "AND             s9, t4, s9",
@@ -875,7 +850,7 @@
         "disassembly": "add edx, 0xFFFFFFFF"
     },
     "4883c201": {
-        "instruction_count": 20,
+        "instruction_count": 19,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "ADD             ra, a2, t1",
@@ -892,7 +867,6 @@
             "SB              t3, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, ra, a2",
             "SLTI            t3, t1, 0x0(0)",
             "XOR             s9, s9, t3",
@@ -901,7 +875,7 @@
         "disassembly": "add rdx, 0x01"
     },
     "4883c2ff": {
-        "instruction_count": 20,
+        "instruction_count": 19,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "ADD             ra, a2, t1",
@@ -918,7 +892,6 @@
             "SB              t3, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, ra, a2",
             "SLTI            t3, t1, 0x0(0)",
             "XOR             s9, s9, t3",
@@ -927,7 +900,7 @@
         "disassembly": "add rdx, 0xFFFFFFFFFFFFFFFF"
     },
     "800701": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LBU             t3, a0, 0x0(0)",
@@ -945,8 +918,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "OR              s9, t3, t1",
             "XORI            t2, ra, 0xffffffff(-1)",
             "AND             s9, t2, s9",
@@ -961,7 +933,7 @@
         "disassembly": "add byte ptr [rdi], 0x01"
     },
     "66830701": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LHU             t3, a0, 0x0(0)",
@@ -979,8 +951,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "OR              s9, t3, t1",
             "XORI            t2, ra, 0xffffffff(-1)",
             "AND             s9, t2, s9",
@@ -995,7 +966,7 @@
         "disassembly": "add word ptr [rdi], 0x01"
     },
     "830701": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LWU             t3, a0, 0x0(0)",
@@ -1013,8 +984,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "OR              s9, t3, t1",
             "XORI            t2, ra, 0xffffffff(-1)",
             "AND             s9, t2, s9",
@@ -1029,7 +999,7 @@
         "disassembly": "add dword ptr [rdi], 0x01"
     },
     "48830701": {
-        "instruction_count": 21,
+        "instruction_count": 20,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LD              t3, a0, 0x0(0)",
@@ -1047,7 +1017,6 @@
             "SB              t2, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, ra, t3",
             "SLTI            t2, t1, 0x0(0)",
             "XOR             s9, s9, t2",
@@ -1056,7 +1025,7 @@
         "disassembly": "add qword ptr [rdi], 0x01"
     },
     "28da": {
-        "instruction_count": 29,
+        "instruction_count": 28,
         "expected_asm": [
             "ANDI            t1, s0, 0xff(255)",
             "ANDI            t3, a2, 0xff(255)",
@@ -1073,8 +1042,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -1091,7 +1059,7 @@
         "disassembly": "sub dl, bl"
     },
     "28fa": {
-        "instruction_count": 30,
+        "instruction_count": 29,
         "expected_asm": [
             "SRLI            t1, s0, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -1109,8 +1077,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -1127,7 +1094,7 @@
         "disassembly": "sub dl, bh"
     },
     "28de": {
-        "instruction_count": 32,
+        "instruction_count": 31,
         "expected_asm": [
             "ANDI            t1, s0, 0xff(255)",
             "SRLI            t3, a2, 0x8(8)",
@@ -1145,8 +1112,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -1165,7 +1131,7 @@
         "disassembly": "sub dh, bl"
     },
     "28fe": {
-        "instruction_count": 33,
+        "instruction_count": 32,
         "expected_asm": [
             "SRLI            t1, s0, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -1184,8 +1150,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -1204,7 +1169,7 @@
         "disassembly": "sub dh, bh"
     },
     "6629da": {
-        "instruction_count": 30,
+        "instruction_count": 29,
         "expected_asm": [
             "ZEXT.H          t1, s0",
             "ZEXT.H          t3, a2",
@@ -1221,8 +1186,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -1240,7 +1204,7 @@
         "disassembly": "sub dx, bx"
     },
     "29da": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "ADD.UW          t1, s0, zero",
             "ADD.UW          t3, a2, zero",
@@ -1257,8 +1221,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -1273,7 +1236,7 @@
         "disassembly": "sub edx, ebx"
     },
     "4829da": {
-        "instruction_count": 18,
+        "instruction_count": 17,
         "expected_asm": [
             "SUB             ra, a2, s0",
             "SLTU            s5, a2, s0",
@@ -1288,7 +1251,6 @@
             "SB              t1, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, s0",
             "SLT             t1, ra, a2",
             "XOR             s9, s9, t1",
@@ -1297,7 +1259,7 @@
         "disassembly": "sub rdx, rbx"
     },
     "2a17": {
-        "instruction_count": 29,
+        "instruction_count": 28,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "ANDI            t4, a2, 0xff(255)",
@@ -1314,8 +1276,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t2, t4, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -1332,7 +1293,7 @@
         "disassembly": "sub dl, [rdi]"
     },
     "2a37": {
-        "instruction_count": 32,
+        "instruction_count": 31,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "SRLI            t4, a2, 0x8(8)",
@@ -1350,8 +1311,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t2, t4, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -1370,7 +1330,7 @@
         "disassembly": "sub dh, [rdi]"
     },
     "662b17": {
-        "instruction_count": 30,
+        "instruction_count": 29,
         "expected_asm": [
             "LHU             t1, a0, 0x0(0)",
             "ZEXT.H          t4, a2",
@@ -1387,8 +1347,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "XORI            t2, t4, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -1406,7 +1365,7 @@
         "disassembly": "sub dx, [rdi]"
     },
     "2b17": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "LWU             t1, a0, 0x0(0)",
             "ADD.UW          t4, a2, zero",
@@ -1423,8 +1382,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "XORI            t2, t4, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -1439,7 +1397,7 @@
         "disassembly": "sub edx, [rdi]"
     },
     "482b17": {
-        "instruction_count": 19,
+        "instruction_count": 18,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "SUB             ra, a2, t1",
@@ -1455,7 +1413,6 @@
             "SB              t4, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, t1",
             "SLT             t4, ra, a2",
             "XOR             s9, s9, t4",
@@ -1464,7 +1421,7 @@
         "disassembly": "sub rdx, [rdi]"
     },
     "2817": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "ANDI            t1, a2, 0xff(255)",
             "LBU             t3, a0, 0x0(0)",
@@ -1481,8 +1438,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t2, t3, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -1497,7 +1453,7 @@
         "disassembly": "sub [rdi], dl"
     },
     "2837": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "SRLI            t1, a2, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -1515,8 +1471,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t2, t3, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -1531,7 +1486,7 @@
         "disassembly": "sub [rdi], dh"
     },
     "662917": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "ZEXT.H          t1, a2",
             "LHU             t3, a0, 0x0(0)",
@@ -1548,8 +1503,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "XORI            t2, t3, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -1564,7 +1518,7 @@
         "disassembly": "sub [rdi], dx"
     },
     "2917": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "ADD.UW          t1, a2, zero",
             "LWU             t3, a0, 0x0(0)",
@@ -1581,8 +1535,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "XORI            t2, t3, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -1597,7 +1550,7 @@
         "disassembly": "sub [rdi], edx"
     },
     "482917": {
-        "instruction_count": 19,
+        "instruction_count": 18,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "SUB             ra, t1, a2",
@@ -1613,7 +1566,6 @@
             "SB              t4, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, a2",
             "SLT             t4, ra, t1",
             "XOR             s9, s9, t4",
@@ -1622,7 +1574,7 @@
         "disassembly": "sub [rdi], rdx"
     },
     "80ea01": {
-        "instruction_count": 30,
+        "instruction_count": 29,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "ANDI            t3, a2, 0xff(255)",
@@ -1640,8 +1592,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -1658,7 +1609,7 @@
         "disassembly": "sub dl, 0x01"
     },
     "80eaff": {
-        "instruction_count": 30,
+        "instruction_count": 29,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "ANDI            t3, a2, 0xff(255)",
@@ -1676,8 +1627,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -1694,7 +1644,7 @@
         "disassembly": "sub dl, 0xFF"
     },
     "80ee01": {
-        "instruction_count": 33,
+        "instruction_count": 32,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "SRLI            t3, a2, 0x8(8)",
@@ -1713,8 +1663,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -1733,7 +1682,7 @@
         "disassembly": "sub dh, 0x01"
     },
     "80eeff": {
-        "instruction_count": 33,
+        "instruction_count": 32,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "SRLI            t3, a2, 0x8(8)",
@@ -1752,8 +1701,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -1772,7 +1720,7 @@
         "disassembly": "sub dh, 0xFF"
     },
     "6683ea01": {
-        "instruction_count": 31,
+        "instruction_count": 30,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "ZEXT.H          t3, a2",
@@ -1790,8 +1738,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -1809,7 +1756,7 @@
         "disassembly": "sub dx, 0x01"
     },
     "6683eaff": {
-        "instruction_count": 31,
+        "instruction_count": 30,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "ZEXT.H          t3, a2",
@@ -1827,8 +1774,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -1846,7 +1792,7 @@
         "disassembly": "sub dx, 0xFFFF"
     },
     "83ea01": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "ADD.UW          t3, a2, zero",
@@ -1864,8 +1810,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -1880,7 +1825,7 @@
         "disassembly": "sub edx, 0x01"
     },
     "83eaff": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "ADD.UW          t3, a2, zero",
@@ -1898,8 +1843,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -1914,7 +1858,7 @@
         "disassembly": "sub edx, 0xFFFFFFFF"
     },
     "4883ea01": {
-        "instruction_count": 19,
+        "instruction_count": 18,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "SUB             ra, a2, t1",
@@ -1930,7 +1874,6 @@
             "SB              t3, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, t1",
             "SLT             t3, ra, a2",
             "XOR             s9, s9, t3",
@@ -1939,7 +1882,7 @@
         "disassembly": "sub rdx, 0x01"
     },
     "4883eaff": {
-        "instruction_count": 19,
+        "instruction_count": 18,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "SUB             ra, a2, t1",
@@ -1955,7 +1898,6 @@
             "SB              t3, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, t1",
             "SLT             t3, ra, a2",
             "XOR             s9, s9, t3",
@@ -1964,7 +1906,7 @@
         "disassembly": "sub rdx, 0xFFFFFFFFFFFFFFFF"
     },
     "802f01": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LBU             t3, a0, 0x0(0)",
@@ -1982,8 +1924,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t2, t3, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -1998,7 +1939,7 @@
         "disassembly": "sub byte ptr [rdi], 0x01"
     },
     "66832f01": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LHU             t3, a0, 0x0(0)",
@@ -2016,8 +1957,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "XORI            t2, t3, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -2032,7 +1972,7 @@
         "disassembly": "sub word ptr [rdi], 0x01"
     },
     "832f01": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LWU             t3, a0, 0x0(0)",
@@ -2050,8 +1990,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "XORI            t2, t3, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -2066,7 +2005,7 @@
         "disassembly": "sub dword ptr [rdi], 0x01"
     },
     "48832f01": {
-        "instruction_count": 20,
+        "instruction_count": 19,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LD              t3, a0, 0x0(0)",
@@ -2083,7 +2022,6 @@
             "SB              t2, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, t1",
             "SLT             t2, ra, t3",
             "XOR             s9, s9, t2",
@@ -2092,7 +2030,7 @@
         "disassembly": "sub qword ptr [rdi], 0x01"
     },
     "10da": {
-        "instruction_count": 37,
+        "instruction_count": 36,
         "expected_asm": [
             "ANDI            t3, s0, 0xff(255)",
             "ANDI            t4, a2, 0xff(255)",
@@ -2126,8 +2064,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "ANDI            t2, t1, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
             "OR              a2, a2, t2"
@@ -2135,7 +2072,7 @@
         "disassembly": "adc dl, bl"
     },
     "10fa": {
-        "instruction_count": 38,
+        "instruction_count": 37,
         "expected_asm": [
             "SRLI            t3, s0, 0x8(8)",
             "ANDI            t3, t3, 0xff(255)",
@@ -2170,8 +2107,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "ANDI            t2, t1, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
             "OR              a2, a2, t2"
@@ -2179,7 +2115,7 @@
         "disassembly": "adc dl, bh"
     },
     "10de": {
-        "instruction_count": 40,
+        "instruction_count": 39,
         "expected_asm": [
             "ANDI            t3, s0, 0xff(255)",
             "SRLI            t4, a2, 0x8(8)",
@@ -2214,8 +2150,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "ANDI            t2, t1, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
@@ -2225,7 +2160,7 @@
         "disassembly": "adc dh, bl"
     },
     "10fe": {
-        "instruction_count": 41,
+        "instruction_count": 40,
         "expected_asm": [
             "SRLI            t3, s0, 0x8(8)",
             "ANDI            t3, t3, 0xff(255)",
@@ -2261,8 +2196,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "ANDI            t2, t1, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
@@ -2272,7 +2206,7 @@
         "disassembly": "adc dh, bh"
     },
     "6611da": {
-        "instruction_count": 38,
+        "instruction_count": 37,
         "expected_asm": [
             "ZEXT.H          t3, s0",
             "ZEXT.H          t4, a2",
@@ -2306,8 +2240,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ZEXT.H          s7, t1",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0xf(15)",
             "ZEXT.H          t2, t1",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
@@ -2316,7 +2249,7 @@
         "disassembly": "adc dx, bx"
     },
     "11da": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "ADD.UW          t3, s0, zero",
             "ADD.UW          t4, a2, zero",
@@ -2350,14 +2283,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ADD.UW          s7, t1, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, t1, 0x1f(31)",
             "ADD.UW          a2, t1, zero"
         ],
         "disassembly": "adc edx, ebx"
     },
     "4811da": {
-        "instruction_count": 26,
+        "instruction_count": 25,
         "expected_asm": [
             "ADD             ra, a2, s0",
             "ADD             t1, ra, s5",
@@ -2383,13 +2315,12 @@
             "XOR             s9, s9, t3",
             "SLTIU           s7, t1, 0x1(1)",
             "SRLI            s8, t1, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDI            a2, t1, 0x0(0)"
         ],
         "disassembly": "adc rdx, rbx"
     },
     "1217": {
-        "instruction_count": 37,
+        "instruction_count": 36,
         "expected_asm": [
             "LBU             t3, a0, 0x0(0)",
             "ANDI            t2, a2, 0xff(255)",
@@ -2423,8 +2354,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "ANDI            t5, t1, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
             "OR              a2, a2, t5"
@@ -2432,7 +2362,7 @@
         "disassembly": "adc dl, [rdi]"
     },
     "1237": {
-        "instruction_count": 40,
+        "instruction_count": 39,
         "expected_asm": [
             "LBU             t3, a0, 0x0(0)",
             "SRLI            t2, a2, 0x8(8)",
@@ -2467,8 +2397,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "ANDI            t5, t1, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
@@ -2478,7 +2407,7 @@
         "disassembly": "adc dh, [rdi]"
     },
     "661317": {
-        "instruction_count": 38,
+        "instruction_count": 37,
         "expected_asm": [
             "LHU             t3, a0, 0x0(0)",
             "ZEXT.H          t2, a2",
@@ -2512,8 +2441,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ZEXT.H          s7, t1",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0xf(15)",
             "ZEXT.H          t5, t1",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
@@ -2522,7 +2450,7 @@
         "disassembly": "adc dx, [rdi]"
     },
     "1317": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "LWU             t3, a0, 0x0(0)",
             "ADD.UW          t2, a2, zero",
@@ -2556,14 +2484,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ADD.UW          s7, t1, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, t1, 0x1f(31)",
             "ADD.UW          a2, t1, zero"
         ],
         "disassembly": "adc edx, [rdi]"
     },
     "481317": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "LD              t3, a0, 0x0(0)",
             "ADD             ra, a2, t3",
@@ -2590,13 +2517,12 @@
             "XOR             s9, s9, t2",
             "SLTIU           s7, t1, 0x1(1)",
             "SRLI            s8, t1, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDI            a2, t1, 0x0(0)"
         ],
         "disassembly": "adc rdx, [rdi]"
     },
     "1017": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "ANDI            t3, a2, 0xff(255)",
             "LBU             t4, a0, 0x0(0)",
@@ -2630,14 +2556,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "SB              t1, a0, 0x0(0)"
         ],
         "disassembly": "adc [rdi], dl"
     },
     "1037": {
-        "instruction_count": 36,
+        "instruction_count": 35,
         "expected_asm": [
             "SRLI            t3, a2, 0x8(8)",
             "ANDI            t3, t3, 0xff(255)",
@@ -2672,14 +2597,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "SB              t1, a0, 0x0(0)"
         ],
         "disassembly": "adc [rdi], dh"
     },
     "661117": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "ZEXT.H          t3, a2",
             "LHU             t4, a0, 0x0(0)",
@@ -2713,14 +2637,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ZEXT.H          s7, t1",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0xf(15)",
             "SH              t1, a0, 0x0(0)"
         ],
         "disassembly": "adc [rdi], dx"
     },
     "1117": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "ADD.UW          t3, a2, zero",
             "LWU             t4, a0, 0x0(0)",
@@ -2754,14 +2677,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ADD.UW          s7, t1, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, t1, 0x1f(31)",
             "SW              t1, a0, 0x0(0)"
         ],
         "disassembly": "adc [rdi], edx"
     },
     "481117": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "LD              t3, a0, 0x0(0)",
             "ADD             ra, t3, a2",
@@ -2788,13 +2710,12 @@
             "XOR             s9, s9, t2",
             "SLTIU           s7, t1, 0x1(1)",
             "SRLI            s8, t1, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SD              t1, a0, 0x0(0)"
         ],
         "disassembly": "adc [rdi], rdx"
     },
     "80d201": {
-        "instruction_count": 37,
+        "instruction_count": 36,
         "expected_asm": [
             "ADDIW           t3, zero, 0x1(1)",
             "ANDI            t4, a2, 0xff(255)",
@@ -2828,8 +2749,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "ANDI            t2, t1, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
             "OR              a2, a2, t2"
@@ -2837,7 +2757,7 @@
         "disassembly": "adc dl, 0x01"
     },
     "80d2ff": {
-        "instruction_count": 37,
+        "instruction_count": 36,
         "expected_asm": [
             "ADDIW           t3, zero, 0xffffffff(-1)",
             "ANDI            t4, a2, 0xff(255)",
@@ -2871,8 +2791,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "ANDI            t2, t1, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
             "OR              a2, a2, t2"
@@ -2880,7 +2799,7 @@
         "disassembly": "adc dl, 0xFF"
     },
     "80d601": {
-        "instruction_count": 40,
+        "instruction_count": 39,
         "expected_asm": [
             "ADDIW           t3, zero, 0x1(1)",
             "SRLI            t4, a2, 0x8(8)",
@@ -2915,8 +2834,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "ANDI            t2, t1, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
@@ -2926,7 +2844,7 @@
         "disassembly": "adc dh, 0x01"
     },
     "80d6ff": {
-        "instruction_count": 40,
+        "instruction_count": 39,
         "expected_asm": [
             "ADDIW           t3, zero, 0xffffffff(-1)",
             "SRLI            t4, a2, 0x8(8)",
@@ -2961,8 +2879,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "ANDI            t2, t1, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
@@ -2972,7 +2889,7 @@
         "disassembly": "adc dh, 0xFF"
     },
     "6683d201": {
-        "instruction_count": 38,
+        "instruction_count": 37,
         "expected_asm": [
             "ADDIW           t3, zero, 0x1(1)",
             "ZEXT.H          t4, a2",
@@ -3006,8 +2923,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ZEXT.H          s7, t1",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0xf(15)",
             "ZEXT.H          t2, t1",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
@@ -3016,7 +2932,7 @@
         "disassembly": "adc dx, 0x01"
     },
     "6683d2ff": {
-        "instruction_count": 38,
+        "instruction_count": 37,
         "expected_asm": [
             "ADDIW           t3, zero, 0xffffffff(-1)",
             "ZEXT.H          t4, a2",
@@ -3050,8 +2966,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ZEXT.H          s7, t1",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0xf(15)",
             "ZEXT.H          t2, t1",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
@@ -3060,7 +2975,7 @@
         "disassembly": "adc dx, 0xFFFF"
     },
     "83d201": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "ADDIW           t3, zero, 0x1(1)",
             "ADD.UW          t4, a2, zero",
@@ -3094,14 +3009,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ADD.UW          s7, t1, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, t1, 0x1f(31)",
             "ADD.UW          a2, t1, zero"
         ],
         "disassembly": "adc edx, 0x01"
     },
     "83d2ff": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "ADDIW           t3, zero, 0xffffffff(-1)",
             "ADD.UW          t4, a2, zero",
@@ -3135,14 +3049,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ADD.UW          s7, t1, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, t1, 0x1f(31)",
             "ADD.UW          a2, t1, zero"
         ],
         "disassembly": "adc edx, 0xFFFFFFFF"
     },
     "4883d201": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "ADDIW           t3, zero, 0x1(1)",
             "ADD             ra, a2, t3",
@@ -3169,13 +3082,12 @@
             "XOR             s9, s9, t4",
             "SLTIU           s7, t1, 0x1(1)",
             "SRLI            s8, t1, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDI            a2, t1, 0x0(0)"
         ],
         "disassembly": "adc rdx, 0x01"
     },
     "4883d2ff": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "ADDIW           t3, zero, 0xffffffff(-1)",
             "ADD             ra, a2, t3",
@@ -3202,13 +3114,12 @@
             "XOR             s9, s9, t4",
             "SLTIU           s7, t1, 0x1(1)",
             "SRLI            s8, t1, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDI            a2, t1, 0x0(0)"
         ],
         "disassembly": "adc rdx, 0xFFFFFFFFFFFFFFFF"
     },
     "801701": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "ADDIW           t3, zero, 0x1(1)",
             "LBU             t4, a0, 0x0(0)",
@@ -3242,14 +3153,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "SB              t1, a0, 0x0(0)"
         ],
         "disassembly": "adc byte ptr [rdi], 0x01"
     },
     "66831701": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "ADDIW           t3, zero, 0x1(1)",
             "LHU             t4, a0, 0x0(0)",
@@ -3283,14 +3193,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ZEXT.H          s7, t1",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0xf(15)",
             "SH              t1, a0, 0x0(0)"
         ],
         "disassembly": "adc word ptr [rdi], 0x01"
     },
     "831701": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "ADDIW           t3, zero, 0x1(1)",
             "LWU             t4, a0, 0x0(0)",
@@ -3324,14 +3233,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ADD.UW          s7, t1, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, t1, 0x1f(31)",
             "SW              t1, a0, 0x0(0)"
         ],
         "disassembly": "adc dword ptr [rdi], 0x01"
     },
     "48831701": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "ADDIW           t3, zero, 0x1(1)",
             "LD              t4, a0, 0x0(0)",
@@ -3359,13 +3267,12 @@
             "XOR             s9, s9, t5",
             "SLTIU           s7, t1, 0x1(1)",
             "SRLI            s8, t1, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SD              t1, a0, 0x0(0)"
         ],
         "disassembly": "adc qword ptr [rdi], 0x01"
     },
     "18da": {
-        "instruction_count": 36,
+        "instruction_count": 35,
         "expected_asm": [
             "ANDI            t3, s0, 0xff(255)",
             "ANDI            t4, a2, 0xff(255)",
@@ -3398,8 +3305,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "ANDI            t2, t1, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
             "OR              a2, a2, t2"
@@ -3407,7 +3313,7 @@
         "disassembly": "sbb dl, bl"
     },
     "18fa": {
-        "instruction_count": 37,
+        "instruction_count": 36,
         "expected_asm": [
             "SRLI            t3, s0, 0x8(8)",
             "ANDI            t3, t3, 0xff(255)",
@@ -3441,8 +3347,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "ANDI            t2, t1, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
             "OR              a2, a2, t2"
@@ -3450,7 +3355,7 @@
         "disassembly": "sbb dl, bh"
     },
     "18de": {
-        "instruction_count": 39,
+        "instruction_count": 38,
         "expected_asm": [
             "ANDI            t3, s0, 0xff(255)",
             "SRLI            t4, a2, 0x8(8)",
@@ -3484,8 +3389,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "ANDI            t2, t1, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
@@ -3495,7 +3399,7 @@
         "disassembly": "sbb dh, bl"
     },
     "18fe": {
-        "instruction_count": 40,
+        "instruction_count": 39,
         "expected_asm": [
             "SRLI            t3, s0, 0x8(8)",
             "ANDI            t3, t3, 0xff(255)",
@@ -3530,8 +3434,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "ANDI            t2, t1, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
@@ -3541,7 +3444,7 @@
         "disassembly": "sbb dh, bh"
     },
     "6619da": {
-        "instruction_count": 37,
+        "instruction_count": 36,
         "expected_asm": [
             "ZEXT.H          t3, s0",
             "ZEXT.H          t4, a2",
@@ -3574,8 +3477,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ZEXT.H          s7, t1",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0xf(15)",
             "ZEXT.H          t2, t1",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
@@ -3584,7 +3486,7 @@
         "disassembly": "sbb dx, bx"
     },
     "19da": {
-        "instruction_count": 34,
+        "instruction_count": 33,
         "expected_asm": [
             "ADD.UW          t3, s0, zero",
             "ADD.UW          t4, a2, zero",
@@ -3617,14 +3519,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ADD.UW          s7, t1, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, t1, 0x1f(31)",
             "ADD.UW          a2, t1, zero"
         ],
         "disassembly": "sbb edx, ebx"
     },
     "4819da": {
-        "instruction_count": 25,
+        "instruction_count": 24,
         "expected_asm": [
             "SUB             ra, a2, s0",
             "SUB             t1, ra, s5",
@@ -3649,13 +3550,12 @@
             "XOR             s9, s9, t3",
             "SLTIU           s7, t1, 0x1(1)",
             "SRLI            s8, t1, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDI            a2, t1, 0x0(0)"
         ],
         "disassembly": "sbb rdx, rbx"
     },
     "1a17": {
-        "instruction_count": 36,
+        "instruction_count": 35,
         "expected_asm": [
             "LBU             t3, a0, 0x0(0)",
             "ANDI            t2, a2, 0xff(255)",
@@ -3688,8 +3588,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "ANDI            t5, t1, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
             "OR              a2, a2, t5"
@@ -3697,7 +3596,7 @@
         "disassembly": "sbb dl, [rdi]"
     },
     "1a37": {
-        "instruction_count": 39,
+        "instruction_count": 38,
         "expected_asm": [
             "LBU             t3, a0, 0x0(0)",
             "SRLI            t2, a2, 0x8(8)",
@@ -3731,8 +3630,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "ANDI            t5, t1, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
@@ -3742,7 +3640,7 @@
         "disassembly": "sbb dh, [rdi]"
     },
     "661b17": {
-        "instruction_count": 37,
+        "instruction_count": 36,
         "expected_asm": [
             "LHU             t3, a0, 0x0(0)",
             "ZEXT.H          t2, a2",
@@ -3775,8 +3673,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ZEXT.H          s7, t1",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0xf(15)",
             "ZEXT.H          t5, t1",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
@@ -3785,7 +3682,7 @@
         "disassembly": "sbb dx, [rdi]"
     },
     "1b17": {
-        "instruction_count": 34,
+        "instruction_count": 33,
         "expected_asm": [
             "LWU             t3, a0, 0x0(0)",
             "ADD.UW          t2, a2, zero",
@@ -3818,14 +3715,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ADD.UW          s7, t1, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, t1, 0x1f(31)",
             "ADD.UW          a2, t1, zero"
         ],
         "disassembly": "sbb edx, [rdi]"
     },
     "481b17": {
-        "instruction_count": 26,
+        "instruction_count": 25,
         "expected_asm": [
             "LD              t3, a0, 0x0(0)",
             "SUB             ra, a2, t3",
@@ -3851,13 +3747,12 @@
             "XOR             s9, s9, t2",
             "SLTIU           s7, t1, 0x1(1)",
             "SRLI            s8, t1, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDI            a2, t1, 0x0(0)"
         ],
         "disassembly": "sbb rdx, [rdi]"
     },
     "1817": {
-        "instruction_count": 34,
+        "instruction_count": 33,
         "expected_asm": [
             "ANDI            t3, a2, 0xff(255)",
             "LBU             t4, a0, 0x0(0)",
@@ -3890,14 +3785,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "SB              t1, a0, 0x0(0)"
         ],
         "disassembly": "sbb [rdi], dl"
     },
     "1837": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "SRLI            t3, a2, 0x8(8)",
             "ANDI            t3, t3, 0xff(255)",
@@ -3931,14 +3825,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "SB              t1, a0, 0x0(0)"
         ],
         "disassembly": "sbb [rdi], dh"
     },
     "661917": {
-        "instruction_count": 34,
+        "instruction_count": 33,
         "expected_asm": [
             "ZEXT.H          t3, a2",
             "LHU             t4, a0, 0x0(0)",
@@ -3971,14 +3864,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ZEXT.H          s7, t1",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0xf(15)",
             "SH              t1, a0, 0x0(0)"
         ],
         "disassembly": "sbb [rdi], dx"
     },
     "1917": {
-        "instruction_count": 34,
+        "instruction_count": 33,
         "expected_asm": [
             "ADD.UW          t3, a2, zero",
             "LWU             t4, a0, 0x0(0)",
@@ -4011,14 +3903,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ADD.UW          s7, t1, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, t1, 0x1f(31)",
             "SW              t1, a0, 0x0(0)"
         ],
         "disassembly": "sbb [rdi], edx"
     },
     "481917": {
-        "instruction_count": 26,
+        "instruction_count": 25,
         "expected_asm": [
             "LD              t3, a0, 0x0(0)",
             "SUB             ra, t3, a2",
@@ -4044,13 +3935,12 @@
             "XOR             s9, s9, t2",
             "SLTIU           s7, t1, 0x1(1)",
             "SRLI            s8, t1, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SD              t1, a0, 0x0(0)"
         ],
         "disassembly": "sbb [rdi], rdx"
     },
     "80da01": {
-        "instruction_count": 37,
+        "instruction_count": 36,
         "expected_asm": [
             "ADDIW           t3, zero, 0x1(1)",
             "ANDI            t4, a2, 0xff(255)",
@@ -4084,8 +3974,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "ANDI            t2, t1, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
             "OR              a2, a2, t2"
@@ -4093,7 +3982,7 @@
         "disassembly": "sbb dl, 0x01"
     },
     "80daff": {
-        "instruction_count": 37,
+        "instruction_count": 36,
         "expected_asm": [
             "ADDIW           t3, zero, 0xffffffff(-1)",
             "ANDI            t4, a2, 0xff(255)",
@@ -4127,8 +4016,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "ANDI            t2, t1, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
             "OR              a2, a2, t2"
@@ -4136,7 +4024,7 @@
         "disassembly": "sbb dl, 0xFF"
     },
     "80de01": {
-        "instruction_count": 40,
+        "instruction_count": 39,
         "expected_asm": [
             "ADDIW           t3, zero, 0x1(1)",
             "SRLI            t4, a2, 0x8(8)",
@@ -4171,8 +4059,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "ANDI            t2, t1, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
@@ -4182,7 +4069,7 @@
         "disassembly": "sbb dh, 0x01"
     },
     "80deff": {
-        "instruction_count": 40,
+        "instruction_count": 39,
         "expected_asm": [
             "ADDIW           t3, zero, 0xffffffff(-1)",
             "SRLI            t4, a2, 0x8(8)",
@@ -4217,8 +4104,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "ANDI            t2, t1, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
@@ -4228,7 +4114,7 @@
         "disassembly": "sbb dh, 0xFF"
     },
     "6683da01": {
-        "instruction_count": 38,
+        "instruction_count": 37,
         "expected_asm": [
             "ADDIW           t3, zero, 0x1(1)",
             "ZEXT.H          t4, a2",
@@ -4262,8 +4148,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ZEXT.H          s7, t1",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0xf(15)",
             "ZEXT.H          t2, t1",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
@@ -4272,7 +4157,7 @@
         "disassembly": "sbb dx, 0x01"
     },
     "6683daff": {
-        "instruction_count": 38,
+        "instruction_count": 37,
         "expected_asm": [
             "ADDIW           t3, zero, 0xffffffff(-1)",
             "ZEXT.H          t4, a2",
@@ -4306,8 +4191,7 @@
             "ANDI            s9, s9, 0x1(1)",
             "ZEXT.H          s7, t1",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0xf(15)",
             "ZEXT.H          t2, t1",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
@@ -4316,7 +4200,7 @@
         "disassembly": "sbb dx, 0xFFFF"
     },
     "83da01": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "ADDIW           t3, zero, 0x1(1)",
             "ADD.UW          t4, a2, zero",
@@ -4350,14 +4234,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ADD.UW          s7, t1, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, t1, 0x1f(31)",
             "ADD.UW          a2, t1, zero"
         ],
         "disassembly": "sbb edx, 0x01"
     },
     "83daff": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "ADDIW           t3, zero, 0xffffffff(-1)",
             "ADD.UW          t4, a2, zero",
@@ -4391,14 +4274,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ADD.UW          s7, t1, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, t1, 0x1f(31)",
             "ADD.UW          a2, t1, zero"
         ],
         "disassembly": "sbb edx, 0xFFFFFFFF"
     },
     "4883da01": {
-        "instruction_count": 26,
+        "instruction_count": 25,
         "expected_asm": [
             "ADDIW           t3, zero, 0x1(1)",
             "SUB             ra, a2, t3",
@@ -4424,13 +4306,12 @@
             "XOR             s9, s9, t4",
             "SLTIU           s7, t1, 0x1(1)",
             "SRLI            s8, t1, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDI            a2, t1, 0x0(0)"
         ],
         "disassembly": "sbb rdx, 0x01"
     },
     "4883daff": {
-        "instruction_count": 26,
+        "instruction_count": 25,
         "expected_asm": [
             "ADDIW           t3, zero, 0xffffffff(-1)",
             "SUB             ra, a2, t3",
@@ -4456,13 +4337,12 @@
             "XOR             s9, s9, t4",
             "SLTIU           s7, t1, 0x1(1)",
             "SRLI            s8, t1, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDI            a2, t1, 0x0(0)"
         ],
         "disassembly": "sbb rdx, 0xFFFFFFFFFFFFFFFF"
     },
     "801f01": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "ADDIW           t3, zero, 0x1(1)",
             "LBU             t4, a0, 0x0(0)",
@@ -4496,14 +4376,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ANDI            s7, t1, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0x7(7)",
             "SB              t1, a0, 0x0(0)"
         ],
         "disassembly": "sbb byte ptr [rdi], 0x01"
     },
     "66831f01": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "ADDIW           t3, zero, 0x1(1)",
             "LHU             t4, a0, 0x0(0)",
@@ -4537,14 +4416,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ZEXT.H          s7, t1",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t1, 0xf(15)",
             "SH              t1, a0, 0x0(0)"
         ],
         "disassembly": "sbb word ptr [rdi], 0x01"
     },
     "831f01": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "ADDIW           t3, zero, 0x1(1)",
             "LWU             t4, a0, 0x0(0)",
@@ -4578,14 +4456,13 @@
             "ANDI            s9, s9, 0x1(1)",
             "ADD.UW          s7, t1, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t1, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, t1, 0x1f(31)",
             "SW              t1, a0, 0x0(0)"
         ],
         "disassembly": "sbb dword ptr [rdi], 0x01"
     },
     "48831f01": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "ADDIW           t3, zero, 0x1(1)",
             "LD              t4, a0, 0x0(0)",
@@ -4612,13 +4489,12 @@
             "XOR             s9, s9, t5",
             "SLTIU           s7, t1, 0x1(1)",
             "SRLI            s8, t1, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SD              t1, a0, 0x0(0)"
         ],
         "disassembly": "sbb qword ptr [rdi], 0x01"
     },
     "08da": {
-        "instruction_count": 19,
+        "instruction_count": 17,
         "expected_asm": [
             "ANDI            t1, s0, 0xff(255)",
             "ANDI            t3, a2, 0xff(255)",
@@ -4631,19 +4507,17 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2"
+            "OR              a2, a2, t4"
         ],
         "disassembly": "or dl, bl"
     },
     "08fa": {
-        "instruction_count": 20,
+        "instruction_count": 18,
         "expected_asm": [
             "SRLI            t1, s0, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -4657,19 +4531,17 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2"
+            "OR              a2, a2, t4"
         ],
         "disassembly": "or dl, bh"
     },
     "08de": {
-        "instruction_count": 22,
+        "instruction_count": 20,
         "expected_asm": [
             "ANDI            t1, s0, 0xff(255)",
             "SRLI            t3, a2, 0x8(8)",
@@ -4683,21 +4555,19 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2",
+            "OR              a2, a2, t4",
             "RORI            a2, a2, 0x38(56)"
         ],
         "disassembly": "or dh, bl"
     },
     "08fe": {
-        "instruction_count": 23,
+        "instruction_count": 21,
         "expected_asm": [
             "SRLI            t1, s0, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -4712,21 +4582,19 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2",
+            "OR              a2, a2, t4",
             "RORI            a2, a2, 0x38(56)"
         ],
         "disassembly": "or dh, bh"
     },
     "6609da": {
-        "instruction_count": 20,
+        "instruction_count": 18,
         "expected_asm": [
             "ZEXT.H          t1, s0",
             "ZEXT.H          t3, a2",
@@ -4739,20 +4607,18 @@
             "SB              t4, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ZEXT.H          t2, ra",
+            "SB              zero, s11, 0x1ca(458)",
+            "ZEXT.H          t4, ra",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
-            "OR              a2, a2, t2"
+            "OR              a2, a2, t4"
         ],
         "disassembly": "or dx, bx"
     },
     "09da": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ADD.UW          t1, s0, zero",
             "ADD.UW          t3, a2, zero",
@@ -4765,17 +4631,15 @@
             "SB              t4, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADD.UW          a2, ra, zero"
         ],
         "disassembly": "or edx, ebx"
     },
     "4809da": {
-        "instruction_count": 14,
+        "instruction_count": 12,
         "expected_asm": [
             "OR              ra, a2, s0",
             "ADDIW           s5, zero, 0x0(0)",
@@ -4786,16 +4650,14 @@
             "SB              t1, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t1, s11, 0x1ca(458)",
-            "ADDIW           t1, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADDI            a2, ra, 0x0(0)"
         ],
         "disassembly": "or rdx, rbx"
     },
     "0a17": {
-        "instruction_count": 19,
+        "instruction_count": 17,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "ANDI            t4, a2, 0xff(255)",
@@ -4808,19 +4670,17 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
-            "ANDI            t5, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t2, ra, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t5"
+            "OR              a2, a2, t2"
         ],
         "disassembly": "or dl, [rdi]"
     },
     "0a37": {
-        "instruction_count": 22,
+        "instruction_count": 20,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "SRLI            t4, a2, 0x8(8)",
@@ -4834,21 +4694,19 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
-            "ANDI            t5, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t2, ra, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t5",
+            "OR              a2, a2, t2",
             "RORI            a2, a2, 0x38(56)"
         ],
         "disassembly": "or dh, [rdi]"
     },
     "660b17": {
-        "instruction_count": 20,
+        "instruction_count": 18,
         "expected_asm": [
             "LHU             t1, a0, 0x0(0)",
             "ZEXT.H          t4, a2",
@@ -4861,20 +4719,18 @@
             "SB              t2, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
-            "ZEXT.H          t5, ra",
+            "SB              zero, s11, 0x1ca(458)",
+            "ZEXT.H          t2, ra",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
-            "OR              a2, a2, t5"
+            "OR              a2, a2, t2"
         ],
         "disassembly": "or dx, [rdi]"
     },
     "0b17": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "LWU             t1, a0, 0x0(0)",
             "ADD.UW          t4, a2, zero",
@@ -4887,17 +4743,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADD.UW          a2, ra, zero"
         ],
         "disassembly": "or edx, [rdi]"
     },
     "480b17": {
-        "instruction_count": 15,
+        "instruction_count": 13,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "OR              ra, a2, t1",
@@ -4909,16 +4763,14 @@
             "SB              t4, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADDI            a2, ra, 0x0(0)"
         ],
         "disassembly": "or rdx, [rdi]"
     },
     "0817": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ANDI            t1, a2, 0xff(255)",
             "LBU             t3, a0, 0x0(0)",
@@ -4931,17 +4783,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SB              ra, a0, 0x0(0)"
         ],
         "disassembly": "or [rdi], dl"
     },
     "0837": {
-        "instruction_count": 18,
+        "instruction_count": 16,
         "expected_asm": [
             "SRLI            t1, a2, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -4955,17 +4805,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SB              ra, a0, 0x0(0)"
         ],
         "disassembly": "or [rdi], dh"
     },
     "660917": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ZEXT.H          t1, a2",
             "LHU             t3, a0, 0x0(0)",
@@ -4978,17 +4826,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SH              ra, a0, 0x0(0)"
         ],
         "disassembly": "or [rdi], dx"
     },
     "0917": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ADD.UW          t1, a2, zero",
             "LWU             t3, a0, 0x0(0)",
@@ -5001,17 +4847,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SW              ra, a0, 0x0(0)"
         ],
         "disassembly": "or [rdi], edx"
     },
     "480917": {
-        "instruction_count": 15,
+        "instruction_count": 13,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "OR              ra, t1, a2",
@@ -5023,16 +4867,14 @@
             "SB              t4, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SD              ra, a0, 0x0(0)"
         ],
         "disassembly": "or [rdi], rdx"
     },
     "80ca01": {
-        "instruction_count": 19,
+        "instruction_count": 17,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "ANDI            t3, a2, 0xff(255)",
@@ -5045,19 +4887,17 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2"
+            "OR              a2, a2, t4"
         ],
         "disassembly": "or dl, 0x01"
     },
     "80caff": {
-        "instruction_count": 19,
+        "instruction_count": 17,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "ANDI            t3, a2, 0xff(255)",
@@ -5070,19 +4910,17 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2"
+            "OR              a2, a2, t4"
         ],
         "disassembly": "or dl, 0xFF"
     },
     "80ce01": {
-        "instruction_count": 22,
+        "instruction_count": 20,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "SRLI            t3, a2, 0x8(8)",
@@ -5096,21 +4934,19 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2",
+            "OR              a2, a2, t4",
             "RORI            a2, a2, 0x38(56)"
         ],
         "disassembly": "or dh, 0x01"
     },
     "80ceff": {
-        "instruction_count": 22,
+        "instruction_count": 20,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "SRLI            t3, a2, 0x8(8)",
@@ -5124,21 +4960,19 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2",
+            "OR              a2, a2, t4",
             "RORI            a2, a2, 0x38(56)"
         ],
         "disassembly": "or dh, 0xFF"
     },
     "6683ca01": {
-        "instruction_count": 20,
+        "instruction_count": 18,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "ZEXT.H          t3, a2",
@@ -5151,20 +4985,18 @@
             "SB              t4, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ZEXT.H          t2, ra",
+            "SB              zero, s11, 0x1ca(458)",
+            "ZEXT.H          t4, ra",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
-            "OR              a2, a2, t2"
+            "OR              a2, a2, t4"
         ],
         "disassembly": "or dx, 0x01"
     },
     "6683caff": {
-        "instruction_count": 20,
+        "instruction_count": 18,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "ZEXT.H          t3, a2",
@@ -5177,20 +5009,18 @@
             "SB              t4, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ZEXT.H          t2, ra",
+            "SB              zero, s11, 0x1ca(458)",
+            "ZEXT.H          t4, ra",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
-            "OR              a2, a2, t2"
+            "OR              a2, a2, t4"
         ],
         "disassembly": "or dx, 0xFFFF"
     },
     "83ca01": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "ADD.UW          t3, a2, zero",
@@ -5203,17 +5033,15 @@
             "SB              t4, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADD.UW          a2, ra, zero"
         ],
         "disassembly": "or edx, 0x01"
     },
     "83caff": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "ADD.UW          t3, a2, zero",
@@ -5226,17 +5054,15 @@
             "SB              t4, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADD.UW          a2, ra, zero"
         ],
         "disassembly": "or edx, 0xFFFFFFFF"
     },
     "4883ca01": {
-        "instruction_count": 15,
+        "instruction_count": 13,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "OR              ra, a2, t1",
@@ -5248,16 +5074,14 @@
             "SB              t3, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t3, s11, 0x1ca(458)",
-            "ADDIW           t3, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADDI            a2, ra, 0x0(0)"
         ],
         "disassembly": "or rdx, 0x01"
     },
     "4883caff": {
-        "instruction_count": 15,
+        "instruction_count": 13,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "OR              ra, a2, t1",
@@ -5269,16 +5093,14 @@
             "SB              t3, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t3, s11, 0x1ca(458)",
-            "ADDIW           t3, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADDI            a2, ra, 0x0(0)"
         ],
         "disassembly": "or rdx, 0xFFFFFFFFFFFFFFFF"
     },
     "800f01": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LBU             t3, a0, 0x0(0)",
@@ -5291,17 +5113,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SB              ra, a0, 0x0(0)"
         ],
         "disassembly": "or byte ptr [rdi], 0x01"
     },
     "66830f01": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LHU             t3, a0, 0x0(0)",
@@ -5314,17 +5134,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SH              ra, a0, 0x0(0)"
         ],
         "disassembly": "or word ptr [rdi], 0x01"
     },
     "830f01": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LWU             t3, a0, 0x0(0)",
@@ -5337,17 +5155,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SW              ra, a0, 0x0(0)"
         ],
         "disassembly": "or dword ptr [rdi], 0x01"
     },
     "48830f01": {
-        "instruction_count": 16,
+        "instruction_count": 14,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LD              t3, a0, 0x0(0)",
@@ -5360,16 +5176,14 @@
             "SB              t2, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SD              ra, a0, 0x0(0)"
         ],
         "disassembly": "or qword ptr [rdi], 0x01"
     },
     "20da": {
-        "instruction_count": 19,
+        "instruction_count": 17,
         "expected_asm": [
             "ANDI            t1, s0, 0xff(255)",
             "ANDI            t3, a2, 0xff(255)",
@@ -5382,19 +5196,17 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2"
+            "OR              a2, a2, t4"
         ],
         "disassembly": "and dl, bl"
     },
     "20fa": {
-        "instruction_count": 20,
+        "instruction_count": 18,
         "expected_asm": [
             "SRLI            t1, s0, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -5408,19 +5220,17 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2"
+            "OR              a2, a2, t4"
         ],
         "disassembly": "and dl, bh"
     },
     "20de": {
-        "instruction_count": 22,
+        "instruction_count": 20,
         "expected_asm": [
             "ANDI            t1, s0, 0xff(255)",
             "SRLI            t3, a2, 0x8(8)",
@@ -5434,21 +5244,19 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2",
+            "OR              a2, a2, t4",
             "RORI            a2, a2, 0x38(56)"
         ],
         "disassembly": "and dh, bl"
     },
     "20fe": {
-        "instruction_count": 23,
+        "instruction_count": 21,
         "expected_asm": [
             "SRLI            t1, s0, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -5463,21 +5271,19 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2",
+            "OR              a2, a2, t4",
             "RORI            a2, a2, 0x38(56)"
         ],
         "disassembly": "and dh, bh"
     },
     "6621da": {
-        "instruction_count": 20,
+        "instruction_count": 18,
         "expected_asm": [
             "ZEXT.H          t1, s0",
             "ZEXT.H          t3, a2",
@@ -5490,20 +5296,18 @@
             "SB              t4, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ZEXT.H          t2, ra",
+            "SB              zero, s11, 0x1ca(458)",
+            "ZEXT.H          t4, ra",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
-            "OR              a2, a2, t2"
+            "OR              a2, a2, t4"
         ],
         "disassembly": "and dx, bx"
     },
     "21da": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ADD.UW          t1, s0, zero",
             "ADD.UW          t3, a2, zero",
@@ -5516,17 +5320,15 @@
             "SB              t4, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADD.UW          a2, ra, zero"
         ],
         "disassembly": "and edx, ebx"
     },
     "4821da": {
-        "instruction_count": 14,
+        "instruction_count": 12,
         "expected_asm": [
             "AND             ra, a2, s0",
             "ADDIW           s5, zero, 0x0(0)",
@@ -5537,16 +5339,14 @@
             "SB              t1, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t1, s11, 0x1ca(458)",
-            "ADDIW           t1, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADDI            a2, ra, 0x0(0)"
         ],
         "disassembly": "and rdx, rbx"
     },
     "2217": {
-        "instruction_count": 19,
+        "instruction_count": 17,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "ANDI            t4, a2, 0xff(255)",
@@ -5559,19 +5359,17 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
-            "ANDI            t5, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t2, ra, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t5"
+            "OR              a2, a2, t2"
         ],
         "disassembly": "and dl, [rdi]"
     },
     "2237": {
-        "instruction_count": 22,
+        "instruction_count": 20,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "SRLI            t4, a2, 0x8(8)",
@@ -5585,21 +5383,19 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
-            "ANDI            t5, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t2, ra, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t5",
+            "OR              a2, a2, t2",
             "RORI            a2, a2, 0x38(56)"
         ],
         "disassembly": "and dh, [rdi]"
     },
     "662317": {
-        "instruction_count": 20,
+        "instruction_count": 18,
         "expected_asm": [
             "LHU             t1, a0, 0x0(0)",
             "ZEXT.H          t4, a2",
@@ -5612,20 +5408,18 @@
             "SB              t2, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
-            "ZEXT.H          t5, ra",
+            "SB              zero, s11, 0x1ca(458)",
+            "ZEXT.H          t2, ra",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
-            "OR              a2, a2, t5"
+            "OR              a2, a2, t2"
         ],
         "disassembly": "and dx, [rdi]"
     },
     "2317": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "LWU             t1, a0, 0x0(0)",
             "ADD.UW          t4, a2, zero",
@@ -5638,17 +5432,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADD.UW          a2, ra, zero"
         ],
         "disassembly": "and edx, [rdi]"
     },
     "482317": {
-        "instruction_count": 15,
+        "instruction_count": 13,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "AND             ra, a2, t1",
@@ -5660,16 +5452,14 @@
             "SB              t4, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADDI            a2, ra, 0x0(0)"
         ],
         "disassembly": "and rdx, [rdi]"
     },
     "2017": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ANDI            t1, a2, 0xff(255)",
             "LBU             t3, a0, 0x0(0)",
@@ -5682,17 +5472,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SB              ra, a0, 0x0(0)"
         ],
         "disassembly": "and [rdi], dl"
     },
     "2037": {
-        "instruction_count": 18,
+        "instruction_count": 16,
         "expected_asm": [
             "SRLI            t1, a2, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -5706,17 +5494,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SB              ra, a0, 0x0(0)"
         ],
         "disassembly": "and [rdi], dh"
     },
     "662117": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ZEXT.H          t1, a2",
             "LHU             t3, a0, 0x0(0)",
@@ -5729,17 +5515,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SH              ra, a0, 0x0(0)"
         ],
         "disassembly": "and [rdi], dx"
     },
     "2117": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ADD.UW          t1, a2, zero",
             "LWU             t3, a0, 0x0(0)",
@@ -5752,17 +5536,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SW              ra, a0, 0x0(0)"
         ],
         "disassembly": "and [rdi], edx"
     },
     "482117": {
-        "instruction_count": 15,
+        "instruction_count": 13,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "AND             ra, t1, a2",
@@ -5774,16 +5556,14 @@
             "SB              t4, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SD              ra, a0, 0x0(0)"
         ],
         "disassembly": "and [rdi], rdx"
     },
     "80e201": {
-        "instruction_count": 19,
+        "instruction_count": 17,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "ANDI            t3, a2, 0xff(255)",
@@ -5796,19 +5576,17 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2"
+            "OR              a2, a2, t4"
         ],
         "disassembly": "and dl, 0x01"
     },
     "80e2ff": {
-        "instruction_count": 19,
+        "instruction_count": 17,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "ANDI            t3, a2, 0xff(255)",
@@ -5821,19 +5599,17 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2"
+            "OR              a2, a2, t4"
         ],
         "disassembly": "and dl, 0xFF"
     },
     "80e601": {
-        "instruction_count": 22,
+        "instruction_count": 20,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "SRLI            t3, a2, 0x8(8)",
@@ -5847,21 +5623,19 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2",
+            "OR              a2, a2, t4",
             "RORI            a2, a2, 0x38(56)"
         ],
         "disassembly": "and dh, 0x01"
     },
     "80e6ff": {
-        "instruction_count": 22,
+        "instruction_count": 20,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "SRLI            t3, a2, 0x8(8)",
@@ -5875,21 +5649,19 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2",
+            "OR              a2, a2, t4",
             "RORI            a2, a2, 0x38(56)"
         ],
         "disassembly": "and dh, 0xFF"
     },
     "6683e201": {
-        "instruction_count": 20,
+        "instruction_count": 18,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "ZEXT.H          t3, a2",
@@ -5902,20 +5674,18 @@
             "SB              t4, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ZEXT.H          t2, ra",
+            "SB              zero, s11, 0x1ca(458)",
+            "ZEXT.H          t4, ra",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
-            "OR              a2, a2, t2"
+            "OR              a2, a2, t4"
         ],
         "disassembly": "and dx, 0x01"
     },
     "6683e2ff": {
-        "instruction_count": 20,
+        "instruction_count": 18,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "ZEXT.H          t3, a2",
@@ -5928,20 +5698,18 @@
             "SB              t4, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ZEXT.H          t2, ra",
+            "SB              zero, s11, 0x1ca(458)",
+            "ZEXT.H          t4, ra",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
-            "OR              a2, a2, t2"
+            "OR              a2, a2, t4"
         ],
         "disassembly": "and dx, 0xFFFF"
     },
     "83e201": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "ADD.UW          t3, a2, zero",
@@ -5954,17 +5722,15 @@
             "SB              t4, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADD.UW          a2, ra, zero"
         ],
         "disassembly": "and edx, 0x01"
     },
     "83e2ff": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "ADD.UW          t3, a2, zero",
@@ -5977,17 +5743,15 @@
             "SB              t4, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADD.UW          a2, ra, zero"
         ],
         "disassembly": "and edx, 0xFFFFFFFF"
     },
     "4883e201": {
-        "instruction_count": 15,
+        "instruction_count": 13,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "AND             ra, a2, t1",
@@ -5999,16 +5763,14 @@
             "SB              t3, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t3, s11, 0x1ca(458)",
-            "ADDIW           t3, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADDI            a2, ra, 0x0(0)"
         ],
         "disassembly": "and rdx, 0x01"
     },
     "4883e2ff": {
-        "instruction_count": 15,
+        "instruction_count": 13,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "AND             ra, a2, t1",
@@ -6020,16 +5782,14 @@
             "SB              t3, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t3, s11, 0x1ca(458)",
-            "ADDIW           t3, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADDI            a2, ra, 0x0(0)"
         ],
         "disassembly": "and rdx, 0xFFFFFFFFFFFFFFFF"
     },
     "802701": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LBU             t3, a0, 0x0(0)",
@@ -6042,17 +5802,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SB              ra, a0, 0x0(0)"
         ],
         "disassembly": "and byte ptr [rdi], 0x01"
     },
     "66832701": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LHU             t3, a0, 0x0(0)",
@@ -6065,17 +5823,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SH              ra, a0, 0x0(0)"
         ],
         "disassembly": "and word ptr [rdi], 0x01"
     },
     "832701": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LWU             t3, a0, 0x0(0)",
@@ -6088,17 +5844,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SW              ra, a0, 0x0(0)"
         ],
         "disassembly": "and dword ptr [rdi], 0x01"
     },
     "48832701": {
-        "instruction_count": 16,
+        "instruction_count": 14,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LD              t3, a0, 0x0(0)",
@@ -6111,16 +5865,14 @@
             "SB              t2, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SD              ra, a0, 0x0(0)"
         ],
         "disassembly": "and qword ptr [rdi], 0x01"
     },
     "30da": {
-        "instruction_count": 19,
+        "instruction_count": 17,
         "expected_asm": [
             "ANDI            t1, s0, 0xff(255)",
             "ANDI            t3, a2, 0xff(255)",
@@ -6133,19 +5885,17 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2"
+            "OR              a2, a2, t4"
         ],
         "disassembly": "xor dl, bl"
     },
     "30fa": {
-        "instruction_count": 20,
+        "instruction_count": 18,
         "expected_asm": [
             "SRLI            t1, s0, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -6159,19 +5909,17 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2"
+            "OR              a2, a2, t4"
         ],
         "disassembly": "xor dl, bh"
     },
     "30de": {
-        "instruction_count": 22,
+        "instruction_count": 20,
         "expected_asm": [
             "ANDI            t1, s0, 0xff(255)",
             "SRLI            t3, a2, 0x8(8)",
@@ -6185,21 +5933,19 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2",
+            "OR              a2, a2, t4",
             "RORI            a2, a2, 0x38(56)"
         ],
         "disassembly": "xor dh, bl"
     },
     "30fe": {
-        "instruction_count": 23,
+        "instruction_count": 21,
         "expected_asm": [
             "SRLI            t1, s0, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -6214,21 +5960,19 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2",
+            "OR              a2, a2, t4",
             "RORI            a2, a2, 0x38(56)"
         ],
         "disassembly": "xor dh, bh"
     },
     "6631da": {
-        "instruction_count": 20,
+        "instruction_count": 18,
         "expected_asm": [
             "ZEXT.H          t1, s0",
             "ZEXT.H          t3, a2",
@@ -6241,20 +5985,18 @@
             "SB              t4, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ZEXT.H          t2, ra",
+            "SB              zero, s11, 0x1ca(458)",
+            "ZEXT.H          t4, ra",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
-            "OR              a2, a2, t2"
+            "OR              a2, a2, t4"
         ],
         "disassembly": "xor dx, bx"
     },
     "31da": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ADD.UW          t1, s0, zero",
             "ADD.UW          t3, a2, zero",
@@ -6267,17 +6009,15 @@
             "SB              t4, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADD.UW          a2, ra, zero"
         ],
         "disassembly": "xor edx, ebx"
     },
     "4831da": {
-        "instruction_count": 14,
+        "instruction_count": 12,
         "expected_asm": [
             "XOR             ra, a2, s0",
             "ADDIW           s5, zero, 0x0(0)",
@@ -6288,16 +6028,14 @@
             "SB              t1, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t1, s11, 0x1ca(458)",
-            "ADDIW           t1, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADDI            a2, ra, 0x0(0)"
         ],
         "disassembly": "xor rdx, rbx"
     },
     "3217": {
-        "instruction_count": 19,
+        "instruction_count": 17,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "ANDI            t4, a2, 0xff(255)",
@@ -6310,19 +6048,17 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
-            "ANDI            t5, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t2, ra, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t5"
+            "OR              a2, a2, t2"
         ],
         "disassembly": "xor dl, [rdi]"
     },
     "3237": {
-        "instruction_count": 22,
+        "instruction_count": 20,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "SRLI            t4, a2, 0x8(8)",
@@ -6336,21 +6072,19 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
-            "ANDI            t5, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t2, ra, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t5",
+            "OR              a2, a2, t2",
             "RORI            a2, a2, 0x38(56)"
         ],
         "disassembly": "xor dh, [rdi]"
     },
     "663317": {
-        "instruction_count": 20,
+        "instruction_count": 18,
         "expected_asm": [
             "LHU             t1, a0, 0x0(0)",
             "ZEXT.H          t4, a2",
@@ -6363,20 +6097,18 @@
             "SB              t2, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
-            "ZEXT.H          t5, ra",
+            "SB              zero, s11, 0x1ca(458)",
+            "ZEXT.H          t2, ra",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
-            "OR              a2, a2, t5"
+            "OR              a2, a2, t2"
         ],
         "disassembly": "xor dx, [rdi]"
     },
     "3317": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "LWU             t1, a0, 0x0(0)",
             "ADD.UW          t4, a2, zero",
@@ -6389,17 +6121,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADD.UW          a2, ra, zero"
         ],
         "disassembly": "xor edx, [rdi]"
     },
     "483317": {
-        "instruction_count": 15,
+        "instruction_count": 13,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "XOR             ra, a2, t1",
@@ -6411,16 +6141,14 @@
             "SB              t4, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADDI            a2, ra, 0x0(0)"
         ],
         "disassembly": "xor rdx, [rdi]"
     },
     "3017": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ANDI            t1, a2, 0xff(255)",
             "LBU             t3, a0, 0x0(0)",
@@ -6433,17 +6161,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SB              ra, a0, 0x0(0)"
         ],
         "disassembly": "xor [rdi], dl"
     },
     "3037": {
-        "instruction_count": 18,
+        "instruction_count": 16,
         "expected_asm": [
             "SRLI            t1, a2, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -6457,17 +6183,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SB              ra, a0, 0x0(0)"
         ],
         "disassembly": "xor [rdi], dh"
     },
     "663117": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ZEXT.H          t1, a2",
             "LHU             t3, a0, 0x0(0)",
@@ -6480,17 +6204,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SH              ra, a0, 0x0(0)"
         ],
         "disassembly": "xor [rdi], dx"
     },
     "3117": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ADD.UW          t1, a2, zero",
             "LWU             t3, a0, 0x0(0)",
@@ -6503,17 +6225,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SW              ra, a0, 0x0(0)"
         ],
         "disassembly": "xor [rdi], edx"
     },
     "483117": {
-        "instruction_count": 15,
+        "instruction_count": 13,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "XOR             ra, t1, a2",
@@ -6525,16 +6245,14 @@
             "SB              t4, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SD              ra, a0, 0x0(0)"
         ],
         "disassembly": "xor [rdi], rdx"
     },
     "80f201": {
-        "instruction_count": 19,
+        "instruction_count": 17,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "ANDI            t3, a2, 0xff(255)",
@@ -6547,19 +6265,17 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2"
+            "OR              a2, a2, t4"
         ],
         "disassembly": "xor dl, 0x01"
     },
     "80f2ff": {
-        "instruction_count": 19,
+        "instruction_count": 17,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "ANDI            t3, a2, 0xff(255)",
@@ -6572,19 +6288,17 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2"
+            "OR              a2, a2, t4"
         ],
         "disassembly": "xor dl, 0xFF"
     },
     "80f601": {
-        "instruction_count": 22,
+        "instruction_count": 20,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "SRLI            t3, a2, 0x8(8)",
@@ -6598,21 +6312,19 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2",
+            "OR              a2, a2, t4",
             "RORI            a2, a2, 0x38(56)"
         ],
         "disassembly": "xor dh, 0x01"
     },
     "80f6ff": {
-        "instruction_count": 22,
+        "instruction_count": 20,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "SRLI            t3, a2, 0x8(8)",
@@ -6626,21 +6338,19 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ANDI            t2, ra, 0xff(255)",
+            "SB              zero, s11, 0x1ca(458)",
+            "ANDI            t4, ra, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
-            "OR              a2, a2, t2",
+            "OR              a2, a2, t4",
             "RORI            a2, a2, 0x38(56)"
         ],
         "disassembly": "xor dh, 0xFF"
     },
     "6683f201": {
-        "instruction_count": 20,
+        "instruction_count": 18,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "ZEXT.H          t3, a2",
@@ -6653,20 +6363,18 @@
             "SB              t4, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ZEXT.H          t2, ra",
+            "SB              zero, s11, 0x1ca(458)",
+            "ZEXT.H          t4, ra",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
-            "OR              a2, a2, t2"
+            "OR              a2, a2, t4"
         ],
         "disassembly": "xor dx, 0x01"
     },
     "6683f2ff": {
-        "instruction_count": 20,
+        "instruction_count": 18,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "ZEXT.H          t3, a2",
@@ -6679,20 +6387,18 @@
             "SB              t4, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
-            "ZEXT.H          t2, ra",
+            "SB              zero, s11, 0x1ca(458)",
+            "ZEXT.H          t4, ra",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
-            "OR              a2, a2, t2"
+            "OR              a2, a2, t4"
         ],
         "disassembly": "xor dx, 0xFFFF"
     },
     "83f201": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "ADD.UW          t3, a2, zero",
@@ -6705,17 +6411,15 @@
             "SB              t4, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADD.UW          a2, ra, zero"
         ],
         "disassembly": "xor edx, 0x01"
     },
     "83f2ff": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "ADD.UW          t3, a2, zero",
@@ -6728,17 +6432,15 @@
             "SB              t4, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADD.UW          a2, ra, zero"
         ],
         "disassembly": "xor edx, 0xFFFFFFFF"
     },
     "4883f201": {
-        "instruction_count": 15,
+        "instruction_count": 13,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "XOR             ra, a2, t1",
@@ -6750,16 +6452,14 @@
             "SB              t3, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t3, s11, 0x1ca(458)",
-            "ADDIW           t3, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADDI            a2, ra, 0x0(0)"
         ],
         "disassembly": "xor rdx, 0x01"
     },
     "4883f2ff": {
-        "instruction_count": 15,
+        "instruction_count": 13,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "XOR             ra, a2, t1",
@@ -6771,16 +6471,14 @@
             "SB              t3, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t3, s11, 0x1ca(458)",
-            "ADDIW           t3, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADDI            a2, ra, 0x0(0)"
         ],
         "disassembly": "xor rdx, 0xFFFFFFFFFFFFFFFF"
     },
     "803701": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LBU             t3, a0, 0x0(0)",
@@ -6793,17 +6491,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SB              ra, a0, 0x0(0)"
         ],
         "disassembly": "xor byte ptr [rdi], 0x01"
     },
     "66833701": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LHU             t3, a0, 0x0(0)",
@@ -6816,17 +6512,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SH              ra, a0, 0x0(0)"
         ],
         "disassembly": "xor word ptr [rdi], 0x01"
     },
     "833701": {
-        "instruction_count": 17,
+        "instruction_count": 15,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LWU             t3, a0, 0x0(0)",
@@ -6839,17 +6533,15 @@
             "SB              t2, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SW              ra, a0, 0x0(0)"
         ],
         "disassembly": "xor dword ptr [rdi], 0x01"
     },
     "48833701": {
-        "instruction_count": 16,
+        "instruction_count": 14,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LD              t3, a0, 0x0(0)",
@@ -6862,16 +6554,14 @@
             "SB              t2, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t2, s11, 0x1ca(458)",
-            "ADDIW           t2, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "SD              ra, a0, 0x0(0)"
         ],
         "disassembly": "xor qword ptr [rdi], 0x01"
     },
     "d0e2": {
-        "instruction_count": 19,
+        "instruction_count": 18,
         "expected_asm": [
             "ANDI            t1, a2, 0xff(255)",
             "SLLI            ra, t1, 0x1(1)",
@@ -6882,8 +6572,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "SRLI            s5, t1, 0x7(7)",
             "ANDI            s5, s5, 0x1(1)",
             "SRLI            s9, t1, 0x7(7)",
@@ -6896,7 +6585,7 @@
         "disassembly": "shl dl, 0x01"
     },
     "d0e6": {
-        "instruction_count": 22,
+        "instruction_count": 21,
         "expected_asm": [
             "SRLI            t1, a2, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -6908,8 +6597,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "SRLI            s5, t1, 0x7(7)",
             "ANDI            s5, s5, 0x1(1)",
             "SRLI            s9, t1, 0x7(7)",
@@ -6924,7 +6612,7 @@
         "disassembly": "shl dh, 0x01"
     },
     "66d1e2": {
-        "instruction_count": 20,
+        "instruction_count": 19,
         "expected_asm": [
             "ZEXT.H          t1, a2",
             "SLLI            ra, t1, 0x1(1)",
@@ -6935,8 +6623,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "SRLI            s5, t1, 0xf(15)",
             "ANDI            s5, s5, 0x1(1)",
             "SRLI            s9, t1, 0xf(15)",
@@ -6950,7 +6637,7 @@
         "disassembly": "shl dx, 0x01"
     },
     "d1e2": {
-        "instruction_count": 17,
+        "instruction_count": 16,
         "expected_asm": [
             "ADD.UW          t1, a2, zero",
             "SLLI            ra, t1, 0x1(1)",
@@ -6961,8 +6648,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "SRLI            s5, t1, 0x1f(31)",
             "ANDI            s5, s5, 0x1(1)",
             "SRLI            s9, t1, 0x1f(31)",
@@ -6973,7 +6659,7 @@
         "disassembly": "shl edx, 0x01"
     },
     "48d1e2": {
-        "instruction_count": 15,
+        "instruction_count": 14,
         "expected_asm": [
             "SLLI            ra, a2, 0x1(1)",
             "ANDI            t1, ra, 0xff(255)",
@@ -6983,7 +6669,6 @@
             "SB              t1, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SRLI            s5, a2, 0x3f(63)",
             "ANDI            s5, s5, 0x1(1)",
             "SRLI            s9, a2, 0x3f(63)",
@@ -6994,7 +6679,7 @@
         "disassembly": "shl rdx, 0x01"
     },
     "c0e23f": {
-        "instruction_count": 16,
+        "instruction_count": 15,
         "expected_asm": [
             "ANDI            t1, a2, 0xff(255)",
             "SLLI            ra, t1, 0x1f(31)",
@@ -7005,8 +6690,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "SRLI            s5, t1, 0x29(41)",
             "ANDI            s5, s5, 0x1(1)",
             "ANDI            t3, ra, 0xff(255)",
@@ -7016,7 +6700,7 @@
         "disassembly": "shl dl, 0x3F"
     },
     "c0e63f": {
-        "instruction_count": 19,
+        "instruction_count": 18,
         "expected_asm": [
             "SRLI            t1, a2, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -7028,8 +6712,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "SRLI            s5, t1, 0x29(41)",
             "ANDI            s5, s5, 0x1(1)",
             "ANDI            t3, ra, 0xff(255)",
@@ -7041,7 +6724,7 @@
         "disassembly": "shl dh, 0x3F"
     },
     "66c1e23f": {
-        "instruction_count": 17,
+        "instruction_count": 16,
         "expected_asm": [
             "ZEXT.H          t1, a2",
             "SLLI            ra, t1, 0x1f(31)",
@@ -7052,8 +6735,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "SRLI            s5, t1, 0x31(49)",
             "ANDI            s5, s5, 0x1(1)",
             "ZEXT.H          t3, ra",
@@ -7064,7 +6746,7 @@
         "disassembly": "shl dx, 0x3F"
     },
     "c1e23f": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "ADD.UW          t1, a2, zero",
             "SLLI            ra, t1, 0x1f(31)",
@@ -7075,8 +6757,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "SRLI            s5, t1, 0x1(1)",
             "ANDI            s5, s5, 0x1(1)",
             "ADD.UW          a2, ra, zero"
@@ -7084,7 +6765,7 @@
         "disassembly": "shl edx, 0x3F"
     },
     "48c1e23f": {
-        "instruction_count": 12,
+        "instruction_count": 11,
         "expected_asm": [
             "SLLI            ra, a2, 0x3f(63)",
             "ANDI            t1, ra, 0xff(255)",
@@ -7094,7 +6775,6 @@
             "SB              t1, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SRLI            s5, a2, 0x1(1)",
             "ANDI            s5, s5, 0x1(1)",
             "ADDI            a2, ra, 0x0(0)"
@@ -7102,13 +6782,13 @@
         "disassembly": "shl rdx, 0x3F"
     },
     "d2e2": {
-        "instruction_count": 24,
+        "instruction_count": 23,
         "expected_asm": [
             "ANDI            t1, a2, 0xff(255)",
             "ANDI            t3, s10, 0xff(255)",
             "ANDI            t4, t3, 0x1f(31)",
             "SLL             ra, t1, t4",
-            "BEQ             t4, zero, 0x44(68)",
+            "BEQ             t4, zero, 0x40(64)",
             "ANDI            t2, ra, 0xff(255)",
             "CPOPW           t2, t2",
             "ANDI            t2, t2, 0x1(1)",
@@ -7116,8 +6796,7 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s5, zero, 0x8(8)",
             "SUB             s5, s5, t4",
             "SRL             s5, t1, s5",
@@ -7132,14 +6811,14 @@
         "disassembly": "shl dl, cl"
     },
     "d2e6": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "SRLI            t1, a2, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
             "ANDI            t3, s10, 0xff(255)",
             "ANDI            t4, t3, 0x1f(31)",
             "SLL             ra, t1, t4",
-            "BEQ             t4, zero, 0x44(68)",
+            "BEQ             t4, zero, 0x40(64)",
             "ANDI            t2, ra, 0xff(255)",
             "CPOPW           t2, t2",
             "ANDI            t2, t2, 0x1(1)",
@@ -7147,8 +6826,7 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s5, zero, 0x8(8)",
             "SUB             s5, s5, t4",
             "SRL             s5, t1, s5",
@@ -7165,13 +6843,13 @@
         "disassembly": "shl dh, cl"
     },
     "66d3e2": {
-        "instruction_count": 25,
+        "instruction_count": 24,
         "expected_asm": [
             "ZEXT.H          t1, a2",
             "ANDI            t3, s10, 0xff(255)",
             "ANDI            t4, t3, 0x1f(31)",
             "SLL             ra, t1, t4",
-            "BEQ             t4, zero, 0x44(68)",
+            "BEQ             t4, zero, 0x40(64)",
             "ANDI            t2, ra, 0xff(255)",
             "CPOPW           t2, t2",
             "ANDI            t2, t2, 0x1(1)",
@@ -7179,8 +6857,7 @@
             "SB              t2, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s5, zero, 0x10(16)",
             "SUB             s5, s5, t4",
             "SRL             s5, t1, s5",
@@ -7196,13 +6873,13 @@
         "disassembly": "shl dx, cl"
     },
     "d3e2": {
-        "instruction_count": 22,
+        "instruction_count": 21,
         "expected_asm": [
             "ADD.UW          t1, a2, zero",
             "ANDI            t3, s10, 0xff(255)",
             "ANDI            t4, t3, 0x1f(31)",
             "SLL             ra, t1, t4",
-            "BEQ             t4, zero, 0x44(68)",
+            "BEQ             t4, zero, 0x40(64)",
             "ANDI            t2, ra, 0xff(255)",
             "CPOPW           t2, t2",
             "ANDI            t2, t2, 0x1(1)",
@@ -7210,8 +6887,7 @@
             "SB              t2, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s5, zero, 0x20(32)",
             "SUB             s5, s5, t4",
             "SRL             s5, t1, s5",
@@ -7224,12 +6900,12 @@
         "disassembly": "shl edx, cl"
     },
     "48d3e2": {
-        "instruction_count": 20,
+        "instruction_count": 19,
         "expected_asm": [
             "ANDI            t1, s10, 0xff(255)",
             "ANDI            t3, t1, 0x3f(63)",
             "SLL             ra, a2, t3",
-            "BEQ             t3, zero, 0x40(64)",
+            "BEQ             t3, zero, 0x3c(60)",
             "ANDI            t4, ra, 0xff(255)",
             "CPOPW           t4, t4",
             "ANDI            t4, t4, 0x1(1)",
@@ -7237,7 +6913,6 @@
             "SB              t4, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s5, zero, 0x40(64)",
             "SUB             s5, s5, t3",
             "SRL             s5, a2, s5",
@@ -7250,7 +6925,7 @@
         "disassembly": "shl rdx, cl"
     },
     "d027": {
-        "instruction_count": 17,
+        "instruction_count": 16,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "SLLI            ra, t1, 0x1(1)",
@@ -7261,8 +6936,7 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "SRLI            s5, t1, 0x7(7)",
             "ANDI            s5, s5, 0x1(1)",
             "SRLI            s9, t1, 0x7(7)",
@@ -7273,7 +6947,7 @@
         "disassembly": "shl byte ptr [rdi], 0x01"
     },
     "66d127": {
-        "instruction_count": 17,
+        "instruction_count": 16,
         "expected_asm": [
             "LHU             t1, a0, 0x0(0)",
             "SLLI            ra, t1, 0x1(1)",
@@ -7284,8 +6958,7 @@
             "SB              t4, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "SRLI            s5, t1, 0xf(15)",
             "ANDI            s5, s5, 0x1(1)",
             "SRLI            s9, t1, 0xf(15)",
@@ -7296,7 +6969,7 @@
         "disassembly": "shl word ptr [rdi], 0x01"
     },
     "d127": {
-        "instruction_count": 17,
+        "instruction_count": 16,
         "expected_asm": [
             "LWU             t1, a0, 0x0(0)",
             "SLLI            ra, t1, 0x1(1)",
@@ -7307,8 +6980,7 @@
             "SB              t4, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "SRLI            s5, t1, 0x1f(31)",
             "ANDI            s5, s5, 0x1(1)",
             "SRLI            s9, t1, 0x1f(31)",
@@ -7319,7 +6991,7 @@
         "disassembly": "shl dword ptr [rdi], 0x01"
     },
     "48d127": {
-        "instruction_count": 16,
+        "instruction_count": 15,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "SLLI            ra, t1, 0x1(1)",
@@ -7330,7 +7002,6 @@
             "SB              t4, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SRLI            s5, t1, 0x3f(63)",
             "ANDI            s5, s5, 0x1(1)",
             "SRLI            s9, t1, 0x3f(63)",
@@ -7341,7 +7012,7 @@
         "disassembly": "shl qword ptr [rdi], 0x01"
     },
     "c0273f": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "SLLI            ra, t1, 0x1f(31)",
@@ -7352,8 +7023,7 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "SRLI            s5, t1, 0x29(41)",
             "ANDI            s5, s5, 0x1(1)",
             "SB              ra, a0, 0x0(0)"
@@ -7361,7 +7031,7 @@
         "disassembly": "shl byte ptr [rdi], 0x3F"
     },
     "66c1273f": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "LHU             t1, a0, 0x0(0)",
             "SLLI            ra, t1, 0x1f(31)",
@@ -7372,8 +7042,7 @@
             "SB              t4, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "SRLI            s5, t1, 0x31(49)",
             "ANDI            s5, s5, 0x1(1)",
             "SH              ra, a0, 0x0(0)"
@@ -7381,7 +7050,7 @@
         "disassembly": "shl word ptr [rdi], 0x3F"
     },
     "c1273f": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "LWU             t1, a0, 0x0(0)",
             "SLLI            ra, t1, 0x1f(31)",
@@ -7392,8 +7061,7 @@
             "SB              t4, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "SRLI            s5, t1, 0x1(1)",
             "ANDI            s5, s5, 0x1(1)",
             "SW              ra, a0, 0x0(0)"
@@ -7401,7 +7069,7 @@
         "disassembly": "shl dword ptr [rdi], 0x3F"
     },
     "48c1273f": {
-        "instruction_count": 13,
+        "instruction_count": 12,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "SLLI            ra, t1, 0x3f(63)",
@@ -7412,7 +7080,6 @@
             "SB              t4, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SRLI            s5, t1, 0x1(1)",
             "ANDI            s5, s5, 0x1(1)",
             "SD              ra, a0, 0x0(0)"
@@ -7420,13 +7087,13 @@
         "disassembly": "shl qword ptr [rdi], 0x3F"
     },
     "d227": {
-        "instruction_count": 22,
+        "instruction_count": 21,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "ANDI            t4, s10, 0xff(255)",
             "ANDI            t2, t4, 0x1f(31)",
             "SLL             ra, t1, t2",
-            "BEQ             t2, zero, 0x44(68)",
+            "BEQ             t2, zero, 0x40(64)",
             "ANDI            t5, ra, 0xff(255)",
             "CPOPW           t5, t5",
             "ANDI            t5, t5, 0x1(1)",
@@ -7434,8 +7101,7 @@
             "SB              t5, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s5, zero, 0x8(8)",
             "SUB             s5, s5, t2",
             "SRL             s5, t1, s5",
@@ -7448,13 +7114,13 @@
         "disassembly": "shl byte ptr [rdi], cl"
     },
     "66d327": {
-        "instruction_count": 22,
+        "instruction_count": 21,
         "expected_asm": [
             "LHU             t1, a0, 0x0(0)",
             "ANDI            t4, s10, 0xff(255)",
             "ANDI            t2, t4, 0x1f(31)",
             "SLL             ra, t1, t2",
-            "BEQ             t2, zero, 0x44(68)",
+            "BEQ             t2, zero, 0x40(64)",
             "ANDI            t5, ra, 0xff(255)",
             "CPOPW           t5, t5",
             "ANDI            t5, t5, 0x1(1)",
@@ -7462,8 +7128,7 @@
             "SB              t5, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s5, zero, 0x10(16)",
             "SUB             s5, s5, t2",
             "SRL             s5, t1, s5",
@@ -7476,13 +7141,13 @@
         "disassembly": "shl word ptr [rdi], cl"
     },
     "d327": {
-        "instruction_count": 22,
+        "instruction_count": 21,
         "expected_asm": [
             "LWU             t1, a0, 0x0(0)",
             "ANDI            t4, s10, 0xff(255)",
             "ANDI            t2, t4, 0x1f(31)",
             "SLL             ra, t1, t2",
-            "BEQ             t2, zero, 0x44(68)",
+            "BEQ             t2, zero, 0x40(64)",
             "ANDI            t5, ra, 0xff(255)",
             "CPOPW           t5, t5",
             "ANDI            t5, t5, 0x1(1)",
@@ -7490,8 +7155,7 @@
             "SB              t5, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s5, zero, 0x20(32)",
             "SUB             s5, s5, t2",
             "SRL             s5, t1, s5",
@@ -7504,13 +7168,13 @@
         "disassembly": "shl dword ptr [rdi], cl"
     },
     "48d327": {
-        "instruction_count": 21,
+        "instruction_count": 20,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "ANDI            t4, s10, 0xff(255)",
             "ANDI            t2, t4, 0x3f(63)",
             "SLL             ra, t1, t2",
-            "BEQ             t2, zero, 0x40(64)",
+            "BEQ             t2, zero, 0x3c(60)",
             "ANDI            t5, ra, 0xff(255)",
             "CPOPW           t5, t5",
             "ANDI            t5, t5, 0x1(1)",
@@ -7518,7 +7182,6 @@
             "SB              t5, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s5, zero, 0x40(64)",
             "SUB             s5, s5, t2",
             "SRL             s5, t1, s5",
@@ -7531,7 +7194,7 @@
         "disassembly": "shl qword ptr [rdi], cl"
     },
     "d0ea": {
-        "instruction_count": 18,
+        "instruction_count": 17,
         "expected_asm": [
             "ANDI            t1, a2, 0xff(255)",
             "SRLI            ra, t1, 0x1(1)",
@@ -7542,8 +7205,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "SRLI            s5, t1, 0x0(0)",
             "ANDI            s5, s5, 0x1(1)",
             "SRLI            s9, t1, 0x7(7)",
@@ -7555,7 +7217,7 @@
         "disassembly": "shr dl, 0x01"
     },
     "d0ee": {
-        "instruction_count": 21,
+        "instruction_count": 20,
         "expected_asm": [
             "SRLI            t1, a2, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -7567,8 +7229,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "SRLI            s5, t1, 0x0(0)",
             "ANDI            s5, s5, 0x1(1)",
             "SRLI            s9, t1, 0x7(7)",
@@ -7582,7 +7243,7 @@
         "disassembly": "shr dh, 0x01"
     },
     "66d1ea": {
-        "instruction_count": 19,
+        "instruction_count": 18,
         "expected_asm": [
             "ZEXT.H          t1, a2",
             "SRLI            ra, t1, 0x1(1)",
@@ -7593,8 +7254,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "SRLI            s5, t1, 0x0(0)",
             "ANDI            s5, s5, 0x1(1)",
             "SRLI            s9, t1, 0xf(15)",
@@ -7607,7 +7267,7 @@
         "disassembly": "shr dx, 0x01"
     },
     "d1ea": {
-        "instruction_count": 16,
+        "instruction_count": 15,
         "expected_asm": [
             "ADD.UW          t1, a2, zero",
             "SRLI            ra, t1, 0x1(1)",
@@ -7618,8 +7278,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "SRLI            s5, t1, 0x0(0)",
             "ANDI            s5, s5, 0x1(1)",
             "SRLI            s9, t1, 0x1f(31)",
@@ -7629,7 +7288,7 @@
         "disassembly": "shr edx, 0x01"
     },
     "48d1ea": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "SRLI            ra, a2, 0x1(1)",
             "ANDI            t1, ra, 0xff(255)",
@@ -7639,7 +7298,6 @@
             "SB              t1, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SRLI            s5, a2, 0x0(0)",
             "ANDI            s5, s5, 0x1(1)",
             "SRLI            s9, a2, 0x3f(63)",
@@ -7649,7 +7307,7 @@
         "disassembly": "shr rdx, 0x01"
     },
     "c0ea3f": {
-        "instruction_count": 16,
+        "instruction_count": 15,
         "expected_asm": [
             "ANDI            t1, a2, 0xff(255)",
             "SRLI            ra, t1, 0x1f(31)",
@@ -7660,8 +7318,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "SRLI            s5, t1, 0x1e(30)",
             "ANDI            s5, s5, 0x1(1)",
             "ANDI            t3, ra, 0xff(255)",
@@ -7671,7 +7328,7 @@
         "disassembly": "shr dl, 0x3F"
     },
     "c0ee3f": {
-        "instruction_count": 19,
+        "instruction_count": 18,
         "expected_asm": [
             "SRLI            t1, a2, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -7683,8 +7340,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "SRLI            s5, t1, 0x1e(30)",
             "ANDI            s5, s5, 0x1(1)",
             "ANDI            t3, ra, 0xff(255)",
@@ -7696,7 +7352,7 @@
         "disassembly": "shr dh, 0x3F"
     },
     "66c1ea3f": {
-        "instruction_count": 17,
+        "instruction_count": 16,
         "expected_asm": [
             "ZEXT.H          t1, a2",
             "SRLI            ra, t1, 0x1f(31)",
@@ -7707,8 +7363,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "SRLI            s5, t1, 0x1e(30)",
             "ANDI            s5, s5, 0x1(1)",
             "ZEXT.H          t3, ra",
@@ -7719,7 +7374,7 @@
         "disassembly": "shr dx, 0x3F"
     },
     "c1ea3f": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "ADD.UW          t1, a2, zero",
             "SRLI            ra, t1, 0x1f(31)",
@@ -7730,8 +7385,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "SRLI            s5, t1, 0x1e(30)",
             "ANDI            s5, s5, 0x1(1)",
             "ADD.UW          a2, ra, zero"
@@ -7739,7 +7393,7 @@
         "disassembly": "shr edx, 0x3F"
     },
     "48c1ea3f": {
-        "instruction_count": 12,
+        "instruction_count": 11,
         "expected_asm": [
             "SRLI            ra, a2, 0x3f(63)",
             "ANDI            t1, ra, 0xff(255)",
@@ -7749,7 +7403,6 @@
             "SB              t1, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SRLI            s5, a2, 0x3e(62)",
             "ANDI            s5, s5, 0x1(1)",
             "ADDI            a2, ra, 0x0(0)"
@@ -7757,13 +7410,13 @@
         "disassembly": "shr rdx, 0x3F"
     },
     "d2ea": {
-        "instruction_count": 22,
+        "instruction_count": 21,
         "expected_asm": [
             "ANDI            t1, a2, 0xff(255)",
             "ANDI            t3, s10, 0xff(255)",
             "ANDI            t4, t3, 0x1f(31)",
             "SRL             ra, t1, t4",
-            "BEQ             t4, zero, 0x3c(60)",
+            "BEQ             t4, zero, 0x38(56)",
             "ANDI            t2, ra, 0xff(255)",
             "CPOPW           t2, t2",
             "ANDI            t2, t2, 0x1(1)",
@@ -7771,8 +7424,7 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDI            s5, t4, 0xffffffff(-1)",
             "SRL             s5, t1, s5",
             "ANDI            s5, s5, 0x1(1)",
@@ -7785,14 +7437,14 @@
         "disassembly": "shr dl, cl"
     },
     "d2ee": {
-        "instruction_count": 25,
+        "instruction_count": 24,
         "expected_asm": [
             "SRLI            t1, a2, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
             "ANDI            t3, s10, 0xff(255)",
             "ANDI            t4, t3, 0x1f(31)",
             "SRL             ra, t1, t4",
-            "BEQ             t4, zero, 0x3c(60)",
+            "BEQ             t4, zero, 0x38(56)",
             "ANDI            t2, ra, 0xff(255)",
             "CPOPW           t2, t2",
             "ANDI            t2, t2, 0x1(1)",
@@ -7800,8 +7452,7 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDI            s5, t4, 0xffffffff(-1)",
             "SRL             s5, t1, s5",
             "ANDI            s5, s5, 0x1(1)",
@@ -7816,13 +7467,13 @@
         "disassembly": "shr dh, cl"
     },
     "66d3ea": {
-        "instruction_count": 23,
+        "instruction_count": 22,
         "expected_asm": [
             "ZEXT.H          t1, a2",
             "ANDI            t3, s10, 0xff(255)",
             "ANDI            t4, t3, 0x1f(31)",
             "SRL             ra, t1, t4",
-            "BEQ             t4, zero, 0x3c(60)",
+            "BEQ             t4, zero, 0x38(56)",
             "ANDI            t2, ra, 0xff(255)",
             "CPOPW           t2, t2",
             "ANDI            t2, t2, 0x1(1)",
@@ -7830,8 +7481,7 @@
             "SB              t2, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDI            s5, t4, 0xffffffff(-1)",
             "SRL             s5, t1, s5",
             "ANDI            s5, s5, 0x1(1)",
@@ -7845,13 +7495,13 @@
         "disassembly": "shr dx, cl"
     },
     "d3ea": {
-        "instruction_count": 20,
+        "instruction_count": 19,
         "expected_asm": [
             "ADD.UW          t1, a2, zero",
             "ANDI            t3, s10, 0xff(255)",
             "ANDI            t4, t3, 0x1f(31)",
             "SRL             ra, t1, t4",
-            "BEQ             t4, zero, 0x3c(60)",
+            "BEQ             t4, zero, 0x38(56)",
             "ANDI            t2, ra, 0xff(255)",
             "CPOPW           t2, t2",
             "ANDI            t2, t2, 0x1(1)",
@@ -7859,8 +7509,7 @@
             "SB              t2, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDI            s5, t4, 0xffffffff(-1)",
             "SRL             s5, t1, s5",
             "ANDI            s5, s5, 0x1(1)",
@@ -7871,12 +7520,12 @@
         "disassembly": "shr edx, cl"
     },
     "48d3ea": {
-        "instruction_count": 18,
+        "instruction_count": 17,
         "expected_asm": [
             "ANDI            t1, s10, 0xff(255)",
             "ANDI            t3, t1, 0x3f(63)",
             "SRL             ra, a2, t3",
-            "BEQ             t3, zero, 0x38(56)",
+            "BEQ             t3, zero, 0x34(52)",
             "ANDI            t4, ra, 0xff(255)",
             "CPOPW           t4, t4",
             "ANDI            t4, t4, 0x1(1)",
@@ -7884,7 +7533,6 @@
             "SB              t4, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDI            s5, t3, 0xffffffff(-1)",
             "SRL             s5, a2, s5",
             "ANDI            s5, s5, 0x1(1)",
@@ -7895,7 +7543,7 @@
         "disassembly": "shr rdx, cl"
     },
     "d02f": {
-        "instruction_count": 16,
+        "instruction_count": 15,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "SRLI            ra, t1, 0x1(1)",
@@ -7906,8 +7554,7 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "SRLI            s5, t1, 0x0(0)",
             "ANDI            s5, s5, 0x1(1)",
             "SRLI            s9, t1, 0x7(7)",
@@ -7917,7 +7564,7 @@
         "disassembly": "shr byte ptr [rdi], 0x01"
     },
     "66d12f": {
-        "instruction_count": 16,
+        "instruction_count": 15,
         "expected_asm": [
             "LHU             t1, a0, 0x0(0)",
             "SRLI            ra, t1, 0x1(1)",
@@ -7928,8 +7575,7 @@
             "SB              t4, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "SRLI            s5, t1, 0x0(0)",
             "ANDI            s5, s5, 0x1(1)",
             "SRLI            s9, t1, 0xf(15)",
@@ -7939,7 +7585,7 @@
         "disassembly": "shr word ptr [rdi], 0x01"
     },
     "d12f": {
-        "instruction_count": 16,
+        "instruction_count": 15,
         "expected_asm": [
             "LWU             t1, a0, 0x0(0)",
             "SRLI            ra, t1, 0x1(1)",
@@ -7950,8 +7596,7 @@
             "SB              t4, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "SRLI            s5, t1, 0x0(0)",
             "ANDI            s5, s5, 0x1(1)",
             "SRLI            s9, t1, 0x1f(31)",
@@ -7961,7 +7606,7 @@
         "disassembly": "shr dword ptr [rdi], 0x01"
     },
     "48d12f": {
-        "instruction_count": 15,
+        "instruction_count": 14,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "SRLI            ra, t1, 0x1(1)",
@@ -7972,7 +7617,6 @@
             "SB              t4, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SRLI            s5, t1, 0x0(0)",
             "ANDI            s5, s5, 0x1(1)",
             "SRLI            s9, t1, 0x3f(63)",
@@ -7982,7 +7626,7 @@
         "disassembly": "shr qword ptr [rdi], 0x01"
     },
     "c02f3f": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "SRLI            ra, t1, 0x1f(31)",
@@ -7993,8 +7637,7 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "SRLI            s5, t1, 0x1e(30)",
             "ANDI            s5, s5, 0x1(1)",
             "SB              ra, a0, 0x0(0)"
@@ -8002,7 +7645,7 @@
         "disassembly": "shr byte ptr [rdi], 0x3F"
     },
     "66c12f3f": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "LHU             t1, a0, 0x0(0)",
             "SRLI            ra, t1, 0x1f(31)",
@@ -8013,8 +7656,7 @@
             "SB              t4, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "SRLI            s5, t1, 0x1e(30)",
             "ANDI            s5, s5, 0x1(1)",
             "SH              ra, a0, 0x0(0)"
@@ -8022,7 +7664,7 @@
         "disassembly": "shr word ptr [rdi], 0x3F"
     },
     "c12f3f": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "LWU             t1, a0, 0x0(0)",
             "SRLI            ra, t1, 0x1f(31)",
@@ -8033,8 +7675,7 @@
             "SB              t4, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "SRLI            s5, t1, 0x1e(30)",
             "ANDI            s5, s5, 0x1(1)",
             "SW              ra, a0, 0x0(0)"
@@ -8042,7 +7683,7 @@
         "disassembly": "shr dword ptr [rdi], 0x3F"
     },
     "48c12f3f": {
-        "instruction_count": 13,
+        "instruction_count": 12,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "SRLI            ra, t1, 0x3f(63)",
@@ -8053,7 +7694,6 @@
             "SB              t4, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SRLI            s5, t1, 0x3e(62)",
             "ANDI            s5, s5, 0x1(1)",
             "SD              ra, a0, 0x0(0)"
@@ -8061,13 +7701,13 @@
         "disassembly": "shr qword ptr [rdi], 0x3F"
     },
     "d22f": {
-        "instruction_count": 20,
+        "instruction_count": 19,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "ANDI            t4, s10, 0xff(255)",
             "ANDI            t2, t4, 0x1f(31)",
             "SRL             ra, t1, t2",
-            "BEQ             t2, zero, 0x3c(60)",
+            "BEQ             t2, zero, 0x38(56)",
             "ANDI            t5, ra, 0xff(255)",
             "CPOPW           t5, t5",
             "ANDI            t5, t5, 0x1(1)",
@@ -8075,8 +7715,7 @@
             "SB              t5, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDI            s5, t2, 0xffffffff(-1)",
             "SRL             s5, t1, s5",
             "ANDI            s5, s5, 0x1(1)",
@@ -8087,13 +7726,13 @@
         "disassembly": "shr byte ptr [rdi], cl"
     },
     "66d32f": {
-        "instruction_count": 20,
+        "instruction_count": 19,
         "expected_asm": [
             "LHU             t1, a0, 0x0(0)",
             "ANDI            t4, s10, 0xff(255)",
             "ANDI            t2, t4, 0x1f(31)",
             "SRL             ra, t1, t2",
-            "BEQ             t2, zero, 0x3c(60)",
+            "BEQ             t2, zero, 0x38(56)",
             "ANDI            t5, ra, 0xff(255)",
             "CPOPW           t5, t5",
             "ANDI            t5, t5, 0x1(1)",
@@ -8101,8 +7740,7 @@
             "SB              t5, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDI            s5, t2, 0xffffffff(-1)",
             "SRL             s5, t1, s5",
             "ANDI            s5, s5, 0x1(1)",
@@ -8113,13 +7751,13 @@
         "disassembly": "shr word ptr [rdi], cl"
     },
     "d32f": {
-        "instruction_count": 20,
+        "instruction_count": 19,
         "expected_asm": [
             "LWU             t1, a0, 0x0(0)",
             "ANDI            t4, s10, 0xff(255)",
             "ANDI            t2, t4, 0x1f(31)",
             "SRL             ra, t1, t2",
-            "BEQ             t2, zero, 0x3c(60)",
+            "BEQ             t2, zero, 0x38(56)",
             "ANDI            t5, ra, 0xff(255)",
             "CPOPW           t5, t5",
             "ANDI            t5, t5, 0x1(1)",
@@ -8127,8 +7765,7 @@
             "SB              t5, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDI            s5, t2, 0xffffffff(-1)",
             "SRL             s5, t1, s5",
             "ANDI            s5, s5, 0x1(1)",
@@ -8139,13 +7776,13 @@
         "disassembly": "shr dword ptr [rdi], cl"
     },
     "48d32f": {
-        "instruction_count": 19,
+        "instruction_count": 18,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "ANDI            t4, s10, 0xff(255)",
             "ANDI            t2, t4, 0x3f(63)",
             "SRL             ra, t1, t2",
-            "BEQ             t2, zero, 0x38(56)",
+            "BEQ             t2, zero, 0x34(52)",
             "ANDI            t5, ra, 0xff(255)",
             "CPOPW           t5, t5",
             "ANDI            t5, t5, 0x1(1)",
@@ -8153,7 +7790,6 @@
             "SB              t5, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDI            s5, t2, 0xffffffff(-1)",
             "SRL             s5, t1, s5",
             "ANDI            s5, s5, 0x1(1)",
@@ -8164,7 +7800,7 @@
         "disassembly": "shr qword ptr [rdi], cl"
     },
     "d0fa": {
-        "instruction_count": 18,
+        "instruction_count": 17,
         "expected_asm": [
             "ANDI            t1, a2, 0xff(255)",
             "SLLI            ra, t1, 0x38(56)",
@@ -8176,8 +7812,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "SRLI            s5, t1, 0x0(0)",
             "ANDI            s5, s5, 0x1(1)",
             "ADDI            s9, zero, 0x0(0)",
@@ -8188,7 +7823,7 @@
         "disassembly": "sar dl, 0x01"
     },
     "d0fe": {
-        "instruction_count": 21,
+        "instruction_count": 20,
         "expected_asm": [
             "SRLI            t1, a2, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -8201,8 +7836,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "SRLI            s5, t1, 0x0(0)",
             "ANDI            s5, s5, 0x1(1)",
             "ADDI            s9, zero, 0x0(0)",
@@ -8215,7 +7849,7 @@
         "disassembly": "sar dh, 0x01"
     },
     "66d1fa": {
-        "instruction_count": 19,
+        "instruction_count": 18,
         "expected_asm": [
             "ZEXT.H          t1, a2",
             "SLLI            ra, t1, 0x30(48)",
@@ -8227,8 +7861,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "SRLI            s5, t1, 0x0(0)",
             "ANDI            s5, s5, 0x1(1)",
             "ADDI            s9, zero, 0x0(0)",
@@ -8240,7 +7873,7 @@
         "disassembly": "sar dx, 0x01"
     },
     "d1fa": {
-        "instruction_count": 15,
+        "instruction_count": 14,
         "expected_asm": [
             "ADD.UW          t1, a2, zero",
             "SRAIW           ra, t1, 0x1(1)",
@@ -8251,8 +7884,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "SRLI            s5, t1, 0x0(0)",
             "ANDI            s5, s5, 0x1(1)",
             "ADDI            s9, zero, 0x0(0)",
@@ -8261,7 +7893,7 @@
         "disassembly": "sar edx, 0x01"
     },
     "48d1fa": {
-        "instruction_count": 13,
+        "instruction_count": 12,
         "expected_asm": [
             "SRAI            ra, a2, 0x1(1)",
             "ANDI            t1, ra, 0xff(255)",
@@ -8271,7 +7903,6 @@
             "SB              t1, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SRLI            s5, a2, 0x0(0)",
             "ANDI            s5, s5, 0x1(1)",
             "ADDI            s9, zero, 0x0(0)",
@@ -8280,7 +7911,7 @@
         "disassembly": "sar rdx, 0x01"
     },
     "c0fa3f": {
-        "instruction_count": 18,
+        "instruction_count": 17,
         "expected_asm": [
             "ANDI            t1, a2, 0xff(255)",
             "SLLI            ra, t1, 0x38(56)",
@@ -8292,8 +7923,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "SRLI            s5, t1, 0x1e(30)",
             "ANDI            s5, s5, 0x1(1)",
             "ADDI            s9, zero, 0x0(0)",
@@ -8304,7 +7934,7 @@
         "disassembly": "sar dl, 0x3F"
     },
     "c0fe3f": {
-        "instruction_count": 21,
+        "instruction_count": 20,
         "expected_asm": [
             "SRLI            t1, a2, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -8317,8 +7947,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "SRLI            s5, t1, 0x1e(30)",
             "ANDI            s5, s5, 0x1(1)",
             "ADDI            s9, zero, 0x0(0)",
@@ -8331,7 +7960,7 @@
         "disassembly": "sar dh, 0x3F"
     },
     "66c1fa3f": {
-        "instruction_count": 19,
+        "instruction_count": 18,
         "expected_asm": [
             "ZEXT.H          t1, a2",
             "SLLI            ra, t1, 0x30(48)",
@@ -8343,8 +7972,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "SRLI            s5, t1, 0x1e(30)",
             "ANDI            s5, s5, 0x1(1)",
             "ADDI            s9, zero, 0x0(0)",
@@ -8356,7 +7984,7 @@
         "disassembly": "sar dx, 0x3F"
     },
     "c1fa3f": {
-        "instruction_count": 15,
+        "instruction_count": 14,
         "expected_asm": [
             "ADD.UW          t1, a2, zero",
             "SRAIW           ra, t1, 0x1f(31)",
@@ -8367,8 +7995,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "SRLI            s5, t1, 0x1e(30)",
             "ANDI            s5, s5, 0x1(1)",
             "ADDI            s9, zero, 0x0(0)",
@@ -8377,7 +8004,7 @@
         "disassembly": "sar edx, 0x3F"
     },
     "48c1fa3f": {
-        "instruction_count": 13,
+        "instruction_count": 12,
         "expected_asm": [
             "SRAI            ra, a2, 0x3f(63)",
             "ANDI            t1, ra, 0xff(255)",
@@ -8387,7 +8014,6 @@
             "SB              t1, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SRLI            s5, a2, 0x3e(62)",
             "ANDI            s5, s5, 0x1(1)",
             "ADDI            s9, zero, 0x0(0)",
@@ -8396,7 +8022,7 @@
         "disassembly": "sar rdx, 0x3F"
     },
     "d2fa": {
-        "instruction_count": 23,
+        "instruction_count": 22,
         "expected_asm": [
             "ANDI            t1, a2, 0xff(255)",
             "ANDI            t3, s10, 0xff(255)",
@@ -8404,7 +8030,7 @@
             "SLLI            ra, t1, 0x38(56)",
             "SRAI            ra, ra, 0x38(56)",
             "SRA             ra, ra, t4",
-            "BEQ             t4, zero, 0x38(56)",
+            "BEQ             t4, zero, 0x34(52)",
             "ANDI            t2, ra, 0xff(255)",
             "CPOPW           t2, t2",
             "ANDI            t2, t2, 0x1(1)",
@@ -8412,8 +8038,7 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDI            s5, t4, 0xffffffff(-1)",
             "SRL             s5, t1, s5",
             "ANDI            s5, s5, 0x1(1)",
@@ -8425,7 +8050,7 @@
         "disassembly": "sar dl, cl"
     },
     "d2fe": {
-        "instruction_count": 26,
+        "instruction_count": 25,
         "expected_asm": [
             "SRLI            t1, a2, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -8434,7 +8059,7 @@
             "SLLI            ra, t1, 0x38(56)",
             "SRAI            ra, ra, 0x38(56)",
             "SRA             ra, ra, t4",
-            "BEQ             t4, zero, 0x38(56)",
+            "BEQ             t4, zero, 0x34(52)",
             "ANDI            t2, ra, 0xff(255)",
             "CPOPW           t2, t2",
             "ANDI            t2, t2, 0x1(1)",
@@ -8442,8 +8067,7 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDI            s5, t4, 0xffffffff(-1)",
             "SRL             s5, t1, s5",
             "ANDI            s5, s5, 0x1(1)",
@@ -8457,7 +8081,7 @@
         "disassembly": "sar dh, cl"
     },
     "66d3fa": {
-        "instruction_count": 24,
+        "instruction_count": 23,
         "expected_asm": [
             "ZEXT.H          t1, a2",
             "ANDI            t3, s10, 0xff(255)",
@@ -8465,7 +8089,7 @@
             "SLLI            ra, t1, 0x30(48)",
             "SRAI            ra, ra, 0x30(48)",
             "SRA             ra, ra, t4",
-            "BEQ             t4, zero, 0x38(56)",
+            "BEQ             t4, zero, 0x34(52)",
             "ANDI            t2, ra, 0xff(255)",
             "CPOPW           t2, t2",
             "ANDI            t2, t2, 0x1(1)",
@@ -8473,8 +8097,7 @@
             "SB              t2, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDI            s5, t4, 0xffffffff(-1)",
             "SRL             s5, t1, s5",
             "ANDI            s5, s5, 0x1(1)",
@@ -8487,13 +8110,13 @@
         "disassembly": "sar dx, cl"
     },
     "d3fa": {
-        "instruction_count": 19,
+        "instruction_count": 18,
         "expected_asm": [
             "ADD.UW          t1, a2, zero",
             "ANDI            t3, s10, 0xff(255)",
             "ANDI            t4, t3, 0x1f(31)",
             "SRAW            ra, t1, t4",
-            "BEQ             t4, zero, 0x38(56)",
+            "BEQ             t4, zero, 0x34(52)",
             "ANDI            t2, ra, 0xff(255)",
             "CPOPW           t2, t2",
             "ANDI            t2, t2, 0x1(1)",
@@ -8501,8 +8124,7 @@
             "SB              t2, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDI            s5, t4, 0xffffffff(-1)",
             "SRL             s5, t1, s5",
             "ANDI            s5, s5, 0x1(1)",
@@ -8512,12 +8134,12 @@
         "disassembly": "sar edx, cl"
     },
     "48d3fa": {
-        "instruction_count": 17,
+        "instruction_count": 16,
         "expected_asm": [
             "ANDI            t1, s10, 0xff(255)",
             "ANDI            t3, t1, 0x3f(63)",
             "SRA             ra, a2, t3",
-            "BEQ             t3, zero, 0x34(52)",
+            "BEQ             t3, zero, 0x30(48)",
             "ANDI            t4, ra, 0xff(255)",
             "CPOPW           t4, t4",
             "ANDI            t4, t4, 0x1(1)",
@@ -8525,7 +8147,6 @@
             "SB              t4, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDI            s5, t3, 0xffffffff(-1)",
             "SRL             s5, a2, s5",
             "ANDI            s5, s5, 0x1(1)",
@@ -8535,7 +8156,7 @@
         "disassembly": "sar rdx, cl"
     },
     "d03f": {
-        "instruction_count": 16,
+        "instruction_count": 15,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "SLLI            ra, t1, 0x38(56)",
@@ -8547,8 +8168,7 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "SRLI            s5, t1, 0x0(0)",
             "ANDI            s5, s5, 0x1(1)",
             "ADDI            s9, zero, 0x0(0)",
@@ -8557,7 +8177,7 @@
         "disassembly": "sar byte ptr [rdi], 0x01"
     },
     "66d13f": {
-        "instruction_count": 16,
+        "instruction_count": 15,
         "expected_asm": [
             "LHU             t1, a0, 0x0(0)",
             "SLLI            ra, t1, 0x30(48)",
@@ -8569,8 +8189,7 @@
             "SB              t4, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "SRLI            s5, t1, 0x0(0)",
             "ANDI            s5, s5, 0x1(1)",
             "ADDI            s9, zero, 0x0(0)",
@@ -8579,7 +8198,7 @@
         "disassembly": "sar word ptr [rdi], 0x01"
     },
     "d13f": {
-        "instruction_count": 15,
+        "instruction_count": 14,
         "expected_asm": [
             "LWU             t1, a0, 0x0(0)",
             "SRAIW           ra, t1, 0x1(1)",
@@ -8590,8 +8209,7 @@
             "SB              t4, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "SRLI            s5, t1, 0x0(0)",
             "ANDI            s5, s5, 0x1(1)",
             "ADDI            s9, zero, 0x0(0)",
@@ -8600,7 +8218,7 @@
         "disassembly": "sar dword ptr [rdi], 0x01"
     },
     "48d13f": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "SRAI            ra, t1, 0x1(1)",
@@ -8611,7 +8229,6 @@
             "SB              t4, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SRLI            s5, t1, 0x0(0)",
             "ANDI            s5, s5, 0x1(1)",
             "ADDI            s9, zero, 0x0(0)",
@@ -8620,7 +8237,7 @@
         "disassembly": "sar qword ptr [rdi], 0x01"
     },
     "c03f3f": {
-        "instruction_count": 16,
+        "instruction_count": 15,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "SLLI            ra, t1, 0x38(56)",
@@ -8632,8 +8249,7 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "SRLI            s5, t1, 0x1e(30)",
             "ANDI            s5, s5, 0x1(1)",
             "ADDI            s9, zero, 0x0(0)",
@@ -8642,7 +8258,7 @@
         "disassembly": "sar byte ptr [rdi], 0x3F"
     },
     "66c13f3f": {
-        "instruction_count": 16,
+        "instruction_count": 15,
         "expected_asm": [
             "LHU             t1, a0, 0x0(0)",
             "SLLI            ra, t1, 0x30(48)",
@@ -8654,8 +8270,7 @@
             "SB              t4, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "SRLI            s5, t1, 0x1e(30)",
             "ANDI            s5, s5, 0x1(1)",
             "ADDI            s9, zero, 0x0(0)",
@@ -8664,7 +8279,7 @@
         "disassembly": "sar word ptr [rdi], 0x3F"
     },
     "c13f3f": {
-        "instruction_count": 15,
+        "instruction_count": 14,
         "expected_asm": [
             "LWU             t1, a0, 0x0(0)",
             "SRAIW           ra, t1, 0x1f(31)",
@@ -8675,8 +8290,7 @@
             "SB              t4, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "SRLI            s5, t1, 0x1e(30)",
             "ANDI            s5, s5, 0x1(1)",
             "ADDI            s9, zero, 0x0(0)",
@@ -8685,7 +8299,7 @@
         "disassembly": "sar dword ptr [rdi], 0x3F"
     },
     "48c13f3f": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "SRAI            ra, t1, 0x3f(63)",
@@ -8696,7 +8310,6 @@
             "SB              t4, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SRLI            s5, t1, 0x3e(62)",
             "ANDI            s5, s5, 0x1(1)",
             "ADDI            s9, zero, 0x0(0)",
@@ -8705,7 +8318,7 @@
         "disassembly": "sar qword ptr [rdi], 0x3F"
     },
     "d23f": {
-        "instruction_count": 21,
+        "instruction_count": 20,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "ANDI            t4, s10, 0xff(255)",
@@ -8713,7 +8326,7 @@
             "SLLI            ra, t1, 0x38(56)",
             "SRAI            ra, ra, 0x38(56)",
             "SRA             ra, ra, t2",
-            "BEQ             t2, zero, 0x38(56)",
+            "BEQ             t2, zero, 0x34(52)",
             "ANDI            t5, ra, 0xff(255)",
             "CPOPW           t5, t5",
             "ANDI            t5, t5, 0x1(1)",
@@ -8721,8 +8334,7 @@
             "SB              t5, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDI            s5, t2, 0xffffffff(-1)",
             "SRL             s5, t1, s5",
             "ANDI            s5, s5, 0x1(1)",
@@ -8732,7 +8344,7 @@
         "disassembly": "sar byte ptr [rdi], cl"
     },
     "66d33f": {
-        "instruction_count": 21,
+        "instruction_count": 20,
         "expected_asm": [
             "LHU             t1, a0, 0x0(0)",
             "ANDI            t4, s10, 0xff(255)",
@@ -8740,7 +8352,7 @@
             "SLLI            ra, t1, 0x30(48)",
             "SRAI            ra, ra, 0x30(48)",
             "SRA             ra, ra, t2",
-            "BEQ             t2, zero, 0x38(56)",
+            "BEQ             t2, zero, 0x34(52)",
             "ANDI            t5, ra, 0xff(255)",
             "CPOPW           t5, t5",
             "ANDI            t5, t5, 0x1(1)",
@@ -8748,8 +8360,7 @@
             "SB              t5, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDI            s5, t2, 0xffffffff(-1)",
             "SRL             s5, t1, s5",
             "ANDI            s5, s5, 0x1(1)",
@@ -8759,13 +8370,13 @@
         "disassembly": "sar word ptr [rdi], cl"
     },
     "d33f": {
-        "instruction_count": 19,
+        "instruction_count": 18,
         "expected_asm": [
             "LWU             t1, a0, 0x0(0)",
             "ANDI            t4, s10, 0xff(255)",
             "ANDI            t2, t4, 0x1f(31)",
             "SRAW            ra, t1, t2",
-            "BEQ             t2, zero, 0x38(56)",
+            "BEQ             t2, zero, 0x34(52)",
             "ANDI            t5, ra, 0xff(255)",
             "CPOPW           t5, t5",
             "ANDI            t5, t5, 0x1(1)",
@@ -8773,8 +8384,7 @@
             "SB              t5, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDI            s5, t2, 0xffffffff(-1)",
             "SRL             s5, t1, s5",
             "ANDI            s5, s5, 0x1(1)",
@@ -8784,13 +8394,13 @@
         "disassembly": "sar dword ptr [rdi], cl"
     },
     "48d33f": {
-        "instruction_count": 18,
+        "instruction_count": 17,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "ANDI            t4, s10, 0xff(255)",
             "ANDI            t2, t4, 0x3f(63)",
             "SRA             ra, t1, t2",
-            "BEQ             t2, zero, 0x34(52)",
+            "BEQ             t2, zero, 0x30(48)",
             "ANDI            t5, ra, 0xff(255)",
             "CPOPW           t5, t5",
             "ANDI            t5, t5, 0x1(1)",
@@ -8798,7 +8408,6 @@
             "SB              t5, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDI            s5, t2, 0xffffffff(-1)",
             "SRL             s5, t1, s5",
             "ANDI            s5, s5, 0x1(1)",
@@ -11238,7 +10847,7 @@
         "disassembly": "rcr qword ptr [rdi], cl"
     },
     "fec2": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "ANDI            t1, a2, 0xff(255)",
             "ADDI            ra, t1, 0x1(1)",
@@ -11263,8 +10872,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ANDI            t3, ra, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
             "OR              a2, a2, t3"
@@ -11272,7 +10880,7 @@
         "disassembly": "inc dl"
     },
     "fec6": {
-        "instruction_count": 31,
+        "instruction_count": 30,
         "expected_asm": [
             "SRLI            t1, a2, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -11298,8 +10906,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ANDI            t3, ra, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
@@ -11309,7 +10916,7 @@
         "disassembly": "inc dh"
     },
     "66ffc2": {
-        "instruction_count": 29,
+        "instruction_count": 28,
         "expected_asm": [
             "ZEXT.H          t1, a2",
             "ADDI            ra, t1, 0x1(1)",
@@ -11334,8 +10941,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ZEXT.H          t3, ra",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
@@ -11344,7 +10950,7 @@
         "disassembly": "inc dx"
     },
     "ffc2": {
-        "instruction_count": 26,
+        "instruction_count": 25,
         "expected_asm": [
             "ADD.UW          t1, a2, zero",
             "ADDI            ra, t1, 0x1(1)",
@@ -11369,14 +10975,13 @@
             "SB              t3, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADD.UW          a2, ra, zero"
         ],
         "disassembly": "inc edx"
     },
     "48ffc2": {
-        "instruction_count": 18,
+        "instruction_count": 17,
         "expected_asm": [
             "ADDI            ra, a2, 0x1(1)",
             "ANDI            t1, ra, 0xf(15)",
@@ -11394,13 +10999,12 @@
             "SB              t1, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDI            a2, ra, 0x0(0)"
         ],
         "disassembly": "inc rdx"
     },
     "fe07": {
-        "instruction_count": 26,
+        "instruction_count": 25,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "ADDI            ra, t1, 0x1(1)",
@@ -11425,14 +11029,13 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "SB              ra, a0, 0x0(0)"
         ],
         "disassembly": "inc [rdi]"
     },
     "66ff07": {
-        "instruction_count": 26,
+        "instruction_count": 25,
         "expected_asm": [
             "LHU             t1, a0, 0x0(0)",
             "ADDI            ra, t1, 0x1(1)",
@@ -11457,14 +11060,13 @@
             "SB              t4, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "SH              ra, a0, 0x0(0)"
         ],
         "disassembly": "inc [rdi]"
     },
     "ff07": {
-        "instruction_count": 26,
+        "instruction_count": 25,
         "expected_asm": [
             "LWU             t1, a0, 0x0(0)",
             "ADDI            ra, t1, 0x1(1)",
@@ -11489,14 +11091,13 @@
             "SB              t4, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "SW              ra, a0, 0x0(0)"
         ],
         "disassembly": "inc [rdi]"
     },
     "48ff07": {
-        "instruction_count": 19,
+        "instruction_count": 18,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "ADDI            ra, t1, 0x1(1)",
@@ -11515,13 +11116,12 @@
             "SB              t4, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SD              ra, a0, 0x0(0)"
         ],
         "disassembly": "inc [rdi]"
     },
     "feca": {
-        "instruction_count": 29,
+        "instruction_count": 28,
         "expected_asm": [
             "ANDI            t1, a2, 0xff(255)",
             "ADDI            ra, t1, 0xffffffff(-1)",
@@ -11547,8 +11147,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ANDI            t3, ra, 0xff(255)",
             "ANDI            a2, a2, 0xffffff00(-256)",
             "OR              a2, a2, t3"
@@ -11556,7 +11155,7 @@
         "disassembly": "dec dl"
     },
     "fece": {
-        "instruction_count": 32,
+        "instruction_count": 31,
         "expected_asm": [
             "SRLI            t1, a2, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -11583,8 +11182,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ANDI            t3, ra, 0xff(255)",
             "RORI            a2, a2, 0x8(8)",
             "ANDI            a2, a2, 0xffffff00(-256)",
@@ -11594,7 +11192,7 @@
         "disassembly": "dec dh"
     },
     "66ffca": {
-        "instruction_count": 30,
+        "instruction_count": 29,
         "expected_asm": [
             "ZEXT.H          t1, a2",
             "ADDI            ra, t1, 0xffffffff(-1)",
@@ -11620,8 +11218,7 @@
             "SB              t3, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ZEXT.H          t3, ra",
             "SRLI            a2, a2, 0x10(16)",
             "SLLI            a2, a2, 0x10(16)",
@@ -11630,7 +11227,7 @@
         "disassembly": "dec dx"
     },
     "ffca": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "ADD.UW          t1, a2, zero",
             "ADDI            ra, t1, 0xffffffff(-1)",
@@ -11656,14 +11253,13 @@
             "SB              t3, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADD.UW          a2, ra, zero"
         ],
         "disassembly": "dec edx"
     },
     "48ffca": {
-        "instruction_count": 19,
+        "instruction_count": 18,
         "expected_asm": [
             "ADDI            ra, a2, 0xffffffff(-1)",
             "ADDIW           t1, zero, 0x1(1)",
@@ -11682,13 +11278,12 @@
             "SB              t1, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDI            a2, ra, 0x0(0)"
         ],
         "disassembly": "dec rdx"
     },
     "fe0f": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "ADDI            ra, t1, 0xffffffff(-1)",
@@ -11714,14 +11309,13 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "SB              ra, a0, 0x0(0)"
         ],
         "disassembly": "dec [rdi]"
     },
     "66ff0f": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "LHU             t1, a0, 0x0(0)",
             "ADDI            ra, t1, 0xffffffff(-1)",
@@ -11747,14 +11341,13 @@
             "SB              t4, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "SH              ra, a0, 0x0(0)"
         ],
         "disassembly": "dec [rdi]"
     },
     "ff0f": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "LWU             t1, a0, 0x0(0)",
             "ADDI            ra, t1, 0xffffffff(-1)",
@@ -11780,14 +11373,13 @@
             "SB              t4, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "SW              ra, a0, 0x0(0)"
         ],
         "disassembly": "dec [rdi]"
     },
     "48ff0f": {
-        "instruction_count": 20,
+        "instruction_count": 19,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "ADDI            ra, t1, 0xffffffff(-1)",
@@ -11807,7 +11399,6 @@
             "SB              t4, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SD              ra, a0, 0x0(0)"
         ],
         "disassembly": "dec [rdi]"
@@ -12122,7 +11713,7 @@
         "disassembly": "mul [rdi]"
     },
     "f6da": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "ANDI            t1, a2, 0xff(255)",
             "SUBW            ra, zero, t1",
@@ -12138,8 +11729,7 @@
             "SRLI            s9, s9, 0x7(7)",
             "XOR             s9, s9, t3",
             "ANDI            s9, s9, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ANDI            t3, t1, 0xf(15)",
             "SLTU            t3, zero, t3",
             "SB              t3, s11, 0x1ca(458)",
@@ -12155,7 +11745,7 @@
         "disassembly": "neg dl"
     },
     "f6de": {
-        "instruction_count": 30,
+        "instruction_count": 29,
         "expected_asm": [
             "SRLI            t1, a2, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -12172,8 +11762,7 @@
             "SRLI            s9, s9, 0x7(7)",
             "XOR             s9, s9, t3",
             "ANDI            s9, s9, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ANDI            t3, t1, 0xf(15)",
             "SLTU            t3, zero, t3",
             "SB              t3, s11, 0x1ca(458)",
@@ -12191,7 +11780,7 @@
         "disassembly": "neg dh"
     },
     "66f7da": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "ZEXT.H          t1, a2",
             "SUBW            ra, zero, t1",
@@ -12207,8 +11796,7 @@
             "SRLI            s9, s9, 0xf(15)",
             "XOR             s9, s9, t3",
             "ANDI            s9, s9, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ANDI            t3, t1, 0xf(15)",
             "SLTU            t3, zero, t3",
             "SB              t3, s11, 0x1ca(458)",
@@ -12225,7 +11813,7 @@
         "disassembly": "neg dx"
     },
     "f7da": {
-        "instruction_count": 25,
+        "instruction_count": 24,
         "expected_asm": [
             "ADD.UW          t1, a2, zero",
             "SUBW            ra, zero, t1",
@@ -12241,8 +11829,7 @@
             "SRLI            s9, s9, 0x1f(31)",
             "XOR             s9, s9, t3",
             "ANDI            s9, s9, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ANDI            t3, t1, 0xf(15)",
             "SLTU            t3, zero, t3",
             "SB              t3, s11, 0x1ca(458)",
@@ -12256,7 +11843,7 @@
         "disassembly": "neg edx"
     },
     "48f7da": {
-        "instruction_count": 17,
+        "instruction_count": 16,
         "expected_asm": [
             "SUB             ra, zero, a2",
             "SLTU            s5, zero, a2",
@@ -12265,7 +11852,6 @@
             "SLT             t1, ra, zero",
             "XOR             s9, s9, t1",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ANDI            t1, a2, 0xf(15)",
             "SLTU            t1, zero, t1",
             "SB              t1, s11, 0x1ca(458)",
@@ -12279,7 +11865,7 @@
         "disassembly": "neg rdx"
     },
     "f61f": {
-        "instruction_count": 25,
+        "instruction_count": 24,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "SUBW            ra, zero, t1",
@@ -12295,8 +11881,7 @@
             "SRLI            s9, s9, 0x7(7)",
             "XOR             s9, s9, t4",
             "ANDI            s9, s9, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ANDI            t4, t1, 0xf(15)",
             "SLTU            t4, zero, t4",
             "SB              t4, s11, 0x1ca(458)",
@@ -12310,7 +11895,7 @@
         "disassembly": "neg [rdi]"
     },
     "66f71f": {
-        "instruction_count": 25,
+        "instruction_count": 24,
         "expected_asm": [
             "LHU             t1, a0, 0x0(0)",
             "SUBW            ra, zero, t1",
@@ -12326,8 +11911,7 @@
             "SRLI            s9, s9, 0xf(15)",
             "XOR             s9, s9, t4",
             "ANDI            s9, s9, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ANDI            t4, t1, 0xf(15)",
             "SLTU            t4, zero, t4",
             "SB              t4, s11, 0x1ca(458)",
@@ -12341,7 +11925,7 @@
         "disassembly": "neg [rdi]"
     },
     "f71f": {
-        "instruction_count": 25,
+        "instruction_count": 24,
         "expected_asm": [
             "LWU             t1, a0, 0x0(0)",
             "SUBW            ra, zero, t1",
@@ -12357,8 +11941,7 @@
             "SRLI            s9, s9, 0x1f(31)",
             "XOR             s9, s9, t4",
             "ANDI            s9, s9, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ANDI            t4, t1, 0xf(15)",
             "SLTU            t4, zero, t4",
             "SB              t4, s11, 0x1ca(458)",
@@ -12372,7 +11955,7 @@
         "disassembly": "neg [rdi]"
     },
     "48f71f": {
-        "instruction_count": 18,
+        "instruction_count": 17,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "SUB             ra, zero, t1",
@@ -12382,7 +11965,6 @@
             "SLT             t4, ra, zero",
             "XOR             s9, s9, t4",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ANDI            t4, t1, 0xf(15)",
             "SLTU            t4, zero, t4",
             "SB              t4, s11, 0x1ca(458)",
@@ -12396,7 +11978,7 @@
         "disassembly": "neg [rdi]"
     },
     "0fb01f": {
-        "instruction_count": 47,
+        "instruction_count": 46,
         "expected_asm": [
             "ADDI            ra, a0, 0x0(0)",
             "ANDI            t1, s0, 0xff(255)",
@@ -12430,8 +12012,7 @@
             "SB              t5, s11, 0x1ca(458)",
             "ANDI            s7, t2, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t2, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t2, 0x7(7)",
             "XORI            t5, t3, 0xffffffff(-1)",
             "OR              s9, t5, t4",
             "AND             s9, s9, t2",
@@ -12449,7 +12030,7 @@
         "disassembly": "cmpxchg [rdi], bl"
     },
     "0fb03f": {
-        "instruction_count": 48,
+        "instruction_count": 47,
         "expected_asm": [
             "ADDI            ra, a0, 0x0(0)",
             "SRLI            t1, s0, 0x8(8)",
@@ -12484,8 +12065,7 @@
             "SB              t5, s11, 0x1ca(458)",
             "ANDI            s7, t2, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t2, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t2, 0x7(7)",
             "XORI            t5, t3, 0xffffffff(-1)",
             "OR              s9, t5, t4",
             "AND             s9, s9, t2",
@@ -12503,7 +12083,7 @@
         "disassembly": "cmpxchg [rdi], bh"
     },
     "660fb11f": {
-        "instruction_count": 53,
+        "instruction_count": 52,
         "expected_asm": [
             "ADDI            ra, a0, 0x0(0)",
             "ZEXT.H          t1, s0",
@@ -12542,8 +12122,7 @@
             "SB              t5, s11, 0x1ca(458)",
             "ZEXT.H          s7, t2",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t2, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t2, 0xf(15)",
             "XORI            t5, t3, 0xffffffff(-1)",
             "OR              s9, t5, t4",
             "AND             s9, s9, t2",
@@ -12562,7 +12141,7 @@
         "disassembly": "cmpxchg [rdi], bx"
     },
     "0fb11f": {
-        "instruction_count": 46,
+        "instruction_count": 45,
         "expected_asm": [
             "ADDI            ra, a0, 0x0(0)",
             "ADD.UW          t1, s0, zero",
@@ -12597,8 +12176,7 @@
             "SB              t5, s11, 0x1ca(458)",
             "ADD.UW          s7, t2, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t2, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, t2, 0x1f(31)",
             "XORI            t5, t3, 0xffffffff(-1)",
             "OR              s9, t5, t4",
             "AND             s9, s9, t2",
@@ -12614,7 +12192,7 @@
         "disassembly": "cmpxchg [rdi], ebx"
     },
     "480fb11f": {
-        "instruction_count": 34,
+        "instruction_count": 33,
         "expected_asm": [
             "ADDI            ra, a0, 0x0(0)",
             "ANDI            t3, ra, 0x7(7)",
@@ -12644,7 +12222,6 @@
             "SB              t4, s11, 0x1ca(458)",
             "SLTIU           s7, t3, 0x1(1)",
             "SRLI            s8, t3, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, t1",
             "SLT             t4, t3, t0",
             "XOR             s9, s9, t4",
@@ -14067,10 +13644,10 @@
             "OR              ra, ra, s5",
             "ORI             ra, ra, 0x2(2)",
             "ORI             ra, ra, 0x200(512)",
-            "LBU             t1, s11, 0x260(608)",
+            "LBU             t1, s11, 0x258(600)",
             "SLLI            t1, t1, 0x15(21)",
             "OR              ra, ra, t1",
-            "LBU             t1, s11, 0x261(609)",
+            "LBU             t1, s11, 0x259(601)",
             "SLLI            t1, t1, 0x12(18)",
             "OR              ra, ra, t1",
             "ADDI            s1, s1, 0xfffffff8(-8)",
@@ -14079,9 +13656,10 @@
         "disassembly": "pushfq"
     },
     "9d": {
-        "instruction_count": 24,
+        "instruction_count": 25,
         "expected_asm": [
             "LD              ra, s1, 0x0(0)",
+            "ORI             ra, ra, 0x202(514)",
             "ADDI            s1, s1, 0x8(8)",
             "ANDI            s5, ra, 0x1(1)",
             "SRLI            t1, ra, 0x2(2)",
@@ -14101,15 +13679,15 @@
             "ANDI            s9, s9, 0x1(1)",
             "SRLI            t1, ra, 0x15(21)",
             "ANDI            t1, t1, 0x1(1)",
-            "SB              t1, s11, 0x260(608)",
+            "SB              t1, s11, 0x258(600)",
             "SRLI            t1, ra, 0x12(18)",
             "ANDI            t1, t1, 0x1(1)",
-            "SB              t1, s11, 0x261(609)"
+            "SB              t1, s11, 0x259(601)"
         ],
         "disassembly": "popfq"
     },
     "a6": {
-        "instruction_count": 32,
+        "instruction_count": 31,
         "expected_asm": [
             "LBU             t2, s11, 0x1ce(462)",
             "ADDIW           ra, zero, 0xffffffff(-1)",
@@ -14130,8 +13708,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ANDI            s7, t4, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t4, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t4, 0x7(7)",
             "XORI            t2, t1, 0xffffffff(-1)",
             "OR              s9, t2, t3",
             "AND             s9, s9, t4",
@@ -14147,7 +13724,7 @@
         "disassembly": "cmpsb"
     },
     "66a7": {
-        "instruction_count": 32,
+        "instruction_count": 31,
         "expected_asm": [
             "LBU             t2, s11, 0x1ce(462)",
             "ADDIW           ra, zero, 0xfffffffe(-2)",
@@ -14168,8 +13745,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ZEXT.H          s7, t4",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t4, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t4, 0xf(15)",
             "XORI            t2, t1, 0xffffffff(-1)",
             "OR              s9, t2, t3",
             "AND             s9, s9, t4",
@@ -14185,7 +13761,7 @@
         "disassembly": "cmpsw"
     },
     "a7": {
-        "instruction_count": 32,
+        "instruction_count": 31,
         "expected_asm": [
             "LBU             t2, s11, 0x1ce(462)",
             "ADDIW           ra, zero, 0xfffffffc(-4)",
@@ -14206,8 +13782,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ADD.UW          s7, t4, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t4, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, t4, 0x1f(31)",
             "XORI            t2, t1, 0xffffffff(-1)",
             "OR              s9, t2, t3",
             "AND             s9, s9, t4",
@@ -14223,7 +13798,7 @@
         "disassembly": "cmpsd"
     },
     "48a7": {
-        "instruction_count": 25,
+        "instruction_count": 24,
         "expected_asm": [
             "LBU             t2, s11, 0x1ce(462)",
             "ADDIW           ra, zero, 0xfffffff8(-8)",
@@ -14244,7 +13819,6 @@
             "SB              t2, s11, 0x1ca(458)",
             "SLTIU           s7, t4, 0x1(1)",
             "SRLI            s8, t4, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, t3",
             "SLT             t2, t4, t1",
             "XOR             s9, s9, t2",
@@ -14361,7 +13935,7 @@
         "disassembly": "stosq"
     },
     "ae": {
-        "instruction_count": 31,
+        "instruction_count": 30,
         "expected_asm": [
             "ANDI            ra, t0, 0xff(255)",
             "LBU             t2, s11, 0x1ce(462)",
@@ -14382,8 +13956,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ANDI            s7, t4, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t4, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t4, 0x7(7)",
             "XORI            t2, ra, 0xffffffff(-1)",
             "OR              s9, t2, t3",
             "AND             s9, s9, t4",
@@ -14398,7 +13971,7 @@
         "disassembly": "scasb"
     },
     "66af": {
-        "instruction_count": 31,
+        "instruction_count": 30,
         "expected_asm": [
             "ZEXT.H          ra, t0",
             "LBU             t2, s11, 0x1ce(462)",
@@ -14419,8 +13992,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ZEXT.H          s7, t4",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t4, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t4, 0xf(15)",
             "XORI            t2, ra, 0xffffffff(-1)",
             "OR              s9, t2, t3",
             "AND             s9, s9, t4",
@@ -14435,7 +14007,7 @@
         "disassembly": "scasw"
     },
     "af": {
-        "instruction_count": 31,
+        "instruction_count": 30,
         "expected_asm": [
             "ADD.UW          ra, t0, zero",
             "LBU             t2, s11, 0x1ce(462)",
@@ -14456,8 +14028,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ADD.UW          s7, t4, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t4, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, t4, 0x1f(31)",
             "XORI            t2, ra, 0xffffffff(-1)",
             "OR              s9, t2, t3",
             "AND             s9, s9, t4",
@@ -14472,7 +14043,7 @@
         "disassembly": "scasd"
     },
     "48af": {
-        "instruction_count": 23,
+        "instruction_count": 22,
         "expected_asm": [
             "LBU             t4, s11, 0x1ce(462)",
             "ADDIW           ra, zero, 0xfffffff8(-8)",
@@ -14492,7 +14063,6 @@
             "SB              t4, s11, 0x1ca(458)",
             "SLTIU           s7, t3, 0x1(1)",
             "SRLI            s8, t3, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, t1",
             "SLT             t4, t3, t0",
             "XOR             s9, s9, t4",
@@ -14689,13 +14259,13 @@
         "disassembly": "rep stosq"
     },
     "f3a6": {
-        "instruction_count": 36,
+        "instruction_count": 35,
         "expected_asm": [
             "LBU             t2, s11, 0x1ce(462)",
             "ADDIW           ra, zero, 0xffffffff(-1)",
             "BNE             zero, t2, 0x8(8)",
             "ADDIW           ra, zero, 0x1(1)",
-            "BEQ             s10, zero, 0x80(128)",
+            "BEQ             s10, zero, 0x7c(124)",
             "LBU             t1, a1, 0x0(0)",
             "LBU             t3, a0, 0x0(0)",
             "SUB             t4, t1, t3",
@@ -14711,8 +14281,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ANDI            s7, t4, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t4, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t4, 0x7(7)",
             "XORI            t2, t1, 0xffffffff(-1)",
             "OR              s9, t2, t3",
             "AND             s9, s9, t4",
@@ -14726,18 +14295,18 @@
             "ADD             a1, a1, ra",
             "ADDI            s10, s10, 0xffffffff(-1)",
             "BEQ             s10, zero, 0x8(8)",
-            "BNE             zero, s7, 0xffffff88(-120)"
+            "BNE             zero, s7, 0xffffff8c(-116)"
         ],
         "disassembly": "repe cmpsb"
     },
     "f366a7": {
-        "instruction_count": 36,
+        "instruction_count": 35,
         "expected_asm": [
             "LBU             t2, s11, 0x1ce(462)",
             "ADDIW           ra, zero, 0xfffffffe(-2)",
             "BNE             zero, t2, 0x8(8)",
             "ADDIW           ra, zero, 0x2(2)",
-            "BEQ             s10, zero, 0x80(128)",
+            "BEQ             s10, zero, 0x7c(124)",
             "LHU             t1, a1, 0x0(0)",
             "LHU             t3, a0, 0x0(0)",
             "SUB             t4, t1, t3",
@@ -14753,8 +14322,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ZEXT.H          s7, t4",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t4, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t4, 0xf(15)",
             "XORI            t2, t1, 0xffffffff(-1)",
             "OR              s9, t2, t3",
             "AND             s9, s9, t4",
@@ -14768,18 +14336,18 @@
             "ADD             a1, a1, ra",
             "ADDI            s10, s10, 0xffffffff(-1)",
             "BEQ             s10, zero, 0x8(8)",
-            "BNE             zero, s7, 0xffffff88(-120)"
+            "BNE             zero, s7, 0xffffff8c(-116)"
         ],
         "disassembly": "repe cmpsw"
     },
     "f3a7": {
-        "instruction_count": 36,
+        "instruction_count": 35,
         "expected_asm": [
             "LBU             t2, s11, 0x1ce(462)",
             "ADDIW           ra, zero, 0xfffffffc(-4)",
             "BNE             zero, t2, 0x8(8)",
             "ADDIW           ra, zero, 0x4(4)",
-            "BEQ             s10, zero, 0x80(128)",
+            "BEQ             s10, zero, 0x7c(124)",
             "LWU             t1, a1, 0x0(0)",
             "LWU             t3, a0, 0x0(0)",
             "SUB             t4, t1, t3",
@@ -14795,8 +14363,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ADD.UW          s7, t4, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t4, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, t4, 0x1f(31)",
             "XORI            t2, t1, 0xffffffff(-1)",
             "OR              s9, t2, t3",
             "AND             s9, s9, t4",
@@ -14810,18 +14377,18 @@
             "ADD             a1, a1, ra",
             "ADDI            s10, s10, 0xffffffff(-1)",
             "BEQ             s10, zero, 0x8(8)",
-            "BNE             zero, s7, 0xffffff88(-120)"
+            "BNE             zero, s7, 0xffffff8c(-116)"
         ],
         "disassembly": "repe cmpsd"
     },
     "f348a7": {
-        "instruction_count": 29,
+        "instruction_count": 28,
         "expected_asm": [
             "LBU             t2, s11, 0x1ce(462)",
             "ADDIW           ra, zero, 0xfffffff8(-8)",
             "BNE             zero, t2, 0x8(8)",
             "ADDIW           ra, zero, 0x8(8)",
-            "BEQ             s10, zero, 0x64(100)",
+            "BEQ             s10, zero, 0x60(96)",
             "LD              t1, a1, 0x0(0)",
             "LD              t3, a0, 0x0(0)",
             "SUB             t4, t1, t3",
@@ -14837,7 +14404,6 @@
             "SB              t2, s11, 0x1ca(458)",
             "SLTIU           s7, t4, 0x1(1)",
             "SRLI            s8, t4, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, t3",
             "SLT             t2, t4, t1",
             "XOR             s9, s9, t2",
@@ -14845,19 +14411,19 @@
             "ADD             a1, a1, ra",
             "ADDI            s10, s10, 0xffffffff(-1)",
             "BEQ             s10, zero, 0x8(8)",
-            "BNE             zero, s7, 0xffffffa4(-92)"
+            "BNE             zero, s7, 0xffffffa8(-88)"
         ],
         "disassembly": "repe cmpsq"
     },
     "f3ae": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "ANDI            ra, t0, 0xff(255)",
             "LBU             t2, s11, 0x1ce(462)",
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "BNE             zero, t2, 0x8(8)",
             "ADDIW           t1, zero, 0x1(1)",
-            "BEQ             s10, zero, 0x78(120)",
+            "BEQ             s10, zero, 0x74(116)",
             "LBU             t3, a0, 0x0(0)",
             "SUB             t4, ra, t3",
             "SLTU            s5, ra, t3",
@@ -14872,8 +14438,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ANDI            s7, t4, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t4, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t4, 0x7(7)",
             "XORI            t2, ra, 0xffffffff(-1)",
             "OR              s9, t2, t3",
             "AND             s9, s9, t4",
@@ -14886,19 +14451,19 @@
             "ADD             a0, a0, t1",
             "ADDI            s10, s10, 0xffffffff(-1)",
             "BEQ             s10, zero, 0x8(8)",
-            "BNE             zero, s7, 0xffffff90(-112)"
+            "BNE             zero, s7, 0xffffff94(-108)"
         ],
         "disassembly": "repe scasb"
     },
     "f366af": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "ZEXT.H          ra, t0",
             "LBU             t2, s11, 0x1ce(462)",
             "ADDIW           t1, zero, 0xfffffffe(-2)",
             "BNE             zero, t2, 0x8(8)",
             "ADDIW           t1, zero, 0x2(2)",
-            "BEQ             s10, zero, 0x78(120)",
+            "BEQ             s10, zero, 0x74(116)",
             "LHU             t3, a0, 0x0(0)",
             "SUB             t4, ra, t3",
             "SLTU            s5, ra, t3",
@@ -14913,8 +14478,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ZEXT.H          s7, t4",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t4, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t4, 0xf(15)",
             "XORI            t2, ra, 0xffffffff(-1)",
             "OR              s9, t2, t3",
             "AND             s9, s9, t4",
@@ -14927,19 +14491,19 @@
             "ADD             a0, a0, t1",
             "ADDI            s10, s10, 0xffffffff(-1)",
             "BEQ             s10, zero, 0x8(8)",
-            "BNE             zero, s7, 0xffffff90(-112)"
+            "BNE             zero, s7, 0xffffff94(-108)"
         ],
         "disassembly": "repe scasw"
     },
     "f3af": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "ADD.UW          ra, t0, zero",
             "LBU             t2, s11, 0x1ce(462)",
             "ADDIW           t1, zero, 0xfffffffc(-4)",
             "BNE             zero, t2, 0x8(8)",
             "ADDIW           t1, zero, 0x4(4)",
-            "BEQ             s10, zero, 0x78(120)",
+            "BEQ             s10, zero, 0x74(116)",
             "LWU             t3, a0, 0x0(0)",
             "SUB             t4, ra, t3",
             "SLTU            s5, ra, t3",
@@ -14954,8 +14518,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ADD.UW          s7, t4, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t4, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, t4, 0x1f(31)",
             "XORI            t2, ra, 0xffffffff(-1)",
             "OR              s9, t2, t3",
             "AND             s9, s9, t4",
@@ -14968,18 +14531,18 @@
             "ADD             a0, a0, t1",
             "ADDI            s10, s10, 0xffffffff(-1)",
             "BEQ             s10, zero, 0x8(8)",
-            "BNE             zero, s7, 0xffffff90(-112)"
+            "BNE             zero, s7, 0xffffff94(-108)"
         ],
         "disassembly": "repe scasd"
     },
     "f348af": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "LBU             t4, s11, 0x1ce(462)",
             "ADDIW           ra, zero, 0xfffffff8(-8)",
             "BNE             zero, t4, 0x8(8)",
             "ADDIW           ra, zero, 0x8(8)",
-            "BEQ             s10, zero, 0x5c(92)",
+            "BEQ             s10, zero, 0x58(88)",
             "LD              t1, a0, 0x0(0)",
             "SUB             t3, t0, t1",
             "SLTU            s5, t0, t1",
@@ -14994,25 +14557,24 @@
             "SB              t4, s11, 0x1ca(458)",
             "SLTIU           s7, t3, 0x1(1)",
             "SRLI            s8, t3, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, t1",
             "SLT             t4, t3, t0",
             "XOR             s9, s9, t4",
             "ADD             a0, a0, ra",
             "ADDI            s10, s10, 0xffffffff(-1)",
             "BEQ             s10, zero, 0x8(8)",
-            "BNE             zero, s7, 0xffffffac(-84)"
+            "BNE             zero, s7, 0xffffffb0(-80)"
         ],
         "disassembly": "repe scasq"
     },
     "f2a6": {
-        "instruction_count": 36,
+        "instruction_count": 35,
         "expected_asm": [
             "LBU             t2, s11, 0x1ce(462)",
             "ADDIW           ra, zero, 0xffffffff(-1)",
             "BNE             zero, t2, 0x8(8)",
             "ADDIW           ra, zero, 0x1(1)",
-            "BEQ             s10, zero, 0x80(128)",
+            "BEQ             s10, zero, 0x7c(124)",
             "LBU             t1, a1, 0x0(0)",
             "LBU             t3, a0, 0x0(0)",
             "SUB             t4, t1, t3",
@@ -15028,8 +14590,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ANDI            s7, t4, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t4, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t4, 0x7(7)",
             "XORI            t2, t1, 0xffffffff(-1)",
             "OR              s9, t2, t3",
             "AND             s9, s9, t4",
@@ -15043,18 +14604,18 @@
             "ADD             a1, a1, ra",
             "ADDI            s10, s10, 0xffffffff(-1)",
             "BEQ             s10, zero, 0x8(8)",
-            "BEQ             s7, zero, 0xffffff88(-120)"
+            "BEQ             s7, zero, 0xffffff8c(-116)"
         ],
         "disassembly": "repne cmpsb"
     },
     "f266a7": {
-        "instruction_count": 36,
+        "instruction_count": 35,
         "expected_asm": [
             "LBU             t2, s11, 0x1ce(462)",
             "ADDIW           ra, zero, 0xfffffffe(-2)",
             "BNE             zero, t2, 0x8(8)",
             "ADDIW           ra, zero, 0x2(2)",
-            "BEQ             s10, zero, 0x80(128)",
+            "BEQ             s10, zero, 0x7c(124)",
             "LHU             t1, a1, 0x0(0)",
             "LHU             t3, a0, 0x0(0)",
             "SUB             t4, t1, t3",
@@ -15070,8 +14631,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ZEXT.H          s7, t4",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t4, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t4, 0xf(15)",
             "XORI            t2, t1, 0xffffffff(-1)",
             "OR              s9, t2, t3",
             "AND             s9, s9, t4",
@@ -15085,18 +14645,18 @@
             "ADD             a1, a1, ra",
             "ADDI            s10, s10, 0xffffffff(-1)",
             "BEQ             s10, zero, 0x8(8)",
-            "BEQ             s7, zero, 0xffffff88(-120)"
+            "BEQ             s7, zero, 0xffffff8c(-116)"
         ],
         "disassembly": "repne cmpsw"
     },
     "f2a7": {
-        "instruction_count": 36,
+        "instruction_count": 35,
         "expected_asm": [
             "LBU             t2, s11, 0x1ce(462)",
             "ADDIW           ra, zero, 0xfffffffc(-4)",
             "BNE             zero, t2, 0x8(8)",
             "ADDIW           ra, zero, 0x4(4)",
-            "BEQ             s10, zero, 0x80(128)",
+            "BEQ             s10, zero, 0x7c(124)",
             "LWU             t1, a1, 0x0(0)",
             "LWU             t3, a0, 0x0(0)",
             "SUB             t4, t1, t3",
@@ -15112,8 +14672,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ADD.UW          s7, t4, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t4, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, t4, 0x1f(31)",
             "XORI            t2, t1, 0xffffffff(-1)",
             "OR              s9, t2, t3",
             "AND             s9, s9, t4",
@@ -15127,18 +14686,18 @@
             "ADD             a1, a1, ra",
             "ADDI            s10, s10, 0xffffffff(-1)",
             "BEQ             s10, zero, 0x8(8)",
-            "BEQ             s7, zero, 0xffffff88(-120)"
+            "BEQ             s7, zero, 0xffffff8c(-116)"
         ],
         "disassembly": "repne cmpsd"
     },
     "f248a7": {
-        "instruction_count": 29,
+        "instruction_count": 28,
         "expected_asm": [
             "LBU             t2, s11, 0x1ce(462)",
             "ADDIW           ra, zero, 0xfffffff8(-8)",
             "BNE             zero, t2, 0x8(8)",
             "ADDIW           ra, zero, 0x8(8)",
-            "BEQ             s10, zero, 0x64(100)",
+            "BEQ             s10, zero, 0x60(96)",
             "LD              t1, a1, 0x0(0)",
             "LD              t3, a0, 0x0(0)",
             "SUB             t4, t1, t3",
@@ -15154,7 +14713,6 @@
             "SB              t2, s11, 0x1ca(458)",
             "SLTIU           s7, t4, 0x1(1)",
             "SRLI            s8, t4, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, t3",
             "SLT             t2, t4, t1",
             "XOR             s9, s9, t2",
@@ -15162,19 +14720,19 @@
             "ADD             a1, a1, ra",
             "ADDI            s10, s10, 0xffffffff(-1)",
             "BEQ             s10, zero, 0x8(8)",
-            "BEQ             s7, zero, 0xffffffa4(-92)"
+            "BEQ             s7, zero, 0xffffffa8(-88)"
         ],
         "disassembly": "repne cmpsq"
     },
     "f2ae": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "ANDI            ra, t0, 0xff(255)",
             "LBU             t2, s11, 0x1ce(462)",
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "BNE             zero, t2, 0x8(8)",
             "ADDIW           t1, zero, 0x1(1)",
-            "BEQ             s10, zero, 0x78(120)",
+            "BEQ             s10, zero, 0x74(116)",
             "LBU             t3, a0, 0x0(0)",
             "SUB             t4, ra, t3",
             "SLTU            s5, ra, t3",
@@ -15189,8 +14747,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ANDI            s7, t4, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t4, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t4, 0x7(7)",
             "XORI            t2, ra, 0xffffffff(-1)",
             "OR              s9, t2, t3",
             "AND             s9, s9, t4",
@@ -15203,19 +14760,19 @@
             "ADD             a0, a0, t1",
             "ADDI            s10, s10, 0xffffffff(-1)",
             "BEQ             s10, zero, 0x8(8)",
-            "BEQ             s7, zero, 0xffffff90(-112)"
+            "BEQ             s7, zero, 0xffffff94(-108)"
         ],
         "disassembly": "repne scasb"
     },
     "f266af": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "ZEXT.H          ra, t0",
             "LBU             t2, s11, 0x1ce(462)",
             "ADDIW           t1, zero, 0xfffffffe(-2)",
             "BNE             zero, t2, 0x8(8)",
             "ADDIW           t1, zero, 0x2(2)",
-            "BEQ             s10, zero, 0x78(120)",
+            "BEQ             s10, zero, 0x74(116)",
             "LHU             t3, a0, 0x0(0)",
             "SUB             t4, ra, t3",
             "SLTU            s5, ra, t3",
@@ -15230,8 +14787,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ZEXT.H          s7, t4",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t4, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, t4, 0xf(15)",
             "XORI            t2, ra, 0xffffffff(-1)",
             "OR              s9, t2, t3",
             "AND             s9, s9, t4",
@@ -15244,19 +14800,19 @@
             "ADD             a0, a0, t1",
             "ADDI            s10, s10, 0xffffffff(-1)",
             "BEQ             s10, zero, 0x8(8)",
-            "BEQ             s7, zero, 0xffffff90(-112)"
+            "BEQ             s7, zero, 0xffffff94(-108)"
         ],
         "disassembly": "repne scasw"
     },
     "f2af": {
-        "instruction_count": 35,
+        "instruction_count": 34,
         "expected_asm": [
             "ADD.UW          ra, t0, zero",
             "LBU             t2, s11, 0x1ce(462)",
             "ADDIW           t1, zero, 0xfffffffc(-4)",
             "BNE             zero, t2, 0x8(8)",
             "ADDIW           t1, zero, 0x4(4)",
-            "BEQ             s10, zero, 0x78(120)",
+            "BEQ             s10, zero, 0x74(116)",
             "LWU             t3, a0, 0x0(0)",
             "SUB             t4, ra, t3",
             "SLTU            s5, ra, t3",
@@ -15271,8 +14827,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ADD.UW          s7, t4, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, t4, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, t4, 0x1f(31)",
             "XORI            t2, ra, 0xffffffff(-1)",
             "OR              s9, t2, t3",
             "AND             s9, s9, t4",
@@ -15285,18 +14840,18 @@
             "ADD             a0, a0, t1",
             "ADDI            s10, s10, 0xffffffff(-1)",
             "BEQ             s10, zero, 0x8(8)",
-            "BEQ             s7, zero, 0xffffff90(-112)"
+            "BEQ             s7, zero, 0xffffff94(-108)"
         ],
         "disassembly": "repne scasd"
     },
     "f248af": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "LBU             t4, s11, 0x1ce(462)",
             "ADDIW           ra, zero, 0xfffffff8(-8)",
             "BNE             zero, t4, 0x8(8)",
             "ADDIW           ra, zero, 0x8(8)",
-            "BEQ             s10, zero, 0x5c(92)",
+            "BEQ             s10, zero, 0x58(88)",
             "LD              t1, a0, 0x0(0)",
             "SUB             t3, t0, t1",
             "SLTU            s5, t0, t1",
@@ -15311,19 +14866,18 @@
             "SB              t4, s11, 0x1ca(458)",
             "SLTIU           s7, t3, 0x1(1)",
             "SRLI            s8, t3, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, t1",
             "SLT             t4, t3, t0",
             "XOR             s9, s9, t4",
             "ADD             a0, a0, ra",
             "ADDI            s10, s10, 0xffffffff(-1)",
             "BEQ             s10, zero, 0x8(8)",
-            "BEQ             s7, zero, 0xffffffac(-84)"
+            "BEQ             s7, zero, 0xffffffb0(-80)"
         ],
         "disassembly": "repne scasq"
     },
     "38da": {
-        "instruction_count": 26,
+        "instruction_count": 25,
         "expected_asm": [
             "ANDI            t1, s0, 0xff(255)",
             "ANDI            t3, a2, 0xff(255)",
@@ -15340,8 +14894,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -15355,7 +14908,7 @@
         "disassembly": "cmp dl, bl"
     },
     "38fa": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "SRLI            t1, s0, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -15373,8 +14926,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -15388,7 +14940,7 @@
         "disassembly": "cmp dl, bh"
     },
     "38de": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "ANDI            t1, s0, 0xff(255)",
             "SRLI            t3, a2, 0x8(8)",
@@ -15406,8 +14958,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -15421,7 +14972,7 @@
         "disassembly": "cmp dh, bl"
     },
     "38fe": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "SRLI            t1, s0, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -15440,8 +14991,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -15455,7 +15005,7 @@
         "disassembly": "cmp dh, bh"
     },
     "6639da": {
-        "instruction_count": 26,
+        "instruction_count": 25,
         "expected_asm": [
             "ZEXT.H          t1, s0",
             "ZEXT.H          t3, a2",
@@ -15472,8 +15022,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -15487,7 +15036,7 @@
         "disassembly": "cmp dx, bx"
     },
     "39da": {
-        "instruction_count": 26,
+        "instruction_count": 25,
         "expected_asm": [
             "ADD.UW          t1, s0, zero",
             "ADD.UW          t3, a2, zero",
@@ -15504,8 +15053,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -15519,7 +15067,7 @@
         "disassembly": "cmp edx, ebx"
     },
     "4839da": {
-        "instruction_count": 17,
+        "instruction_count": 16,
         "expected_asm": [
             "SUB             ra, a2, s0",
             "SLTU            s5, a2, s0",
@@ -15534,7 +15082,6 @@
             "SB              t1, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, s0",
             "SLT             t1, ra, a2",
             "XOR             s9, s9, t1"
@@ -15542,7 +15089,7 @@
         "disassembly": "cmp rdx, rbx"
     },
     "3a17": {
-        "instruction_count": 26,
+        "instruction_count": 25,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "ANDI            t4, a2, 0xff(255)",
@@ -15559,8 +15106,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t2, t4, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -15574,7 +15120,7 @@
         "disassembly": "cmp dl, [rdi]"
     },
     "3a37": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "LBU             t1, a0, 0x0(0)",
             "SRLI            t4, a2, 0x8(8)",
@@ -15592,8 +15138,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t2, t4, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -15607,7 +15152,7 @@
         "disassembly": "cmp dh, [rdi]"
     },
     "663b17": {
-        "instruction_count": 26,
+        "instruction_count": 25,
         "expected_asm": [
             "LHU             t1, a0, 0x0(0)",
             "ZEXT.H          t4, a2",
@@ -15624,8 +15169,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "XORI            t2, t4, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -15639,7 +15183,7 @@
         "disassembly": "cmp dx, [rdi]"
     },
     "3b17": {
-        "instruction_count": 26,
+        "instruction_count": 25,
         "expected_asm": [
             "LWU             t1, a0, 0x0(0)",
             "ADD.UW          t4, a2, zero",
@@ -15656,8 +15200,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "XORI            t2, t4, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -15671,7 +15214,7 @@
         "disassembly": "cmp edx, [rdi]"
     },
     "483b17": {
-        "instruction_count": 18,
+        "instruction_count": 17,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "SUB             ra, a2, t1",
@@ -15687,7 +15230,6 @@
             "SB              t4, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, t1",
             "SLT             t4, ra, a2",
             "XOR             s9, s9, t4"
@@ -15695,7 +15237,7 @@
         "disassembly": "cmp rdx, [rdi]"
     },
     "3817": {
-        "instruction_count": 26,
+        "instruction_count": 25,
         "expected_asm": [
             "ANDI            t1, a2, 0xff(255)",
             "LBU             t3, a0, 0x0(0)",
@@ -15712,8 +15254,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t2, t3, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -15727,7 +15268,7 @@
         "disassembly": "cmp [rdi], dl"
     },
     "3837": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "SRLI            t1, a2, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -15745,8 +15286,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t2, t3, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -15760,7 +15300,7 @@
         "disassembly": "cmp [rdi], dh"
     },
     "663917": {
-        "instruction_count": 26,
+        "instruction_count": 25,
         "expected_asm": [
             "ZEXT.H          t1, a2",
             "LHU             t3, a0, 0x0(0)",
@@ -15777,8 +15317,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "XORI            t2, t3, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -15792,7 +15331,7 @@
         "disassembly": "cmp [rdi], dx"
     },
     "3917": {
-        "instruction_count": 26,
+        "instruction_count": 25,
         "expected_asm": [
             "ADD.UW          t1, a2, zero",
             "LWU             t3, a0, 0x0(0)",
@@ -15809,8 +15348,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "XORI            t2, t3, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -15824,7 +15362,7 @@
         "disassembly": "cmp [rdi], edx"
     },
     "483917": {
-        "instruction_count": 18,
+        "instruction_count": 17,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "SUB             ra, t1, a2",
@@ -15840,7 +15378,6 @@
             "SB              t4, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, a2",
             "SLT             t4, ra, t1",
             "XOR             s9, s9, t4"
@@ -15848,7 +15385,7 @@
         "disassembly": "cmp [rdi], rdx"
     },
     "80fa01": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "ANDI            t3, a2, 0xff(255)",
@@ -15866,8 +15403,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -15881,7 +15417,7 @@
         "disassembly": "cmp dl, 0x01"
     },
     "80faff": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "ANDI            t3, a2, 0xff(255)",
@@ -15899,8 +15435,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -15914,7 +15449,7 @@
         "disassembly": "cmp dl, 0xFF"
     },
     "80fe01": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "SRLI            t3, a2, 0x8(8)",
@@ -15933,8 +15468,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -15948,7 +15482,7 @@
         "disassembly": "cmp dh, 0x01"
     },
     "80feff": {
-        "instruction_count": 28,
+        "instruction_count": 27,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "SRLI            t3, a2, 0x8(8)",
@@ -15967,8 +15501,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -15982,7 +15515,7 @@
         "disassembly": "cmp dh, 0xFF"
     },
     "6683fa01": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "ZEXT.H          t3, a2",
@@ -16000,8 +15533,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -16015,7 +15547,7 @@
         "disassembly": "cmp dx, 0x01"
     },
     "6683faff": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "ZEXT.H          t3, a2",
@@ -16033,8 +15565,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -16048,7 +15579,7 @@
         "disassembly": "cmp dx, 0xFFFF"
     },
     "83fa01": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "ADD.UW          t3, a2, zero",
@@ -16066,8 +15597,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -16081,7 +15611,7 @@
         "disassembly": "cmp edx, 0x01"
     },
     "83faff": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "ADD.UW          t3, a2, zero",
@@ -16099,8 +15629,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -16114,7 +15643,7 @@
         "disassembly": "cmp edx, 0xFFFFFFFF"
     },
     "4883fa01": {
-        "instruction_count": 18,
+        "instruction_count": 17,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "SUB             ra, a2, t1",
@@ -16130,7 +15659,6 @@
             "SB              t3, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, t1",
             "SLT             t3, ra, a2",
             "XOR             s9, s9, t3"
@@ -16138,7 +15666,7 @@
         "disassembly": "cmp rdx, 0x01"
     },
     "4883faff": {
-        "instruction_count": 18,
+        "instruction_count": 17,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "SUB             ra, a2, t1",
@@ -16154,7 +15682,6 @@
             "SB              t3, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, t1",
             "SLT             t3, ra, a2",
             "XOR             s9, s9, t3"
@@ -16162,7 +15689,7 @@
         "disassembly": "cmp rdx, 0xFFFFFFFFFFFFFFFF"
     },
     "803f01": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LBU             t3, a0, 0x0(0)",
@@ -16180,8 +15707,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "XORI            t2, t3, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -16195,7 +15721,7 @@
         "disassembly": "cmp byte ptr [rdi], 0x01"
     },
     "66833f01": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LHU             t3, a0, 0x0(0)",
@@ -16213,8 +15739,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "XORI            t2, t3, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -16228,7 +15753,7 @@
         "disassembly": "cmp word ptr [rdi], 0x01"
     },
     "833f01": {
-        "instruction_count": 27,
+        "instruction_count": 26,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LWU             t3, a0, 0x0(0)",
@@ -16246,8 +15771,7 @@
             "SB              t2, s11, 0x1ca(458)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "XORI            t2, t3, 0xffffffff(-1)",
             "OR              s9, t2, t1",
             "AND             s9, s9, ra",
@@ -16261,7 +15785,7 @@
         "disassembly": "cmp dword ptr [rdi], 0x01"
     },
     "48833f01": {
-        "instruction_count": 19,
+        "instruction_count": 18,
         "expected_asm": [
             "ADDIW           t1, zero, 0x1(1)",
             "LD              t3, a0, 0x0(0)",
@@ -16278,7 +15802,6 @@
             "SB              t2, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, t1",
             "SLT             t2, ra, t3",
             "XOR             s9, s9, t2"
@@ -16286,7 +15809,7 @@
         "disassembly": "cmp qword ptr [rdi], 0x01"
     },
     "84d8": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "ANDI            t1, s0, 0xff(255)",
             "ANDI            t3, t0, 0xff(255)",
@@ -16299,14 +15822,13 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)"
         ],
         "disassembly": "test al, bl"
     },
     "84f8": {
-        "instruction_count": 15,
+        "instruction_count": 14,
         "expected_asm": [
             "SRLI            t1, s0, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -16320,14 +15842,13 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)"
         ],
         "disassembly": "test al, bh"
     },
     "84dc": {
-        "instruction_count": 15,
+        "instruction_count": 14,
         "expected_asm": [
             "ANDI            t1, s0, 0xff(255)",
             "SRLI            t3, t0, 0x8(8)",
@@ -16341,14 +15862,13 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)"
         ],
         "disassembly": "test ah, bl"
     },
     "84fc": {
-        "instruction_count": 16,
+        "instruction_count": 15,
         "expected_asm": [
             "SRLI            t1, s0, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -16363,14 +15883,13 @@
             "SB              t4, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)"
         ],
         "disassembly": "test ah, bh"
     },
     "6685d8": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "ZEXT.H          t1, s0",
             "ZEXT.H          t3, t0",
@@ -16383,14 +15902,13 @@
             "SB              t4, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)"
         ],
         "disassembly": "test ax, bx"
     },
     "85d8": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "ADD.UW          t1, s0, zero",
             "ADD.UW          t3, t0, zero",
@@ -16403,14 +15921,13 @@
             "SB              t4, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)"
         ],
         "disassembly": "test eax, ebx"
     },
     "4885d8": {
-        "instruction_count": 11,
+        "instruction_count": 10,
         "expected_asm": [
             "AND             ra, t0, s0",
             "ADDIW           s5, zero, 0x0(0)",
@@ -16421,13 +15938,12 @@
             "SB              t1, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)"
         ],
         "disassembly": "test rax, rbx"
     },
     "841f": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "ANDI            t1, s0, 0xff(255)",
             "LBU             t3, a0, 0x0(0)",
@@ -16440,14 +15956,13 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)"
         ],
         "disassembly": "test [rdi], bl"
     },
     "843f": {
-        "instruction_count": 15,
+        "instruction_count": 14,
         "expected_asm": [
             "SRLI            t1, s0, 0x8(8)",
             "ANDI            t1, t1, 0xff(255)",
@@ -16461,14 +15976,13 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)"
         ],
         "disassembly": "test [rdi], bh"
     },
     "66851f": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "ZEXT.H          t1, s0",
             "LHU             t3, a0, 0x0(0)",
@@ -16481,14 +15995,13 @@
             "SB              t2, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)"
         ],
         "disassembly": "test [rdi], bx"
     },
     "851f": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "ADD.UW          t1, s0, zero",
             "LWU             t3, a0, 0x0(0)",
@@ -16501,14 +16014,13 @@
             "SB              t2, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)"
         ],
         "disassembly": "test [rdi], ebx"
     },
     "48851f": {
-        "instruction_count": 12,
+        "instruction_count": 11,
         "expected_asm": [
             "LD              t1, a0, 0x0(0)",
             "AND             ra, t1, s0",
@@ -16520,13 +16032,12 @@
             "SB              t4, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)"
         ],
         "disassembly": "test [rdi], rbx"
     },
     "f607ff": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "LBU             t3, a0, 0x0(0)",
@@ -16539,14 +16050,13 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)"
         ],
         "disassembly": "test byte ptr [rdi], 0xFF"
     },
     "66f707ffff": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "LHU             t3, a0, 0x0(0)",
@@ -16559,14 +16069,13 @@
             "SB              t2, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)"
         ],
         "disassembly": "test word ptr [rdi], 0xFFFF"
     },
     "f707ffffffff": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "LWU             t3, a0, 0x0(0)",
@@ -16579,14 +16088,13 @@
             "SB              t2, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)"
         ],
         "disassembly": "test dword ptr [rdi], 0xFFFFFFFF"
     },
     "48f707ffffffff": {
-        "instruction_count": 13,
+        "instruction_count": 12,
         "expected_asm": [
             "ADDIW           t1, zero, 0xffffffff(-1)",
             "LD              t3, a0, 0x0(0)",
@@ -16599,13 +16107,12 @@
             "SB              t2, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)"
         ],
         "disassembly": "test qword ptr [rdi], 0xFFFFFFFFFFFFFFFF"
     },
     "f60700": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "ADDIW           t1, zero, 0x0(0)",
             "LBU             t3, a0, 0x0(0)",
@@ -16618,14 +16125,13 @@
             "SB              t2, s11, 0x1c9(457)",
             "ANDI            s7, ra, 0xff(255)",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x7(7)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0x7(7)",
             "ADDIW           s9, zero, 0x0(0)"
         ],
         "disassembly": "test byte ptr [rdi], 0x00"
     },
     "66f7070000": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "ADDIW           t1, zero, 0x0(0)",
             "LHU             t3, a0, 0x0(0)",
@@ -16638,14 +16144,13 @@
             "SB              t2, s11, 0x1c9(457)",
             "ZEXT.H          s7, ra",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0xf(15)",
-            "ANDI            s8, s8, 0x1(1)",
+            "BEXTI           s8, ra, 0xf(15)",
             "ADDIW           s9, zero, 0x0(0)"
         ],
         "disassembly": "test word ptr [rdi], 0x00"
     },
     "f70700000000": {
-        "instruction_count": 14,
+        "instruction_count": 13,
         "expected_asm": [
             "ADDIW           t1, zero, 0x0(0)",
             "LWU             t3, a0, 0x0(0)",
@@ -16658,14 +16163,13 @@
             "SB              t2, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)"
         ],
         "disassembly": "test dword ptr [rdi], 0x00"
     },
     "48f70700000000": {
-        "instruction_count": 13,
+        "instruction_count": 12,
         "expected_asm": [
             "ADDIW           t1, zero, 0x0(0)",
             "LD              t3, a0, 0x0(0)",
@@ -16678,7 +16182,6 @@
             "SB              t2, s11, 0x1c9(457)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "ADDIW           s9, zero, 0x0(0)"
         ],
         "disassembly": "test qword ptr [rdi], 0x00"

--- a/counts/HotBlocks.json
+++ b/counts/HotBlocks.json
@@ -1,6 +1,6 @@
 {
     "llvmpipe_shader": {
-        "instruction_count": 201,
+        "instruction_count": 199,
         "expected_asm": [
             "LD              s3, a1, 0x0(0)",
             "LWU             s3, s3, 0x4(4)",
@@ -188,25 +188,23 @@
             "SB              t4, s11, 0x1c9(457)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "ADDIW           s9, zero, 0x0(0)",
-            "LBU             t4, s11, 0x1ca(458)",
-            "ADDIW           t4, zero, 0x0(0)",
+            "SB              zero, s11, 0x1ca(458)",
             "ADD.UW          s3, ra, zero",
             "BNE             zero, s7, 0x10(16)",
             "ADDI            gp, gp, 0x13a(314)",
-            "AUIPC           t6, 0xffffffea(-22)",
-            "JALR            zero, t6, 0x384(900)",
+            "AUIPC           t6, 0xffffffeb(-21)",
+            "JALR            zero, t6, 0xfffff92c(-1748)",
             "LUI             ra, 0xd(13)",
             "ADDIW           ra, ra, 0xfffffc32(-974)",
             "ADD             gp, gp, ra",
-            "AUIPC           t6, 0xffffffea(-22)",
-            "JALR            zero, t6, 0x370(880)"
+            "AUIPC           t6, 0xffffffeb(-21)",
+            "JALR            zero, t6, 0xfffff918(-1768)"
         ]
     },
     "Crysis": {
-        "instruction_count": 558,
+        "instruction_count": 557,
         "expected_asm": [
             "ADDI            ra, a0, 0xffffffe0(-32)",
             "VSETIVLI        zero, 16, e8, m1, tu, mu",
@@ -459,7 +457,6 @@
             "SB              t3, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, t1",
             "SLT             t3, ra, s10",
             "XOR             s9, s9, t3",
@@ -672,7 +669,7 @@
             "VSETIVLI        zero, 4, e8, m1, tu, mu",
             "VSE8.V          v12, ra, none, 1",
             "ADDIW           ra, zero, 0x1(1)",
-            "SB              ra, s11, 0x229(553)",
+            "SB              ra, s11, 0x225(549)",
             "SD              gp, s11, 0x80(128)",
             "SD              t0, s11, 0x0(0)",
             "SD              s10, s11, 0x8(8)",
@@ -723,7 +720,7 @@
             "VSE64.V         v16, ra, none, 1",
             "ADDI            ra, s11, 0x1b8(440)",
             "VSE64.V         v17, ra, none, 1",
-            "LBU             ra, s11, 0x224(548)",
+            "LBU             ra, s11, 0x223(547)",
             "XORI            ra, ra, 0x1(1)",
             "BNE             zero, ra, 0x28(40)",
             "FSD             f0, s11, 0x88(136)",
@@ -757,19 +754,19 @@
             "SB              s8, s11, 0x1cc(460)",
             "SB              s9, s11, 0x1cd(461)",
             "ADDIW           t1, zero, 0x1(1)",
-            "SB              t1, s11, 0x228(552)",
-            "LUI             t5, 0x557(1367)",
-            "ADDIW           t5, t5, 0xf9(249)",
+            "SB              t1, s11, 0x224(548)",
+            "LUI             t5, 0x2b(43)",
+            "ADDIW           t5, t5, 0xfffffad1(-1327)",
+            "SLLI            t5, t5, 0x11(17)",
+            "ADDI            t5, t5, 0x15(21)",
             "SLLI            t5, t5, 0xc(12)",
-            "ADDI            t5, t5, 0x605(1541)",
-            "SLLI            t5, t5, 0xc(12)",
-            "ADDI            t5, t5, 0x700(1792)",
+            "ADDI            t5, t5, 0x6c0(1728)",
             "ADDI            a0, sp, 0x0(0)",
             "JALR            zero, t5, 0x0(0)"
         ]
     },
     "XXHash": {
-        "instruction_count": 160,
+        "instruction_count": 159,
         "expected_asm": [
             "SH3ADD          ra, a3, a5",
             "VSETIVLI        zero, 16, e8, m1, tu, mu",
@@ -924,17 +921,16 @@
             "SB              t3, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, t1",
             "SLT             t3, ra, a3",
             "XOR             s9, s9, t3",
             "ADDI            gp, t0, 0x0(0)",
             "AUIPC           t6, 0xffffffea(-22)",
-            "JALR            zero, t6, 0xfffff834(-1996)"
+            "JALR            zero, t6, 0xfffffde4(-540)"
         ]
     },
     "Baldur 2 FMV": {
-        "instruction_count": 1771,
+        "instruction_count": 1770,
         "expected_asm": [
             "ADDI            t0, s1, 0x0(0)",
             "ADDIW           t1, zero, 0xfffffff0(-16)",
@@ -2695,7 +2691,6 @@
             "SB              t3, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, ra, s1",
             "SLTI            t3, t1, 0x0(0)",
             "XOR             s9, s9, t3",
@@ -2706,11 +2701,11 @@
             "ADDI            s1, s1, 0x8(8)",
             "ADDI            gp, ra, 0x0(0)",
             "AUIPC           t6, 0xffffffe8(-24)",
-            "JALR            zero, t6, 0xfffffc84(-892)"
+            "JALR            zero, t6, 0x238(568)"
         ]
     },
     "dotnet rotate": {
-        "instruction_count": 3867,
+        "instruction_count": 3866,
         "expected_asm": [
             "ADD.UW          t0, a6, zero",
             "RORIW           t0, t0, 0x1b(27)",
@@ -6563,7 +6558,6 @@
             "SB              t4, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, t1",
             "SLT             t4, ra, t0",
             "XOR             s9, s9, t4",
@@ -6573,16 +6567,16 @@
             "ADDIW           t1, t1, 0xfffffc34(-972)",
             "ADD             gp, gp, t1",
             "AUIPC           t6, 0xffffffe4(-28)",
-            "JALR            zero, t6, 0x28(40)",
+            "JALR            zero, t6, 0x5e0(1504)",
             "LUI             t1, 0xfffb09a1(-325215)",
             "ADDIW           t1, t1, 0xffffffb3(-77)",
             "ADD             gp, gp, t1",
             "AUIPC           t6, 0xffffffe4(-28)",
-            "JALR            zero, t6, 0x14(20)"
+            "JALR            zero, t6, 0x5cc(1484)"
         ]
     },
     "7z block": {
-        "instruction_count": 115,
+        "instruction_count": 114,
         "expected_asm": [
             "LD              s0, a0, 0x0(0)",
             "LD              a1, a0, 0x28(40)",
@@ -6680,8 +6674,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -6695,14 +6688,14 @@
             "BNE             zero, ra, 0x10(16)",
             "ADDI            gp, gp, 0x74(116)",
             "AUIPC           t6, 0xffffffe4(-28)",
-            "JALR            zero, t6, 0xfffffe50(-432)",
+            "JALR            zero, t6, 0x40c(1036)",
             "ADDI            gp, gp, 0x8b(139)",
             "AUIPC           t6, 0xffffffe4(-28)",
-            "JALR            zero, t6, 0xfffffe44(-444)"
+            "JALR            zero, t6, 0x400(1024)"
         ]
     },
     "Outlast camera": {
-        "instruction_count": 237,
+        "instruction_count": 236,
         "expected_asm": [
             "LWU             s10, a0, 0x10(16)",
             "LD              s4, a0, 0x8(8)",
@@ -6930,7 +6923,6 @@
             "SB              t1, s11, 0x1ca(458)",
             "SLTIU           s7, ra, 0x1(1)",
             "SRLI            s8, ra, 0x3f(63)",
-            "ANDI            s8, s8, 0x1(1)",
             "SLT             s9, zero, t0",
             "SLT             t1, ra, a4",
             "XOR             s9, s9, t1",
@@ -6938,13 +6930,13 @@
             "BNE             zero, ra, 0x10(16)",
             "ADDI            gp, gp, 0x16f(367)",
             "AUIPC           t6, 0xffffffe4(-28)",
-            "JALR            zero, t6, 0xfffffa98(-1384)",
+            "JALR            zero, t6, 0x58(88)",
             "AUIPC           t6, 0xffffffe4(-28)",
-            "JALR            zero, t6, 0xfffffa90(-1392)"
+            "JALR            zero, t6, 0x50(80)"
         ]
     },
     "Outlast camera 2": {
-        "instruction_count": 225,
+        "instruction_count": 224,
         "expected_asm": [
             "ADDI            ra, t0, 0x214(532)",
             "LHU             s6, ra, 0x0(0)",
@@ -7151,8 +7143,7 @@
             "SB              t4, s11, 0x1ca(458)",
             "ADD.UW          s7, ra, zero",
             "SLTIU           s7, s7, 0x1(1)",
-            "SRLI            s8, ra, 0x1f(31)",
-            "ANDI            s8, s8, 0x1(1)",
+            "SRLIW           s8, ra, 0x1f(31)",
             "XORI            t4, t3, 0xffffffff(-1)",
             "OR              s9, t4, t1",
             "AND             s9, s9, ra",
@@ -7167,10 +7158,10 @@
             "XORI            ra, ra, 0x1(1)",
             "BNE             zero, ra, 0x10(16)",
             "ADDI            gp, gp, 0x160(352)",
-            "AUIPC           t6, 0xffffffe3(-29)",
-            "JALR            zero, t6, 0x710(1808)",
-            "AUIPC           t6, 0xffffffe3(-29)",
-            "JALR            zero, t6, 0x708(1800)"
+            "AUIPC           t6, 0xffffffe4(-28)",
+            "JALR            zero, t6, 0xfffffcd4(-812)",
+            "AUIPC           t6, 0xffffffe4(-28)",
+            "JALR            zero, t6, 0xfffffccc(-820)"
         ]
     }
 }

--- a/counts/Lock.json
+++ b/counts/Lock.json
@@ -163,7 +163,7 @@
             "ANDI            t2, t3, 0x3(3)",
             "ADDIW           t4, zero, 0x3(3)",
             "BNE             t2, t4, 0x28(40)",
-            "ADDI            t2, s11, 0x268(616)",
+            "ADDI            t2, s11, 0x260(608)",
             "ADDIW           t4, zero, 0x1(1)",
             "AMOADD.D        zero, t2, t4, aq, rl",
             "FENCE          ",

--- a/counts/SSE4_1.json
+++ b/counts/SSE4_1.json
@@ -205,24 +205,28 @@
         "disassembly": "pmaxsd xmm2, xmm3"
     },
     "660f3a0ad303": {
-        "instruction_count": 5,
+        "instruction_count": 7,
         "expected_asm": [
             "VSETIVLI        zero, 1, e32, m1, tu, mu",
-            "VFMV.F.S        f28, v5",
-            "FCVT.W.S        ra, f28, rtz",
-            "FCVT.S.W        f29, ra, rtz",
-            "VFMV.S.F        v4, f29"
+            "ADDIW           t1, zero, 0x1(1)",
+            "CSRRW           ra, t1, 0x2(2)",
+            "VFCVT.X.F.V     v26, v5, none",
+            "VFCVT.F.X.V     v27, v26, none",
+            "VFSGNJ.VV       v4, v27, v5, none",
+            "CSRRW           zero, ra, 0x2(2)"
         ],
         "disassembly": "roundss xmm2, xmm3, 0x03"
     },
     "660f3a0bd303": {
-        "instruction_count": 5,
+        "instruction_count": 7,
         "expected_asm": [
             "VSETIVLI        zero, 1, e64, m1, tu, mu",
-            "VFMV.F.S        f28, v5",
-            "FCVT.L.D        ra, f28, rtz",
-            "FCVT.D.L        f29, ra, rtz",
-            "VFMV.S.F        v4, f29"
+            "ADDIW           t1, zero, 0x1(1)",
+            "CSRRW           ra, t1, 0x2(2)",
+            "VFCVT.X.F.V     v26, v5, none",
+            "VFCVT.F.X.V     v27, v26, none",
+            "VFSGNJ.VV       v4, v27, v5, none",
+            "CSRRW           zero, ra, 0x2(2)"
         ],
         "disassembly": "roundsd xmm2, xmm3, 0x03"
     },

--- a/counts/X87.json
+++ b/counts/X87.json
@@ -31,7 +31,7 @@
         "disassembly": "fadd [rdi]"
     },
     "dec3": {
-        "instruction_count": 14,
+        "instruction_count": 20,
         "expected_asm": [
             "FADD.D          f3, f3, f0, dyn",
             "FSGNJ.D         f28, f0, f0",
@@ -44,6 +44,12 @@
             "FSGNJ.D         f6, f7, f7",
             "FSGNJ.D         f7, f28, f28",
             "LB              ra, s11, 0x222(546)",
+            "LHU             t3, s11, 0x21e(542)",
+            "SLLI            ra, ra, 0x1(1)",
+            "ADDIW           t1, zero, 0x3(3)",
+            "SLL             t1, t1, ra",
+            "OR              t3, t3, t1",
+            "SH              t3, s11, 0x21e(542)",
             "ADDI            ra, ra, 0x1(1)",
             "ANDI            ra, ra, 0x7(7)",
             "SB              ra, s11, 0x222(546)"
@@ -103,7 +109,7 @@
         "disassembly": "fsub [rdi]"
     },
     "deeb": {
-        "instruction_count": 14,
+        "instruction_count": 20,
         "expected_asm": [
             "FSUB.D          f3, f3, f0, dyn",
             "FSGNJ.D         f28, f0, f0",
@@ -116,6 +122,12 @@
             "FSGNJ.D         f6, f7, f7",
             "FSGNJ.D         f7, f28, f28",
             "LB              ra, s11, 0x222(546)",
+            "LHU             t3, s11, 0x21e(542)",
+            "SLLI            ra, ra, 0x1(1)",
+            "ADDIW           t1, zero, 0x3(3)",
+            "SLL             t1, t1, ra",
+            "OR              t3, t3, t1",
+            "SH              t3, s11, 0x21e(542)",
             "ADDI            ra, ra, 0x1(1)",
             "ANDI            ra, ra, 0x7(7)",
             "SB              ra, s11, 0x222(546)"
@@ -175,7 +187,7 @@
         "disassembly": "fsubr [rdi]"
     },
     "dee3": {
-        "instruction_count": 14,
+        "instruction_count": 20,
         "expected_asm": [
             "FSUB.D          f3, f0, f3, dyn",
             "FSGNJ.D         f28, f0, f0",
@@ -188,6 +200,12 @@
             "FSGNJ.D         f6, f7, f7",
             "FSGNJ.D         f7, f28, f28",
             "LB              ra, s11, 0x222(546)",
+            "LHU             t3, s11, 0x21e(542)",
+            "SLLI            ra, ra, 0x1(1)",
+            "ADDIW           t1, zero, 0x3(3)",
+            "SLL             t1, t1, ra",
+            "OR              t3, t3, t1",
+            "SH              t3, s11, 0x21e(542)",
             "ADDI            ra, ra, 0x1(1)",
             "ANDI            ra, ra, 0x7(7)",
             "SB              ra, s11, 0x222(546)"
@@ -247,7 +265,7 @@
         "disassembly": "fmul [rdi]"
     },
     "decb": {
-        "instruction_count": 14,
+        "instruction_count": 20,
         "expected_asm": [
             "FMUL.D          f3, f3, f0, dyn",
             "FSGNJ.D         f28, f0, f0",
@@ -260,6 +278,12 @@
             "FSGNJ.D         f6, f7, f7",
             "FSGNJ.D         f7, f28, f28",
             "LB              ra, s11, 0x222(546)",
+            "LHU             t3, s11, 0x21e(542)",
+            "SLLI            ra, ra, 0x1(1)",
+            "ADDIW           t1, zero, 0x3(3)",
+            "SLL             t1, t1, ra",
+            "OR              t3, t3, t1",
+            "SH              t3, s11, 0x21e(542)",
             "ADDI            ra, ra, 0x1(1)",
             "ANDI            ra, ra, 0x7(7)",
             "SB              ra, s11, 0x222(546)"
@@ -319,7 +343,7 @@
         "disassembly": "fdiv [rdi]"
     },
     "defb": {
-        "instruction_count": 14,
+        "instruction_count": 20,
         "expected_asm": [
             "FDIV.D          f3, f3, f0, dyn",
             "FSGNJ.D         f28, f0, f0",
@@ -332,6 +356,12 @@
             "FSGNJ.D         f6, f7, f7",
             "FSGNJ.D         f7, f28, f28",
             "LB              ra, s11, 0x222(546)",
+            "LHU             t3, s11, 0x21e(542)",
+            "SLLI            ra, ra, 0x1(1)",
+            "ADDIW           t1, zero, 0x3(3)",
+            "SLL             t1, t1, ra",
+            "OR              t3, t3, t1",
+            "SH              t3, s11, 0x21e(542)",
             "ADDI            ra, ra, 0x1(1)",
             "ANDI            ra, ra, 0x7(7)",
             "SB              ra, s11, 0x222(546)"
@@ -391,7 +421,7 @@
         "disassembly": "fdivr [rdi]"
     },
     "def3": {
-        "instruction_count": 14,
+        "instruction_count": 20,
         "expected_asm": [
             "FDIV.D          f3, f0, f3, dyn",
             "FSGNJ.D         f28, f0, f0",
@@ -404,6 +434,12 @@
             "FSGNJ.D         f6, f7, f7",
             "FSGNJ.D         f7, f28, f28",
             "LB              ra, s11, 0x222(546)",
+            "LHU             t3, s11, 0x21e(542)",
+            "SLLI            ra, ra, 0x1(1)",
+            "ADDIW           t1, zero, 0x3(3)",
+            "SLL             t1, t1, ra",
+            "OR              t3, t3, t1",
+            "SH              t3, s11, 0x21e(542)",
             "ADDI            ra, ra, 0x1(1)",
             "ANDI            ra, ra, 0x7(7)",
             "SB              ra, s11, 0x222(546)"
@@ -459,7 +495,7 @@
         "disassembly": "fcomi st0, st3"
     },
     "dff3": {
-        "instruction_count": 34,
+        "instruction_count": 40,
         "expected_asm": [
             "SB              zero, s11, 0x1c9(457)",
             "FEQ.D           ra, f0, f0",
@@ -491,10 +527,16 @@
             "FSGNJ.D         f5, f6, f6",
             "FSGNJ.D         f6, f7, f7",
             "FSGNJ.D         f7, f28, f28",
-            "LB              t3, s11, 0x222(546)",
-            "ADDI            t3, t3, 0x1(1)",
-            "ANDI            t3, t3, 0x7(7)",
-            "SB              t3, s11, 0x222(546)"
+            "LB              ra, s11, 0x222(546)",
+            "LHU             t3, s11, 0x21e(542)",
+            "SLLI            ra, ra, 0x1(1)",
+            "ADDIW           t1, zero, 0x3(3)",
+            "SLL             t1, t1, ra",
+            "OR              t3, t3, t1",
+            "SH              t3, s11, 0x21e(542)",
+            "ADDI            ra, ra, 0x1(1)",
+            "ANDI            ra, ra, 0x7(7)",
+            "SB              ra, s11, 0x222(546)"
         ],
         "disassembly": "fcomip st0, st3"
     },
@@ -526,7 +568,7 @@
         "disassembly": "fucomi st0, st3"
     },
     "dfeb": {
-        "instruction_count": 34,
+        "instruction_count": 40,
         "expected_asm": [
             "SB              zero, s11, 0x1c9(457)",
             "FEQ.D           ra, f0, f0",
@@ -558,10 +600,16 @@
             "FSGNJ.D         f5, f6, f6",
             "FSGNJ.D         f6, f7, f7",
             "FSGNJ.D         f7, f28, f28",
-            "LB              t3, s11, 0x222(546)",
-            "ADDI            t3, t3, 0x1(1)",
-            "ANDI            t3, t3, 0x7(7)",
-            "SB              t3, s11, 0x222(546)"
+            "LB              ra, s11, 0x222(546)",
+            "LHU             t3, s11, 0x21e(542)",
+            "SLLI            ra, ra, 0x1(1)",
+            "ADDIW           t1, zero, 0x3(3)",
+            "SLL             t1, t1, ra",
+            "OR              t3, t3, t1",
+            "SH              t3, s11, 0x21e(542)",
+            "ADDI            ra, ra, 0x1(1)",
+            "ANDI            ra, ra, 0x7(7)",
+            "SB              ra, s11, 0x222(546)"
         ],
         "disassembly": "fucomip st0, st3"
     },
@@ -584,7 +632,7 @@
         "disassembly": "fist [rdi]"
     },
     "df1f": {
-        "instruction_count": 16,
+        "instruction_count": 22,
         "expected_asm": [
             "ADDI            ra, a0, 0x0(0)",
             "FCVT.W.D        t1, f0, dyn",
@@ -599,6 +647,12 @@
             "FSGNJ.D         f6, f7, f7",
             "FSGNJ.D         f7, f28, f28",
             "LB              t3, s11, 0x222(546)",
+            "LHU             t2, s11, 0x21e(542)",
+            "SLLI            t3, t3, 0x1(1)",
+            "ADDIW           t4, zero, 0x3(3)",
+            "SLL             t4, t4, t3",
+            "OR              t2, t2, t4",
+            "SH              t2, s11, 0x21e(542)",
             "ADDI            t3, t3, 0x1(1)",
             "ANDI            t3, t3, 0x7(7)",
             "SB              t3, s11, 0x222(546)"
@@ -606,7 +660,7 @@
         "disassembly": "fistp [rdi]"
     },
     "db1f": {
-        "instruction_count": 16,
+        "instruction_count": 22,
         "expected_asm": [
             "ADDI            ra, a0, 0x0(0)",
             "FCVT.W.D        t1, f0, dyn",
@@ -621,6 +675,12 @@
             "FSGNJ.D         f6, f7, f7",
             "FSGNJ.D         f7, f28, f28",
             "LB              t3, s11, 0x222(546)",
+            "LHU             t2, s11, 0x21e(542)",
+            "SLLI            t3, t3, 0x1(1)",
+            "ADDIW           t4, zero, 0x3(3)",
+            "SLL             t4, t4, t3",
+            "OR              t2, t2, t4",
+            "SH              t2, s11, 0x21e(542)",
             "ADDI            t3, t3, 0x1(1)",
             "ANDI            t3, t3, 0x7(7)",
             "SB              t3, s11, 0x222(546)"
@@ -628,7 +688,7 @@
         "disassembly": "fistp [rdi]"
     },
     "df3f": {
-        "instruction_count": 16,
+        "instruction_count": 22,
         "expected_asm": [
             "ADDI            ra, a0, 0x0(0)",
             "FCVT.L.D        t1, f0, dyn",
@@ -643,6 +703,12 @@
             "FSGNJ.D         f6, f7, f7",
             "FSGNJ.D         f7, f28, f28",
             "LB              t3, s11, 0x222(546)",
+            "LHU             t2, s11, 0x21e(542)",
+            "SLLI            t3, t3, 0x1(1)",
+            "ADDIW           t4, zero, 0x3(3)",
+            "SLL             t4, t4, t3",
+            "OR              t2, t2, t4",
+            "SH              t2, s11, 0x21e(542)",
             "ADDI            t3, t3, 0x1(1)",
             "ANDI            t3, t3, 0x7(7)",
             "SB              t3, s11, 0x222(546)"
@@ -650,7 +716,7 @@
         "disassembly": "fistp [rdi]"
     },
     "df0f": {
-        "instruction_count": 16,
+        "instruction_count": 22,
         "expected_asm": [
             "ADDI            ra, a0, 0x0(0)",
             "FCVT.W.D        t1, f0, rtz",
@@ -665,6 +731,12 @@
             "FSGNJ.D         f6, f7, f7",
             "FSGNJ.D         f7, f28, f28",
             "LB              t3, s11, 0x222(546)",
+            "LHU             t2, s11, 0x21e(542)",
+            "SLLI            t3, t3, 0x1(1)",
+            "ADDIW           t4, zero, 0x3(3)",
+            "SLL             t4, t4, t3",
+            "OR              t2, t2, t4",
+            "SH              t2, s11, 0x21e(542)",
             "ADDI            t3, t3, 0x1(1)",
             "ANDI            t3, t3, 0x7(7)",
             "SB              t3, s11, 0x222(546)"
@@ -672,7 +744,7 @@
         "disassembly": "fisttp [rdi]"
     },
     "db0f": {
-        "instruction_count": 16,
+        "instruction_count": 22,
         "expected_asm": [
             "ADDI            ra, a0, 0x0(0)",
             "FCVT.W.D        t1, f0, rtz",
@@ -687,6 +759,12 @@
             "FSGNJ.D         f6, f7, f7",
             "FSGNJ.D         f7, f28, f28",
             "LB              t3, s11, 0x222(546)",
+            "LHU             t2, s11, 0x21e(542)",
+            "SLLI            t3, t3, 0x1(1)",
+            "ADDIW           t4, zero, 0x3(3)",
+            "SLL             t4, t4, t3",
+            "OR              t2, t2, t4",
+            "SH              t2, s11, 0x21e(542)",
             "ADDI            t3, t3, 0x1(1)",
             "ANDI            t3, t3, 0x7(7)",
             "SB              t3, s11, 0x222(546)"
@@ -694,7 +772,7 @@
         "disassembly": "fisttp [rdi]"
     },
     "dd0f": {
-        "instruction_count": 16,
+        "instruction_count": 22,
         "expected_asm": [
             "ADDI            ra, a0, 0x0(0)",
             "FCVT.L.D        t1, f0, rtz",
@@ -709,6 +787,12 @@
             "FSGNJ.D         f6, f7, f7",
             "FSGNJ.D         f7, f28, f28",
             "LB              t3, s11, 0x222(546)",
+            "LHU             t2, s11, 0x21e(542)",
+            "SLLI            t3, t3, 0x1(1)",
+            "ADDIW           t4, zero, 0x3(3)",
+            "SLL             t4, t4, t3",
+            "OR              t2, t2, t4",
+            "SH              t2, s11, 0x21e(542)",
             "ADDI            t3, t3, 0x1(1)",
             "ANDI            t3, t3, 0x7(7)",
             "SB              t3, s11, 0x222(546)"
@@ -775,7 +859,7 @@
             "VSE64.V         v16, ra, none, 1",
             "ADDI            ra, s11, 0x1b8(440)",
             "VSE64.V         v17, ra, none, 1",
-            "LBU             ra, s11, 0x224(548)",
+            "LBU             ra, s11, 0x223(547)",
             "XORI            ra, ra, 0x1(1)",
             "BNE             zero, ra, 0x28(40)",
             "FSD             f0, s11, 0x88(136)",
@@ -809,9 +893,9 @@
             "SB              s8, s11, 0x1cc(460)",
             "SB              s9, s11, 0x1cd(461)",
             "ADDIW           t1, zero, 0x1(1)",
-            "SB              t1, s11, 0x228(552)",
+            "SB              t1, s11, 0x224(548)",
             "ADDI            a0, s11, 0x0(0)",
-            "LD              t4, s11, 0x390(912)",
+            "LD              t4, s11, 0x388(904)",
             "JALR            ra, t4, 0x0(0)",
             "LD              gp, s11, 0x80(128)",
             "LD              t0, s11, 0x0(0)",
@@ -863,7 +947,7 @@
             "VLE64.V         v16, t1, none, 1",
             "ADDI            t1, s11, 0x1b8(440)",
             "VLE64.V         v17, t1, none, 1",
-            "LBU             t1, s11, 0x224(548)",
+            "LBU             t1, s11, 0x223(547)",
             "XORI            t1, t1, 0x1(1)",
             "BNE             zero, t1, 0x28(40)",
             "FLD             f0, s11, 0x88(136)",
@@ -898,7 +982,7 @@
             "LBU             s9, s11, 0x1cd(461)",
             "LBU             t1, s11, 0x214(532)",
             "CSRRW           zero, t1, 0x2(2)",
-            "SB              zero, s11, 0x228(552)",
+            "SB              zero, s11, 0x224(548)",
             "FENCE          "
         ],
         "disassembly": "fsin"
@@ -956,7 +1040,7 @@
             "VSE64.V         v16, ra, none, 1",
             "ADDI            ra, s11, 0x1b8(440)",
             "VSE64.V         v17, ra, none, 1",
-            "LBU             ra, s11, 0x224(548)",
+            "LBU             ra, s11, 0x223(547)",
             "XORI            ra, ra, 0x1(1)",
             "BNE             zero, ra, 0x28(40)",
             "FSD             f0, s11, 0x88(136)",
@@ -990,9 +1074,9 @@
             "SB              s8, s11, 0x1cc(460)",
             "SB              s9, s11, 0x1cd(461)",
             "ADDIW           t1, zero, 0x1(1)",
-            "SB              t1, s11, 0x228(552)",
+            "SB              t1, s11, 0x224(548)",
             "ADDI            a0, s11, 0x0(0)",
-            "LD              t4, s11, 0x398(920)",
+            "LD              t4, s11, 0x390(912)",
             "JALR            ra, t4, 0x0(0)",
             "LD              gp, s11, 0x80(128)",
             "LD              t0, s11, 0x0(0)",
@@ -1044,7 +1128,7 @@
             "VLE64.V         v16, t1, none, 1",
             "ADDI            t1, s11, 0x1b8(440)",
             "VLE64.V         v17, t1, none, 1",
-            "LBU             t1, s11, 0x224(548)",
+            "LBU             t1, s11, 0x223(547)",
             "XORI            t1, t1, 0x1(1)",
             "BNE             zero, t1, 0x28(40)",
             "FLD             f0, s11, 0x88(136)",
@@ -1079,13 +1163,13 @@
             "LBU             s9, s11, 0x1cd(461)",
             "LBU             t1, s11, 0x214(532)",
             "CSRRW           zero, t1, 0x2(2)",
-            "SB              zero, s11, 0x228(552)",
+            "SB              zero, s11, 0x224(548)",
             "FENCE          "
         ],
         "disassembly": "fcos"
     },
     "d9e8": {
-        "instruction_count": 15,
+        "instruction_count": 22,
         "expected_asm": [
             "ADDIW           ra, zero, 0x3ff(1023)",
             "SLLI            ra, ra, 0x34(52)",
@@ -1101,12 +1185,19 @@
             "LB              t1, s11, 0x222(546)",
             "ADDI            t1, t1, 0xffffffff(-1)",
             "ANDI            t1, t1, 0x7(7)",
-            "SB              t1, s11, 0x222(546)"
+            "SB              t1, s11, 0x222(546)",
+            "LHU             t4, s11, 0x21e(542)",
+            "SLLI            t1, t1, 0x1(1)",
+            "ADDIW           t3, zero, 0x3(3)",
+            "SLL             t3, t3, t1",
+            "XORI            t3, t3, 0xffffffff(-1)",
+            "AND             t4, t4, t3",
+            "SH              t4, s11, 0x21e(542)"
         ],
         "disassembly": "fld1"
     },
     "d9e9": {
-        "instruction_count": 21,
+        "instruction_count": 28,
         "expected_asm": [
             "LUI             ra, 0x1003(4099)",
             "ADDIW           ra, ra, 0xfffffa4d(-1459)",
@@ -1128,12 +1219,19 @@
             "LB              t1, s11, 0x222(546)",
             "ADDI            t1, t1, 0xffffffff(-1)",
             "ANDI            t1, t1, 0x7(7)",
-            "SB              t1, s11, 0x222(546)"
+            "SB              t1, s11, 0x222(546)",
+            "LHU             t4, s11, 0x21e(542)",
+            "SLLI            t1, t1, 0x1(1)",
+            "ADDIW           t3, zero, 0x3(3)",
+            "SLL             t3, t3, t1",
+            "XORI            t3, t3, 0xffffffff(-1)",
+            "AND             t4, t4, t3",
+            "SH              t4, s11, 0x21e(542)"
         ],
         "disassembly": "fldl2t"
     },
     "d9ea": {
-        "instruction_count": 21,
+        "instruction_count": 28,
         "expected_asm": [
             "LUI             ra, 0x7ff(2047)",
             "ADDIW           ra, ra, 0xfffffe2b(-469)",
@@ -1155,12 +1253,19 @@
             "LB              t1, s11, 0x222(546)",
             "ADDI            t1, t1, 0xffffffff(-1)",
             "ANDI            t1, t1, 0x7(7)",
-            "SB              t1, s11, 0x222(546)"
+            "SB              t1, s11, 0x222(546)",
+            "LHU             t4, s11, 0x21e(542)",
+            "SLLI            t1, t1, 0x1(1)",
+            "ADDIW           t3, zero, 0x3(3)",
+            "SLL             t3, t3, t1",
+            "XORI            t3, t3, 0xffffffff(-1)",
+            "AND             t4, t4, t3",
+            "SH              t4, s11, 0x21e(542)"
         ],
         "disassembly": "fldl2e"
     },
     "d9eb": {
-        "instruction_count": 21,
+        "instruction_count": 28,
         "expected_asm": [
             "LUI             ra, 0x200(512)",
             "ADDIW           ra, ra, 0x491(1169)",
@@ -1182,12 +1287,19 @@
             "LB              t1, s11, 0x222(546)",
             "ADDI            t1, t1, 0xffffffff(-1)",
             "ANDI            t1, t1, 0x7(7)",
-            "SB              t1, s11, 0x222(546)"
+            "SB              t1, s11, 0x222(546)",
+            "LHU             t4, s11, 0x21e(542)",
+            "SLLI            t1, t1, 0x1(1)",
+            "ADDIW           t3, zero, 0x3(3)",
+            "SLL             t3, t3, t1",
+            "XORI            t3, t3, 0xffffffff(-1)",
+            "AND             t4, t4, t3",
+            "SH              t4, s11, 0x21e(542)"
         ],
         "disassembly": "fldpi"
     },
     "d9ec": {
-        "instruction_count": 21,
+        "instruction_count": 28,
         "expected_asm": [
             "LUI             ra, 0xff(255)",
             "ADDIW           ra, ra, 0x4d1(1233)",
@@ -1209,12 +1321,19 @@
             "LB              t1, s11, 0x222(546)",
             "ADDI            t1, t1, 0xffffffff(-1)",
             "ANDI            t1, t1, 0x7(7)",
-            "SB              t1, s11, 0x222(546)"
+            "SB              t1, s11, 0x222(546)",
+            "LHU             t4, s11, 0x21e(542)",
+            "SLLI            t1, t1, 0x1(1)",
+            "ADDIW           t3, zero, 0x3(3)",
+            "SLL             t3, t3, t1",
+            "XORI            t3, t3, 0xffffffff(-1)",
+            "AND             t4, t4, t3",
+            "SH              t4, s11, 0x21e(542)"
         ],
         "disassembly": "fldlg2"
     },
     "d9ed": {
-        "instruction_count": 19,
+        "instruction_count": 26,
         "expected_asm": [
             "LUI             ra, 0x3fe63(261731)",
             "ADDIW           ra, ra, 0xfffffe43(-445)",
@@ -1234,12 +1353,19 @@
             "LB              t1, s11, 0x222(546)",
             "ADDI            t1, t1, 0xffffffff(-1)",
             "ANDI            t1, t1, 0x7(7)",
-            "SB              t1, s11, 0x222(546)"
+            "SB              t1, s11, 0x222(546)",
+            "LHU             t4, s11, 0x21e(542)",
+            "SLLI            t1, t1, 0x1(1)",
+            "ADDIW           t3, zero, 0x3(3)",
+            "SLL             t3, t3, t1",
+            "XORI            t3, t3, 0xffffffff(-1)",
+            "AND             t4, t4, t3",
+            "SH              t4, s11, 0x21e(542)"
         ],
         "disassembly": "fldln2"
     },
     "d9ee": {
-        "instruction_count": 13,
+        "instruction_count": 20,
         "expected_asm": [
             "FMV.D.X         f28, zero",
             "FSGNJ.D         f7, f6, f6",
@@ -1253,7 +1379,14 @@
             "LB              ra, s11, 0x222(546)",
             "ADDI            ra, ra, 0xffffffff(-1)",
             "ANDI            ra, ra, 0x7(7)",
-            "SB              ra, s11, 0x222(546)"
+            "SB              ra, s11, 0x222(546)",
+            "LHU             t3, s11, 0x21e(542)",
+            "SLLI            ra, ra, 0x1(1)",
+            "ADDIW           t1, zero, 0x3(3)",
+            "SLL             t1, t1, ra",
+            "XORI            t1, t1, 0xffffffff(-1)",
+            "AND             t3, t3, t1",
+            "SH              t3, s11, 0x21e(542)"
         ],
         "disassembly": "fldz"
     },
@@ -1325,7 +1458,7 @@
             "VSE64.V         v16, ra, none, 1",
             "ADDI            ra, s11, 0x1b8(440)",
             "VSE64.V         v17, ra, none, 1",
-            "LBU             ra, s11, 0x224(548)",
+            "LBU             ra, s11, 0x223(547)",
             "XORI            ra, ra, 0x1(1)",
             "BNE             zero, ra, 0x28(40)",
             "FSD             f0, s11, 0x88(136)",
@@ -1359,7 +1492,7 @@
             "SB              s8, s11, 0x1cc(460)",
             "SB              s9, s11, 0x1cd(461)",
             "ADDIW           t1, zero, 0x1(1)",
-            "SB              t1, s11, 0x228(552)",
+            "SB              t1, s11, 0x224(548)",
             "ADDI            a0, s11, 0x0(0)",
             "LD              t4, s11, 0x3b0(944)",
             "JALR            ra, t4, 0x0(0)",
@@ -1413,7 +1546,7 @@
             "VLE64.V         v16, t1, none, 1",
             "ADDI            t1, s11, 0x1b8(440)",
             "VLE64.V         v17, t1, none, 1",
-            "LBU             t1, s11, 0x224(548)",
+            "LBU             t1, s11, 0x223(547)",
             "XORI            t1, t1, 0x1(1)",
             "BNE             zero, t1, 0x28(40)",
             "FLD             f0, s11, 0x88(136)",
@@ -1448,7 +1581,7 @@
             "LBU             s9, s11, 0x1cd(461)",
             "LBU             t1, s11, 0x214(532)",
             "CSRRW           zero, t1, 0x2(2)",
-            "SB              zero, s11, 0x228(552)",
+            "SB              zero, s11, 0x224(548)",
             "FENCE          "
         ],
         "disassembly": "fprem"
@@ -1531,7 +1664,7 @@
             "VSE64.V         v16, t1, none, 1",
             "ADDI            t1, s11, 0x1b8(440)",
             "VSE64.V         v17, t1, none, 1",
-            "LBU             t1, s11, 0x224(548)",
+            "LBU             t1, s11, 0x223(547)",
             "XORI            t1, t1, 0x1(1)",
             "BNE             zero, t1, 0x28(40)",
             "FSD             f0, s11, 0x88(136)",
@@ -1565,7 +1698,7 @@
             "SB              s8, s11, 0x1cc(460)",
             "SB              s9, s11, 0x1cd(461)",
             "ADDIW           t3, zero, 0x1(1)",
-            "SB              t3, s11, 0x228(552)",
+            "SB              t3, s11, 0x224(548)",
             "ADDI            a1, ra, 0x0(0)",
             "ADDI            a0, s11, 0x0(0)",
             "LD              t4, s11, 0x3f8(1016)",
@@ -1620,7 +1753,7 @@
             "VLE64.V         v16, t3, none, 1",
             "ADDI            t3, s11, 0x1b8(440)",
             "VLE64.V         v17, t3, none, 1",
-            "LBU             t3, s11, 0x224(548)",
+            "LBU             t3, s11, 0x223(547)",
             "XORI            t3, t3, 0x1(1)",
             "BNE             zero, t3, 0x28(40)",
             "FLD             f0, s11, 0x88(136)",
@@ -1655,7 +1788,7 @@
             "LBU             s9, s11, 0x1cd(461)",
             "LBU             t3, s11, 0x214(532)",
             "CSRRW           zero, t3, 0x2(2)",
-            "SB              zero, s11, 0x228(552)",
+            "SB              zero, s11, 0x224(548)",
             "FENCE          "
         ],
         "disassembly": "fldenv [rdi]"
@@ -1714,7 +1847,7 @@
             "VSE64.V         v16, t1, none, 1",
             "ADDI            t1, s11, 0x1b8(440)",
             "VSE64.V         v17, t1, none, 1",
-            "LBU             t1, s11, 0x224(548)",
+            "LBU             t1, s11, 0x223(547)",
             "XORI            t1, t1, 0x1(1)",
             "BNE             zero, t1, 0x28(40)",
             "FSD             f0, s11, 0x88(136)",
@@ -1748,7 +1881,7 @@
             "SB              s8, s11, 0x1cc(460)",
             "SB              s9, s11, 0x1cd(461)",
             "ADDIW           t3, zero, 0x1(1)",
-            "SB              t3, s11, 0x228(552)",
+            "SB              t3, s11, 0x224(548)",
             "ADDI            a1, ra, 0x0(0)",
             "ADDI            a0, s11, 0x0(0)",
             "LD              t4, s11, 0x3e8(1000)",
@@ -1803,7 +1936,7 @@
             "VLE64.V         v16, t3, none, 1",
             "ADDI            t3, s11, 0x1b8(440)",
             "VLE64.V         v17, t3, none, 1",
-            "LBU             t3, s11, 0x224(548)",
+            "LBU             t3, s11, 0x223(547)",
             "XORI            t3, t3, 0x1(1)",
             "BNE             zero, t3, 0x28(40)",
             "FLD             f0, s11, 0x88(136)",
@@ -1838,7 +1971,7 @@
             "LBU             s9, s11, 0x1cd(461)",
             "LBU             t3, s11, 0x214(532)",
             "CSRRW           zero, t3, 0x2(2)",
-            "SB              zero, s11, 0x228(552)",
+            "SB              zero, s11, 0x224(548)",
             "FENCE          "
         ],
         "disassembly": "fnstenv [rdi]"

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -2329,8 +2329,37 @@ void Recompiler::updateZero(biscuit::GPR result, x86_size_e size) {
 
 void Recompiler::updateSign(biscuit::GPR result, x86_size_e size) {
     biscuit::GPR sf = flag(X86_REF_SF);
-    as.SRLI(sf, result, getBitSize(size) - 1);
-    as.ANDI(sf, sf, 1);
+    switch (getBitSize(size)) {
+    case 64: {
+        as.SRLI(sf, result, 63);
+        break;
+    }
+    case 32: {
+        as.SRLIW(sf, result, 31);
+        break;
+    }
+    case 16: {
+        if (Extensions::B) {
+            as.BEXTI(sf, result, 15);
+        } else {
+            as.SRLI(sf, result, 15);
+            as.ANDI(sf, sf, 1);
+        }
+        break;
+    }
+    case 8: {
+        if (Extensions::B) {
+            as.BEXTI(sf, result, 7);
+        } else {
+            as.SRLI(sf, result, 7);
+            as.ANDI(sf, sf, 1);
+        }
+        break;
+    }
+    default: {
+        UNREACHABLE();
+    }
+    }
 }
 
 void Recompiler::jumpAndLink(u64 rip) {


### PR DESCRIPTION
Makes sign flag calculation be 1 instruction for all sizes