### PR TITLE
Make code relocatable

### DIFF
--- a/counts/HotBlocks.json
+++ b/counts/HotBlocks.json
@@ -1,6 +1,6 @@
 {
     "llvmpipe_shader": {
-        "instruction_count": 199,
+        "instruction_count": 196,
         "expected_asm": [
             "LD              s3, a1, 0x0(0)",
             "LWU             s3, s3, 0x4(4)",
@@ -192,19 +192,16 @@
             "ADDIW           s9, zero, 0x0(0)",
             "SB              zero, s11, 0x1ca(458)",
             "ADD.UW          s3, ra, zero",
-            "BNE             zero, s7, 0x10(16)",
-            "ADDI            gp, gp, 0x13a(314)",
-            "AUIPC           t6, 0xffffffeb(-21)",
-            "JALR            zero, t6, 0x140(320)",
-            "LUI             ra, 0xd(13)",
-            "ADDIW           ra, ra, 0xfffffc32(-974)",
-            "ADD             gp, gp, ra",
-            "AUIPC           t6, 0xffffffeb(-21)",
-            "JALR            zero, t6, 0x12c(300)"
+            "LD              ra, s1, 0x0(0)",
+            "ADDI            s1, s1, 0x8(8)",
+            "ADDI            gp, ra, 0x0(0)",
+            "LD              t6, s11, 0x488(1160)",
+            "LD              t6, t6, 0x88(136)",
+            "JALR            zero, t6, 0x0(0)"
         ]
     },
     "Crysis": {
-        "instruction_count": 528,
+        "instruction_count": 523,
         "expected_asm": [
             "ADDI            ra, a0, 0xffffffe0(-32)",
             "VSETIVLI        zero, 16, e8, m1, tu, mu",
@@ -726,18 +723,13 @@
             "SB              s9, s11, 0x1cd(461)",
             "ADDIW           t1, zero, 0x1(1)",
             "SB              t1, s11, 0x224(548)",
-            "LUI             t5, 0x55f(1375)",
-            "ADDIW           t5, t5, 0x791(1937)",
-            "SLLI            t5, t5, 0xc(12)",
-            "ADDI            t5, t5, 0x261(609)",
-            "SLLI            t5, t5, 0xc(12)",
-            "ADDI            t5, t5, 0x6f0(1776)",
             "ADDI            a0, sp, 0x0(0)",
-            "JALR            zero, t5, 0x0(0)"
+            "LD              t4, s11, 0x480(1152)",
+            "JALR            ra, t4, 0x0(0)"
         ]
     },
     "XXHash": {
-        "instruction_count": 159,
+        "instruction_count": 160,
         "expected_asm": [
             "SH3ADD          ra, a3, a5",
             "VSETIVLI        zero, 16, e8, m1, tu, mu",
@@ -896,12 +888,13 @@
             "SLT             t3, ra, a3",
             "XOR             s9, s9, t3",
             "ADDI            gp, t0, 0x0(0)",
-            "AUIPC           t6, 0xffffffea(-22)",
-            "JALR            zero, t6, 0x66c(1644)"
+            "LD              t6, s11, 0x488(1160)",
+            "LD              t6, t6, 0x88(136)",
+            "JALR            zero, t6, 0x0(0)"
         ]
     },
     "Baldur 2 FMV": {
-        "instruction_count": 1770,
+        "instruction_count": 1771,
         "expected_asm": [
             "ADDI            t0, s1, 0x0(0)",
             "ADDIW           t1, zero, 0xfffffff0(-16)",
@@ -2671,12 +2664,13 @@
             "LD              ra, s1, 0x0(0)",
             "ADDI            s1, s1, 0x8(8)",
             "ADDI            gp, ra, 0x0(0)",
-            "AUIPC           t6, 0xffffffe9(-23)",
-            "JALR            zero, t6, 0xfffffac0(-1344)"
+            "LD              t6, s11, 0x488(1160)",
+            "LD              t6, t6, 0x88(136)",
+            "JALR            zero, t6, 0x0(0)"
         ]
     },
     "dotnet rotate": {
-        "instruction_count": 3866,
+        "instruction_count": 3868,
         "expected_asm": [
             "ADD.UW          t0, a6, zero",
             "RORIW           ra, t0, 0x1b(27)",
@@ -6533,21 +6527,23 @@
             "SLT             t4, ra, t0",
             "XOR             s9, s9, t4",
             "XORI            ra, s7, 0x1(1)",
-            "BNE             zero, ra, 0x18(24)",
+            "BNE             zero, ra, 0x1c(28)",
             "LUI             t1, 0x1(1)",
             "ADDIW           t1, t1, 0xfffffc34(-972)",
             "ADD             gp, gp, t1",
-            "AUIPC           t6, 0xffffffe5(-27)",
-            "JALR            zero, t6, 0xfffffe68(-408)",
+            "LD              t6, s11, 0x488(1160)",
+            "LD              t6, t6, 0x88(136)",
+            "JALR            zero, t6, 0x0(0)",
             "LUI             t1, 0xfffb09a1(-325215)",
             "ADDIW           t1, t1, 0xffffffb3(-77)",
             "ADD             gp, gp, t1",
-            "AUIPC           t6, 0xffffffe5(-27)",
-            "JALR            zero, t6, 0xfffffe54(-428)"
+            "LD              t6, s11, 0x488(1160)",
+            "LD              t6, t6, 0x88(136)",
+            "JALR            zero, t6, 0x0(0)"
         ]
     },
     "7z block": {
-        "instruction_count": 114,
+        "instruction_count": 116,
         "expected_asm": [
             "LD              s0, a0, 0x0(0)",
             "LD              a1, a0, 0x28(40)",
@@ -6656,17 +6652,19 @@
             "XOR             s9, s9, t4",
             "ANDI            s9, s9, 0x1(1)",
             "XORI            ra, s5, 0x1(1)",
-            "BNE             zero, ra, 0x10(16)",
+            "BNE             zero, ra, 0x14(20)",
             "ADDI            gp, gp, 0x74(116)",
-            "AUIPC           t6, 0xffffffe5(-27)",
-            "JALR            zero, t6, 0xfffffc94(-876)",
+            "LD              t6, s11, 0x488(1160)",
+            "LD              t6, t6, 0x88(136)",
+            "JALR            zero, t6, 0x0(0)",
             "ADDI            gp, gp, 0x8b(139)",
-            "AUIPC           t6, 0xffffffe5(-27)",
-            "JALR            zero, t6, 0xfffffc88(-888)"
+            "LD              t6, s11, 0x488(1160)",
+            "LD              t6, t6, 0x88(136)",
+            "JALR            zero, t6, 0x0(0)"
         ]
     },
     "Outlast camera": {
-        "instruction_count": 236,
+        "instruction_count": 238,
         "expected_asm": [
             "LWU             s10, a0, 0x10(16)",
             "LD              s4, a0, 0x8(8)",
@@ -6898,16 +6896,18 @@
             "SLT             t1, ra, a4",
             "XOR             s9, s9, t1",
             "XORI            ra, s7, 0x1(1)",
-            "BNE             zero, ra, 0x10(16)",
+            "BNE             zero, ra, 0x14(20)",
             "ADDI            gp, gp, 0x16f(367)",
-            "AUIPC           t6, 0xffffffe5(-27)",
-            "JALR            zero, t6, 0xfffff8e0(-1824)",
-            "AUIPC           t6, 0xffffffe5(-27)",
-            "JALR            zero, t6, 0xfffff8d8(-1832)"
+            "LD              t6, s11, 0x488(1160)",
+            "LD              t6, t6, 0x88(136)",
+            "JALR            zero, t6, 0x0(0)",
+            "LD              t6, s11, 0x488(1160)",
+            "LD              t6, t6, 0x88(136)",
+            "JALR            zero, t6, 0x0(0)"
         ]
     },
     "Outlast camera 2": {
-        "instruction_count": 224,
+        "instruction_count": 226,
         "expected_asm": [
             "ADDI            ra, t0, 0x214(532)",
             "LHU             s6, ra, 0x0(0)",
@@ -7127,12 +7127,14 @@
             "VFADD.VV        v3, v3, v2, none",
             "OR              ra, s5, s7",
             "XORI            ra, ra, 0x1(1)",
-            "BNE             zero, ra, 0x10(16)",
+            "BNE             zero, ra, 0x14(20)",
             "ADDI            gp, gp, 0x160(352)",
-            "AUIPC           t6, 0xffffffe4(-28)",
-            "JALR            zero, t6, 0x55c(1372)",
-            "AUIPC           t6, 0xffffffe4(-28)",
-            "JALR            zero, t6, 0x554(1364)"
+            "LD              t6, s11, 0x488(1160)",
+            "LD              t6, t6, 0x88(136)",
+            "JALR            zero, t6, 0x0(0)",
+            "LD              t6, s11, 0x488(1160)",
+            "LD              t6, t6, 0x88(136)",
+            "JALR            zero, t6, 0x0(0)"
         ]
     }
 }

