### PR TITLE
Fix flags being wrongly optimized near shift by zero

### DIFF
--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -77,7 +77,7 @@ static bool flag_passthrough(ZydisMnemonic mnemonic, x86_ref_e flag) {
     case ZYDIS_MNEMONIC_SAR:
     case ZYDIS_MNEMONIC_ROL:
     case ZYDIS_MNEMONIC_ROR: {
-        return flag == X86_REF_CF || flag == X86_REF_OF;
+        return true;
     }
     default: {
         return false;

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -67,7 +67,6 @@ private:
 // Some instructions modify the flags conditionally or sometimes they don't modify them at all.
 // This needs to be marked as a usage of the flag as it can be passed through if they don't modify,
 // and previous instructions need to know that.
-// TODO: actually this might be unnecessary if Zydis doesn't mark these flags as modified, test it
 static bool flag_passthrough(ZydisMnemonic mnemonic, x86_ref_e flag) {
     switch (mnemonic) {
     case ZYDIS_MNEMONIC_SHL:

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -67,7 +67,7 @@ private:
 // Some instructions modify the flags conditionally or sometimes they don't modify them at all.
 // This needs to be marked as a usage of the flag as it can be passed through if they don't modify,
 // and previous instructions need to know that.
-static bool flag_passthrough(ZydisMnemonic mnemonic, x86_ref_e flag) {
+static bool flag_passthrough(ZydisMnemonic mnemonic) {
     switch (mnemonic) {
     case ZYDIS_MNEMONIC_SHL:
     case ZYDIS_MNEMONIC_SHLD:
@@ -2130,38 +2130,39 @@ void Recompiler::scanAhead(u64 rip) {
             u32 changed =
                 instruction.cpu_flags->modified | instruction.cpu_flags->set_0 | instruction.cpu_flags->set_1 | instruction.cpu_flags->undefined;
             u32 used = instruction.cpu_flags->tested;
+            bool passthrough = flag_passthrough(instruction.mnemonic);
 
-            if (used & ZYDIS_CPUFLAG_CF || flag_passthrough(instruction.mnemonic, X86_REF_CF)) {
+            if (used & ZYDIS_CPUFLAG_CF || passthrough) {
                 flag_access_cpazso[0].push_back({false, rip});
             } else if (changed & ZYDIS_CPUFLAG_CF) {
                 flag_access_cpazso[0].push_back({true, rip});
             }
 
-            if (used & ZYDIS_CPUFLAG_PF || flag_passthrough(instruction.mnemonic, X86_REF_PF)) {
+            if (used & ZYDIS_CPUFLAG_PF || passthrough) {
                 flag_access_cpazso[1].push_back({false, rip});
             } else if (changed & ZYDIS_CPUFLAG_PF) {
                 flag_access_cpazso[1].push_back({true, rip});
             }
 
-            if (used & ZYDIS_CPUFLAG_AF || flag_passthrough(instruction.mnemonic, X86_REF_AF)) {
+            if (used & ZYDIS_CPUFLAG_AF || passthrough) {
                 flag_access_cpazso[2].push_back({false, rip});
             } else if (changed & ZYDIS_CPUFLAG_AF) {
                 flag_access_cpazso[2].push_back({true, rip});
             }
 
-            if (used & ZYDIS_CPUFLAG_ZF || flag_passthrough(instruction.mnemonic, X86_REF_ZF)) {
+            if (used & ZYDIS_CPUFLAG_ZF || passthrough) {
                 flag_access_cpazso[3].push_back({false, rip});
             } else if (changed & ZYDIS_CPUFLAG_ZF) {
                 flag_access_cpazso[3].push_back({true, rip});
             }
 
-            if (used & ZYDIS_CPUFLAG_SF || flag_passthrough(instruction.mnemonic, X86_REF_SF)) {
+            if (used & ZYDIS_CPUFLAG_SF || passthrough) {
                 flag_access_cpazso[4].push_back({false, rip});
             } else if (changed & ZYDIS_CPUFLAG_SF) {
                 flag_access_cpazso[4].push_back({true, rip});
             }
 
-            if (used & ZYDIS_CPUFLAG_OF || flag_passthrough(instruction.mnemonic, X86_REF_OF)) {
+            if (used & ZYDIS_CPUFLAG_OF || passthrough) {
                 flag_access_cpazso[5].push_back({false, rip});
             } else if (changed & ZYDIS_CPUFLAG_OF) {
                 flag_access_cpazso[5].push_back({true, rip});
@@ -2204,6 +2205,11 @@ void Recompiler::scanAhead(u64 rip) {
                             u32 changed = instruction_ahead.cpu_flags->modified | instruction_ahead.cpu_flags->set_0 |
                                           instruction_ahead.cpu_flags->set_1 | instruction_ahead.cpu_flags->undefined;
                             u32 used = instruction_ahead.cpu_flags->tested;
+                            if (flag_passthrough(mnemonic)) {
+                                // For now, instructions that conditionally modify flags will act as if they use flags
+                                // This is necessary so that any block that jumps to a e.g. shift instruction will still emit its final flags
+                                used = flags_we_care_about;
+                            }
 
                             u32 used_not_previously_changed = used & ~changed_this_block;
                             used_this_block |= used_not_previously_changed;


### PR DESCRIPTION
Shifts don't touch the flags if the shift amount is zero, which means that any previous flag calculating instructions need to emit flags. Tests to be added in a commit soon.

Fixes #474 