### PR TITLE
Reduce mounts directory spam in /tmp

### DIFF
--- a/src/felix86/common/global.cpp
+++ b/src/felix86/common/global.cpp
@@ -281,13 +281,6 @@ void initialize_globals() {
         g_mounts_path = mounts_path;
     }
 
-    if (g_mounts_path.empty()) {
-        char templ[] = "/tmp/.f86.mnt.XXXXXX";
-        char* path = mkdtemp(templ);
-        ASSERT_MSG(path == templ, "Failed to mkdtemp for mounts directory?");
-        g_mounts_path = path;
-    }
-
     const char* guest_rootfs = getenv("__FELIX86_ROOTFS");
     if (guest_rootfs) {
         g_config.rootfs_path = guest_rootfs;
@@ -381,8 +374,6 @@ void initialize_globals() {
         }
         exit(1);
     }
-
-    ASSERT_MSG(!g_mounts_path.empty(), "Mounts path is empty?");
 
     if (!std::filesystem::exists(g_config.rootfs_path)) {
         ERROR("Rootfs path does <%s> not exist", g_config.rootfs_path.c_str());

--- a/src/felix86/hle/filesystem.cpp
+++ b/src/felix86/hle/filesystem.cpp
@@ -609,6 +609,13 @@ int Filesystem::PivotRoot(const char* new_root, const char* put_old) {
 
     const char* new_root_full = new_root_resolved.full_path();
 
+    if (g_mounts_path.empty()) {
+        char templ[] = "/tmp/.f86.mnt.XXXXXX";
+        char* path = mkdtemp(templ);
+        ASSERT_MSG(path == templ, "Failed to mkdtemp for mounts directory?");
+        g_mounts_path = path;
+    }
+
     std::filesystem::path path = g_mounts_path / ("mount." + std::to_string(gettid()) + ".XXXXXX");
     char buffer[PATH_MAX];
     ASSERT(path.string().size() < PATH_MAX);

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -1519,8 +1519,10 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
         envp.push_back(log_env.c_str());
         std::string rootfs_env = std::string("__FELIX86_ROOTFS=") + g_config.rootfs_path.string();
         envp.push_back(rootfs_env.c_str());
-        std::string mounts_env = std::string("__FELIX86_MOUNTS=") + g_mounts_path.string();
-        envp.push_back(mounts_env.c_str());
+        if (!g_mounts_path.empty()) {
+            std::string mounts_env = std::string("__FELIX86_MOUNTS=") + g_mounts_path.string();
+            envp.push_back(mounts_env.c_str());
+        }
         size_t current_mount = 0;
         for (auto& mount_path : g_process_globals.mount_paths) {
             envp.push_back(strdup((std::string("__FELIX86_MOUNT_") + std::to_string(current_mount++) + "=" + mount_path.string()).c_str()));


### PR DESCRIPTION
When running thousands of instances for testing this would add up to many unnecessary folders.