--- a/counts/SSSE3.json
+++ b/counts/SSSE3.json
@@ -158,10 +158,10 @@
     "660f3a0fd30a": {
         "instruction_count": 4,
         "expected_asm": [
-            "VSETIVLI        zero, 16, e8, m2, tu, mu",
-            "VMV.V.V         v26, v5",
-            "VSLIDEUP.VI     v26, v4, 0xfffffff0(-16), none",
-            "VSLIDEDOWN.VI   v4, v26, 0xa(10), none"
+            "VSETIVLI        zero, 16, e8, m1, tu, mu",
+            "VSLIDEDOWN.VI   v26, v5, 0xa(10), none",
+            "VSLIDEUP.VI     v26, v4, 0x6(6), none",
+            "VMV.V.V         v4, v26"
         ],
         "disassembly": "palignr xmm2, xmm3, 0x0A"
     },

--- a/src/felix86/common/process_lock.hpp
+++ b/src/felix86/common/process_lock.hpp
@@ -25,7 +25,6 @@ struct Semaphore {
     Semaphore();
 
     [[nodiscard]] SemaphoreGuard lock() {
-        assert(inner != SEM_FAILED);
         return SemaphoreGuard(&inner);
     }
 

--- a/src/felix86/common/state.hpp
+++ b/src/felix86/common/state.hpp
@@ -159,7 +159,8 @@ static_assert(sizeof(XmmReg) == 16);
     X(felix86_fxrstor)                                                                                                                               \
     X(felix86_pcmpxstrx)                                                                                                                             \
     X(felix86_mpsadbw)                                                                                                                               \
-    X(felix86_crash_and_burn)
+    X(felix86_crash_and_burn)                                                                                                                        \
+    X(felix86_exit_dispatcher)
 
 // TODO: Please make me standard layout type? offsetof warnings...
 struct ThreadState {

--- a/src/felix86/common/utility.cpp
+++ b/src/felix86/common/utility.cpp
@@ -9,6 +9,7 @@
 #include "felix86/common/state.hpp"
 #include "felix86/common/types.hpp"
 #include "felix86/common/utility.hpp"
+#include "felix86/emulator.hpp"
 #include "felix86/hle/cpuid.hpp"
 #include "felix86/v2/recompiler.hpp"
 #include "fmt/format.h"
@@ -1779,4 +1780,8 @@ std::string felix86_mountinfo() {
         rv += "\n";
     }
     return rv;
+}
+
+void felix86_exit_dispatcher(struct felix86_frame* frame) {
+    frame->state->recompiler->exitDispatcher(frame);
 }

--- a/src/felix86/common/utility.hpp
+++ b/src/felix86/common/utility.hpp
@@ -171,4 +171,6 @@ std::string disassemble_one(u64 address);
 
 void felix86_crash_and_burn();
 
+[[noreturn]] void felix86_exit_dispatcher(struct felix86_frame* frame);
+
 std::string felix86_mountinfo();

--- a/src/felix86/emulator.cpp
+++ b/src/felix86/emulator.cpp
@@ -218,10 +218,6 @@ void* Emulator::CompileNext(ThreadState* thread_state) {
     return (void*)next_block;
 }
 
-void Emulator::ExitDispatcher(felix86_frame* frame) {
-    frame->state->recompiler->exitDispatcher(frame);
-}
-
 std::pair<ExitReason, int> Emulator::Start() {
     ExitReason exit_reason;
     int exit_code;

--- a/src/felix86/emulator.hpp
+++ b/src/felix86/emulator.hpp
@@ -22,10 +22,6 @@ struct Emulator {
 
     static void StartTest(const TestConfig& config, u64 stack);
 
-    // The exit dispatcher function also restores the stack pointer to what it was before
-    // entering the dispatcher, so it can be called from anywhere
-    [[noreturn]] static void ExitDispatcher(felix86_frame* frame);
-
 private:
     [[nodiscard]] static std::pair<void*, size_t> setupMainStack(ThreadState* state);
 

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -681,7 +681,7 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
         if (g_config.calltrace_on_exit) {
             dump_states();
         }
-        Emulator::ExitDispatcher(frame);
+        felix86_exit_dispatcher(frame);
         UNREACHABLE();
         break;
     }
@@ -1047,7 +1047,7 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
         if (g_config.calltrace_on_exit) {
             dump_states();
         }
-        Emulator::ExitDispatcher(frame);
+        felix86_exit_dispatcher(frame);
         UNREACHABLE();
         break;
     }
@@ -1606,7 +1606,7 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
     }
     case felix86_riscv64_rt_sigreturn: {
         Signals::sigreturn(frame->state);
-        Emulator::ExitDispatcher(frame);
+        felix86_exit_dispatcher(frame);
         UNREACHABLE();
         break;
     }

