### PR TITLE
Optimize TZCNT and LZCNT

### DIFF
--- a/counts/Base.json
+++ b/counts/Base.json
@@ -12136,6 +12136,140 @@
         ],
         "disassembly": "cmpxchg [rdi], rbx"
     },
+    "6666f30fbcc3": {
+        "instruction_count": 8,
+        "expected_asm": [
+            "ZEXT.H          s5, s0",
+            "SLTIU           s5, s5, 0x1(1)",
+            "BSETI           t1, s0, 0x10(16)",
+            "CTZW            ra, t1",
+            "SRLI            t3, t0, 0x10(16)",
+            "SLLI            t3, t3, 0x10(16)",
+            "OR              t0, t3, ra",
+            "SLTIU           s7, ra, 0x1(1)"
+        ],
+        "disassembly": "tzcnt ax, bx"
+    },
+    "6666f30fbc07": {
+        "instruction_count": 8,
+        "expected_asm": [
+            "LHU             ra, a0, 0x0(0)",
+            "SLTIU           s5, ra, 0x1(1)",
+            "BSETI           t4, ra, 0x10(16)",
+            "CTZW            t3, t4",
+            "SRLI            t2, t0, 0x10(16)",
+            "SLLI            t2, t2, 0x10(16)",
+            "OR              t0, t2, t3",
+            "SLTIU           s7, t3, 0x1(1)"
+        ],
+        "disassembly": "tzcnt ax, [rdi]"
+    },
+    "f30fbcc3": {
+        "instruction_count": 4,
+        "expected_asm": [
+            "ADD.UW          s5, s0, zero",
+            "SLTIU           s5, s5, 0x1(1)",
+            "CTZW            t0, s0",
+            "SLTIU           s7, t0, 0x1(1)"
+        ],
+        "disassembly": "tzcnt eax, ebx"
+    },
+    "f30fbc07": {
+        "instruction_count": 4,
+        "expected_asm": [
+            "LWU             ra, a0, 0x0(0)",
+            "SLTIU           s5, ra, 0x1(1)",
+            "CTZW            t0, ra",
+            "SLTIU           s7, t0, 0x1(1)"
+        ],
+        "disassembly": "tzcnt eax, [rdi]"
+    },
+    "f3480fbcc3": {
+        "instruction_count": 3,
+        "expected_asm": [
+            "SLTIU           s5, s0, 0x1(1)",
+            "CTZ             t0, s0",
+            "SLTIU           s7, t0, 0x1(1)"
+        ],
+        "disassembly": "tzcnt rax, rbx"
+    },
+    "f3480fbc07": {
+        "instruction_count": 4,
+        "expected_asm": [
+            "LD              ra, a0, 0x0(0)",
+            "SLTIU           s5, ra, 0x1(1)",
+            "CTZ             t0, ra",
+            "SLTIU           s7, t0, 0x1(1)"
+        ],
+        "disassembly": "tzcnt rax, [rdi]"
+    },
+    "6666f30fbdc3": {
+        "instruction_count": 8,
+        "expected_asm": [
+            "ZEXT.H          ra, s0",
+            "SLTIU           s5, ra, 0x1(1)",
+            "CLZW            t1, ra",
+            "ADDI            t1, t1, 0xfffffff0(-16)",
+            "SRLI            t3, t0, 0x10(16)",
+            "SLLI            t3, t3, 0x10(16)",
+            "OR              t0, t3, t1",
+            "SLTIU           s7, t1, 0x1(1)"
+        ],
+        "disassembly": "lzcnt ax, bx"
+    },
+    "6666f30fbd07": {
+        "instruction_count": 8,
+        "expected_asm": [
+            "LHU             t1, a0, 0x0(0)",
+            "SLTIU           s5, t1, 0x1(1)",
+            "CLZW            t4, t1",
+            "ADDI            t4, t4, 0xfffffff0(-16)",
+            "SRLI            t2, t0, 0x10(16)",
+            "SLLI            t2, t2, 0x10(16)",
+            "OR              t0, t2, t4",
+            "SLTIU           s7, t4, 0x1(1)"
+        ],
+        "disassembly": "lzcnt ax, [rdi]"
+    },
+    "f30fbdc3": {
+        "instruction_count": 4,
+        "expected_asm": [
+            "ADD.UW          ra, s0, zero",
+            "SLTIU           s5, ra, 0x1(1)",
+            "CLZW            t0, s0",
+            "SLTIU           s7, t0, 0x1(1)"
+        ],
+        "disassembly": "lzcnt eax, ebx"
+    },
+    "f30fbd07": {
+        "instruction_count": 4,
+        "expected_asm": [
+            "LWU             t1, a0, 0x0(0)",
+            "SLTIU           s5, t1, 0x1(1)",
+            "CLZW            t0, t1",
+            "SLTIU           s7, t0, 0x1(1)"
+        ],
+        "disassembly": "lzcnt eax, [rdi]"
+    },
+    "f3480fbdc3": {
+        "instruction_count": 3,
+        "expected_asm": [
+            "SLTIU           s5, s0, 0x1(1)",
+            "CLZ             t0, s0",
+            "SLTIU           s7, t0, 0x1(1)"
+        ],
+        "disassembly": "lzcnt rax, rbx"
+    },
+    "f3480fbd07": {
+        "instruction_count": 4,
+        "expected_asm": [
+            "LD              t1, a0, 0x0(0)",
+            "SLTIU           s5, t1, 0x1(1)",
+            "CLZ             t0, t1",
+            "SLTIU           s7, t0, 0x1(1)"
+        ],
+        "disassembly": "lzcnt rax, [rdi]"
+    },
     "88da": {
         "instruction_count": 3,
         "expected_asm": [
@@ -12225,13 +12359,12 @@
         "disassembly": "mov dh, [rdi]"
     },
     "668b17": {
-        "instruction_count": 5,
+        "instruction_count": 4,
         "expected_asm": [
-            "LHU             ra, a0, 0x0(0)",
-            "ZEXT.H          t3, ra",
-            "SRLI            a2, a2, 0x10(16)",
-            "SLLI            a2, a2, 0x10(16)",
-            "OR              a2, a2, t3"
+            "LHU             t1, a0, 0x0(0)",
+            "SRLI            ra, a2, 0x10(16)",
+            "SLLI            ra, ra, 0x10(16)",
+            "OR              a2, ra, t1"
         ],
         "disassembly": "mov dx, [rdi]"
     },
@@ -16253,15 +16386,17 @@
         "disassembly": "xchg [rdi], bh"
     },
     "66871f": {
-        "instruction_count": 27,
+        "instruction_count": 29,
         "expected_asm": [
             "ADDI            ra, a0, 0x0(0)",
             "ZEXT.H          t1, s0",
             "ANDI            t5, ra, 0x3(3)",
             "ADDI            t5, t5, 0xfffffffd(-3)",
-            "BNE             zero, t5, 0x14(20)",
+            "BNE             zero, t5, 0x1c(28)",
+            "FENCE          ",
             "LHU             t3, ra, 0x0(0)",
             "SH              t1, ra, 0x0(0)",
+            "FENCE          ",
             "ADDI            t4, t3, 0x0(0)",
             "JAL             zero, 0x3c(60)",
             "ANDI            t2, ra, 0xfffffffc(-4)",
@@ -16286,12 +16421,19 @@
         "disassembly": "xchg [rdi], bx"
     },
     "871f": {
-        "instruction_count": 5,
+        "instruction_count": 12,
         "expected_asm": [
             "ADDI            ra, a0, 0x0(0)",
             "ADD.UW          t1, s0, zero",
+            "ANDI            t2, ra, 0x3(3)",
+            "BNE             zero, t2, 0x10(16)",
             "ADDI            t3, t1, 0x0(0)",
             "AMOSWAP.W       t4, ra, t3, aq, rl",
+            "JAL             zero, 0x14(20)",
+            "FENCE          ",
+            "LWU             t4, ra, 0x0(0)",
+            "SW              t1, ra, 0x0(0)",
+            "FENCE          ",
             "ADD.UW          s0, t4, zero"
         ],
         "disassembly": "xchg [rdi], ebx"

--- a/counts/Base_NoFlags.json
+++ b/counts/Base_NoFlags.json
@@ -5994,5 +5994,112 @@
             "ADDI            t0, t1, 0x0(0)"
         ],
         "disassembly": "cmpxchg [rdi], rbx"
+    },
+    "6666f30fbcc3": {
+        "instruction_count": 5,
+        "expected_asm": [
+            "BSETI           t1, s0, 0x10(16)",
+            "CTZW            ra, t1",
+            "SRLI            t3, t0, 0x10(16)",
+            "SLLI            t3, t3, 0x10(16)",
+            "OR              t0, t3, ra"
+        ],
+        "disassembly": "tzcnt ax, bx"
+    },
+    "6666f30fbc07": {
+        "instruction_count": 6,
+        "expected_asm": [
+            "LHU             ra, a0, 0x0(0)",
+            "BSETI           t4, ra, 0x10(16)",
+            "CTZW            t3, t4",
+            "SRLI            t2, t0, 0x10(16)",
+            "SLLI            t2, t2, 0x10(16)",
+            "OR              t0, t2, t3"
+        ],
+        "disassembly": "tzcnt ax, [rdi]"
+    },
+    "f30fbcc3": {
+        "instruction_count": 1,
+        "expected_asm": [
+            "CTZW            t0, s0"
+        ],
+        "disassembly": "tzcnt eax, ebx"
+    },
+    "f30fbc07": {
+        "instruction_count": 2,
+        "expected_asm": [
+            "LWU             ra, a0, 0x0(0)",
+            "CTZW            t0, ra"
+        ],
+        "disassembly": "tzcnt eax, [rdi]"
+    },
+    "f3480fbcc3": {
+        "instruction_count": 1,
+        "expected_asm": [
+            "CTZ             t0, s0"
+        ],
+        "disassembly": "tzcnt rax, rbx"
+    },
+    "f3480fbc07": {
+        "instruction_count": 2,
+        "expected_asm": [
+            "LD              ra, a0, 0x0(0)",
+            "CTZ             t0, ra"
+        ],
+        "disassembly": "tzcnt rax, [rdi]"
+    },
+    "6666f30fbdc3": {
+        "instruction_count": 6,
+        "expected_asm": [
+            "ZEXT.H          ra, s0",
+            "CLZW            t1, ra",
+            "ADDI            t1, t1, 0xfffffff0(-16)",
+            "SRLI            t3, t0, 0x10(16)",
+            "SLLI            t3, t3, 0x10(16)",
+            "OR              t0, t3, t1"
+        ],
+        "disassembly": "lzcnt ax, bx"
+    },
+    "6666f30fbd07": {
+        "instruction_count": 6,
+        "expected_asm": [
+            "LHU             t1, a0, 0x0(0)",
+            "CLZW            t4, t1",
+            "ADDI            t4, t4, 0xfffffff0(-16)",
+            "SRLI            t2, t0, 0x10(16)",
+            "SLLI            t2, t2, 0x10(16)",
+            "OR              t0, t2, t4"
+        ],
+        "disassembly": "lzcnt ax, [rdi]"
+    },
+    "f30fbdc3": {
+        "instruction_count": 1,
+        "expected_asm": [
+            "CLZW            t0, s0"
+        ],
+        "disassembly": "lzcnt eax, ebx"
+    },
+    "f30fbd07": {
+        "instruction_count": 2,
+        "expected_asm": [
+            "LWU             t1, a0, 0x0(0)",
+            "CLZW            t0, t1"
+        ],
+        "disassembly": "lzcnt eax, [rdi]"
+    },
+    "f3480fbdc3": {
+        "instruction_count": 1,
+        "expected_asm": [
+            "CLZ             t0, s0"
+        ],
+        "disassembly": "lzcnt rax, rbx"
+    },
+    "f3480fbd07": {
+        "instruction_count": 2,
+        "expected_asm": [
+            "LD              t1, a0, 0x0(0)",
+            "CLZ             t0, t1"
+        ],
+        "disassembly": "lzcnt rax, [rdi]"
     }
 }

