### PR TITLE
Massively reduce memory footprint

### DIFF
--- a/src/felix86/common/state.cpp
+++ b/src/felix86/common/state.cpp
@@ -3,7 +3,7 @@
 #include "felix86/common/state.hpp"
 #include "felix86/v2/recompiler.hpp"
 
-constexpr size_t trampoline_storage_size = 1024 * 1024;
+constexpr size_t trampoline_storage_size = 1024 * 512;
 
 void ThreadState::InitializeKey() {
     int result = pthread_key_create(&g_thread_state_key, [](void*) {});

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -16,11 +16,13 @@
 #include "fmt/format.h"
 
 // TODO: benchmark to find best arrangement?
+constexpr static u64 MB = 1024 * 1024;
+
 constexpr static u64 code_cache_sizes[] = {
-    8 * 1024 * 1024,
-    16 * 1024 * 1024,
-    32 * 1024 * 1024,
-    64 * 1042 * 1024,
+    4 * MB,
+    8 * MB,
+    16 * MB,
+    32 * MB,
 };
 
 constexpr static u64 code_cache_sizes_count = std::size(code_cache_sizes);
@@ -86,8 +88,8 @@ static u8* allocateCodeCache(size_t size) {
     void* address = MAP_FAILED;
     // If the program is allocated in 32-bit address space then it's not worth performing this optimization
     // as to not interfere with MAP_32BIT and because immediates can be made in 2 instructions
-    if (min > 4 * 1024 * 1024 && !g_mode32) {
-        min += 256 * 1024 * 1024;
+    if (min > 4 * MB && !g_mode32) {
+        min += 256 * MB;
         address = ::mmap((void*)min, max_code_cache_size, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
         if (address == MAP_FAILED) {
             WARN("Failed to allocate code cache near the program");

--- a/src/felix86/v2/recompiler.hpp
+++ b/src/felix86/v2/recompiler.hpp
@@ -11,9 +11,7 @@
 #include "felix86/common/types.hpp"
 #include "felix86/common/utility.hpp"
 
-constexpr int address_cache_bits = 20;
-
-constexpr static u64 jit_stack_size = 1024 * 1024;
+constexpr int address_cache_bits = 16;
 
 struct AddressCacheEntry {
     u64 host{}, guest{};


### PR DESCRIPTION
There was no noticeable performance improvement from having such a huge address cache. Also reduce max code cache size. Should reduce initial thread size by 15+1+4=20MiB and max code cache by 32MiB. Shaves off at least 2GiB from games like Genshin Impact that spawn a ton of threads.