### PR TITLE
Fix PSRL/PSLL using 64-bit src

### DIFF
--- a/src/felix86/v2/handlers.cpp
+++ b/src/felix86/v2/handlers.cpp
@@ -7001,7 +7001,6 @@ FAST_HANDLE(PSLLW) {
         as.VMV_XS(count, src); // for some reason, bits 0-63 need to be considered for the shift
         rec.setVectorState(SEW::E16, 8);
         // Make a mask to zero elements if shift is >= 16
-        as.VMV_XS(count, src);
         as.SLTIU(mask, count, 16);
         as.NEG(mask, mask);
         as.VSLL(shifted, dst, count);


### PR DESCRIPTION
Despite PSRLD/PSLLD/PSRLW/PSLLW needing way less than 64 bits, all of the 64 bits need to be considered for the shift. Previously we would only consider 16/32 of the bits which meant high shift values wouldn't zero out the register correctly.