--- a/external/biscuit/src/assembler.cpp
+++ b/external/biscuit/src/assembler.cpp
@@ -1,5 +1,5 @@
-#include <biscuit/assert.hpp>
 #include <biscuit/assembler.hpp>
+#include <biscuit/assert.hpp>
 
 #include <array>
 #include <bit>
@@ -10,11 +10,9 @@
 
 namespace biscuit {
 
-Assembler::Assembler(size_t capacity)
-    : m_buffer(capacity) {}
+Assembler::Assembler(size_t capacity) : m_buffer(capacity) {}
 
-Assembler::Assembler(uint8_t* buffer, size_t capacity, ArchFeature features)
-    : m_buffer(buffer, capacity), m_features{features} {}
+Assembler::Assembler(uint8_t* buffer, size_t capacity, ArchFeature features) : m_buffer(buffer, capacity), m_features{features} {}
 
 Assembler::~Assembler() = default;
 
@@ -88,7 +86,7 @@ void Assembler::AND(GPR rd, GPR lhs, GPR rhs) noexcept {
 void Assembler::ANDI(GPR rd, GPR rs, uint32_t imm) noexcept {
     if (IsOptimizationEnabled(Optimization::AutoCompress)) {
         uint32_t sign_extended = static_cast<uint32_t>(static_cast<int32_t>(imm << 26) >> 26);
-        if (rd == rs  && IsValid3BitCompressedReg(rd) && (imm & 0xFFF) == (sign_extended & 0xFFF)) {
+        if (rd == rs && IsValid3BitCompressedReg(rd) && (imm & 0xFFF) == (sign_extended & 0xFFF)) {
             C_ANDI(rd, imm);
             return;
         }
@@ -284,8 +282,7 @@ void Assembler::CALL(int32_t offset) noexcept {
     const auto needs_increment = (uimm & 0x800) != 0;
 
     // Sign-extend the lower portion if the MSB of it is set.
-    const auto new_lower = needs_increment ? static_cast<int32_t>(lower << 20) >> 20
-                                           : static_cast<int32_t>(lower);
+    const auto new_lower = needs_increment ? static_cast<int32_t>(lower << 20) >> 20 : static_cast<int32_t>(lower);
     const auto new_upper = needs_increment ? upper + 1 : upper;
 
     AUIPC(x1, static_cast<int32_t>(new_upper));
@@ -1324,7 +1321,7 @@ void Assembler::BSETI(GPR rd, GPR rs, uint32_t bit) noexcept {
     }
 
     const auto imm = (0b001010U << 6) | bit;
-    EmitIType(m_buffer, imm, rs, 0b001, rd, 0b0110011);
+    EmitIType(m_buffer, imm, rs, 0b001, rd, 0b0010011);
 }
 
 void Assembler::CLMUL(GPR rd, GPR rs1, GPR rs2) noexcept {
@@ -1724,13 +1721,9 @@ ptrdiff_t Assembler::LinkAndGetOffset(Label* label) {
 
 void Assembler::ResolveLabelOffsets(Label* label) {
     // Conditional branch instructions make use of the B-type immediate encoding for offsets.
-    const auto is_b_type = [](uint32_t instruction) {
-        return (instruction & 0x7F) == 0b1100011;
-    };
+    const auto is_b_type = [](uint32_t instruction) { return (instruction & 0x7F) == 0b1100011; };
     // JAL makes use of the J-type immediate encoding for offsets.
-    const auto is_j_type = [](uint32_t instruction) {
-        return (instruction & 0x7F) == 0b1101111;
-    };
+    const auto is_j_type = [](uint32_t instruction) { return (instruction & 0x7F) == 0b1101111; };
     // C.BEQZ and C.BNEZ make use of this encoding type.
     const auto is_cb_type = [](uint32_t instruction) {
         const auto op = instruction & 0b11;
@@ -1794,13 +1787,9 @@ void Assembler::ResolveLabelOffsets(Label* label) {
 }
 
 void Assembler::ResolveLiteralOffsetsRaw(ptrdiff_t location, const std::set<ptrdiff_t>& offsets) {
-    [[maybe_unused]] const auto is_auipc_type = [](uint32_t instruction) {
-        return (instruction & 0x7F) == 0b0010111;
-    };
+    [[maybe_unused]] const auto is_auipc_type = [](uint32_t instruction) { return (instruction & 0x7F) == 0b0010111; };
 
-    const auto is_gpr_load_type = [](uint32_t instruction) {
-        return (instruction & 0x7F) == 0b0000011;
-    };
+    const auto is_gpr_load_type = [](uint32_t instruction) { return (instruction & 0x7F) == 0b0000011; };
 
     for (const auto offset : offsets) {
         const auto address = m_buffer.GetOffsetAddress(offset);

--- a/src/felix86/tools/generate_instruction_count.cpp
+++ b/src/felix86/tools/generate_instruction_count.cpp
@@ -402,6 +402,18 @@ int main() {
         GEN(cmpxchg(ptr[rdi], bx));
         GEN(cmpxchg(ptr[rdi], ebx));
         GEN(cmpxchg(ptr[rdi], rbx));
+        GEN(tzcnt(ax, bx));
+        GEN(tzcnt(ax, word[rdi]));
+        GEN(tzcnt(eax, ebx));
+        GEN(tzcnt(eax, dword[rdi]));
+        GEN(tzcnt(rax, rbx));
+        GEN(tzcnt(rax, qword[rdi]));
+        GEN(lzcnt(ax, bx));
+        GEN(lzcnt(ax, word[rdi]));
+        GEN(lzcnt(eax, ebx));
+        GEN(lzcnt(eax, dword[rdi]));
+        GEN(lzcnt(rax, rbx));
+        GEN(lzcnt(rax, qword[rdi]));
         if (flags) {
             GEN_Group1(mov);
             GEN(mov(rax, qword[rdi + 128]));


### PR DESCRIPTION
TZCNT and LZCNT should now have a perfect implementation for all possible operands.

CTZ(W)/CLZ(W) can be used for 32/64-bit. 16-bit TZCNT works by setting the 16th bit in src, 16-bit LZCNT by subtracting 16 from the result of CLZW (since upper 16 bits are zero)