--- a/src/felix86/hle/thunks.cpp
+++ b/src/felix86/hle/thunks.cpp
@@ -1070,7 +1070,7 @@ void* Thunks::generateTrampoline(Recompiler& rec, const char* name) {
 
     GuestToHostMarshaller marshaller(name, signature);
     marshaller.emitPrologue(as);
-    Recompiler::call(as, target);
+    rec.call(target);
     marshaller.emitEpilogue(as);
 
     return trampoline;
@@ -1084,7 +1084,7 @@ void* Thunks::generateTrampoline(Recompiler& rec, const char* name, const char* 
 
     GuestToHostMarshaller marshaller(name, signature);
     marshaller.emitPrologue(as);
-    Recompiler::call(as, host_ptr);
+    rec.call(host_ptr);
     marshaller.emitEpilogue(as);
 
     return trampoline;

--- a/src/felix86/repl.cpp
+++ b/src/felix86/repl.cpp
@@ -105,7 +105,7 @@ void compile(const std::string& input) {
     output.push_back(0x0F);
     output.push_back(0x0B);
 
-    std::unique_ptr<Recompiler> rec = std::make_unique<Recompiler>();
+    std::unique_ptr<Recompiler> rec = std::make_unique<Recompiler>(true);
     rec->setFlagMode(flag_mode);
     auto start = rec->getAssembler().GetCursorPointer();
     rec->compileSequence((u64)output.data());

--- a/src/felix86/tools/generate_instruction_count.cpp
+++ b/src/felix86/tools/generate_instruction_count.cpp
@@ -295,7 +295,7 @@ int main() {
     Extensions::Zicond = true;
     Handlers::initialize();
 
-    std::unique_ptr<Recompiler> rec_storage = std::make_unique<Recompiler>();
+    std::unique_ptr<Recompiler> rec_storage = std::make_unique<Recompiler>(true /* relocatable code */);
     Recompiler& rec = *rec_storage;
     nlohmann::ordered_json json;
 
@@ -1169,8 +1169,7 @@ int main() {
         x.pcmpeqd(xmm1, xmm10);
         x.movmskps(r14d, xmm1);
         x.xor_(r14d, 0x0F);
-        u8* curr = x.getCurr<u8*>();
-        x.jz((void*)(curr + 0xcafe));
+        x.ret();
     });
 
     gen_many(rec, "Crysis", json, [](Xbyak::CodeGenerator& x) {

--- a/src/felix86/v2/handlers.cpp
+++ b/src/felix86/v2/handlers.cpp
@@ -1619,9 +1619,8 @@ FAST_HANDLE(AND) {
 FAST_HANDLE(HLT) {
     rec.setExitReason(ExitReason::EXIT_REASON_HLT);
     rec.writebackState();
-    as.LI(t5, (u64)Emulator::ExitDispatcher);
     as.MV(a0, sp);
-    as.JR(t5);
+    rec.callPointer(offsetof(ThreadState, felix86_exit_dispatcher));
     rec.stopCompiling();
 }
 
@@ -11067,9 +11066,8 @@ FAST_HANDLE(INVLPG) {
     case INVLPG_GUEST_CODE_FINISHED: {
         rec.setExitReason(ExitReason::EXIT_REASON_GUEST_CODE_FINISHED);
         rec.writebackState();
-        as.LI(t5, (u64)Emulator::ExitDispatcher);
         as.MV(a0, sp);
-        as.JR(t5);
+        rec.callPointer(offsetof(ThreadState, felix86_exit_dispatcher));
         rec.stopCompiling();
         break;
     }


### PR DESCRIPTION
Add a mode in Recompiler which disables linking and AUIPC usage, and replace usages of LI(pointer) with loads from ThreadState+call. Makes instruction count generator/repl always generate the same code.