### PR TITLE
CMake: Use cache variable for GIT_HASH

### DIFF
--- a/CheckGit.cmake
+++ b/CheckGit.cmake
@@ -1,4 +1,26 @@
-set(CURRENT_LIST_DIR ${CMAKE_CURRENT_LIST_DIR})
+find_package(Git QUIET)
+
+function(get_git_hash variable)
+    if(NOT GIT_FOUND)
+        set(${variable} "GIT-NOTFOUND" PARENT_SCOPE)
+        return()
+    endif()
+
+    execute_process(COMMAND
+        "${GIT_EXECUTABLE}" rev-parse --short HEAD
+        WORKING_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}"
+        RESULT_VARIABLE res
+        OUTPUT_VARIABLE out
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET)
+
+    if(NOT res EQUAL 0)
+        set(out "${out}-${res}-NOTFOUND")
+    endif()
+
+    set(${variable} "${out}" PARENT_SCOPE)
+endfunction()
+
 if (NOT DEFINED pre_configure_dir)
     set(pre_configure_dir ${CMAKE_CURRENT_LIST_DIR}/src/felix86/common)
 endif ()
@@ -10,73 +32,33 @@ endif ()
 set(pre_configure_file ${pre_configure_dir}/git_version.cpp.in)
 set(post_configure_file ${post_configure_dir}/git_version.cpp)
 
-function(CheckGitWrite git_hash)
-    file(WRITE ${CMAKE_BINARY_DIR}/git-state.txt ${git_hash})
-endfunction()
-
-function(CheckGitRead git_hash)
-    if (EXISTS ${CMAKE_BINARY_DIR}/git-state.txt)
-        file(STRINGS ${CMAKE_BINARY_DIR}/git-state.txt CONTENT)
-        LIST(GET CONTENT 0 var)
-
-        set(${git_hash} ${var} PARENT_SCOPE)
-    endif ()
-endfunction()
-
 function(CheckGitVersion)
-    execute_process(
-        COMMAND git rev-parse --is-inside-work-tree
-        WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-        OUTPUT_VARIABLE IS_REPO
-        OUTPUT_STRIP_TRAILING_WHITESPACE
-        ERROR_QUIET
-    )
-
-    if (NOT IS_REPO STREQUAL "true")
-        set(GIT_HASH "?")
-        set(GIT_HASH_CACHE "INVALID")
-    else()
-        # Get the latest abbreviated commit hash of the working branch
-        execute_process(
-            COMMAND git log -1 --format=%h
-            WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR}
-            OUTPUT_VARIABLE GIT_HASH
-            OUTPUT_STRIP_TRAILING_WHITESPACE
-        )
-
-        CheckGitRead(GIT_HASH_CACHE)
-    endif()
+    get_git_hash(GIT_HASH)
 
     if (NOT EXISTS ${post_configure_dir})
         file(MAKE_DIRECTORY ${post_configure_dir})
     endif ()
 
-    if (NOT DEFINED GIT_HASH_CACHE)
-        set(GIT_HASH_CACHE "INVALID")
-    endif ()
-
     # Only update the git_version.cpp if the hash has changed. This will
     # prevent us from rebuilding the project more than we need to.
-    if (NOT "${GIT_HASH}" STREQUAL "${GIT_HASH_CACHE}" OR NOT EXISTS "${post_configure_file}")
-        # Set che GIT_HASH_CACHE variable the next build won't have
+    if (NOT GIT_HASH STREQUAL GIT_HASH_CACHE OR
+        NOT EXISTS "${post_configure_file}")
+        # Set the GIT_HASH_CACHE variable so the next build won't have
         # to regenerate the source file.
-        CheckGitWrite(${GIT_HASH})
+        set(GIT_HASH_CACHE "${GIT_HASH}" CACHE INTERNAL "" FORCE)
 
         configure_file(${pre_configure_file} ${post_configure_file} @ONLY)
-    endif ()
-
+    endif()
 endfunction()
 
 function(CheckGitSetup)
-
     add_custom_target(AlwaysCheckGit COMMAND ${CMAKE_COMMAND}
         -DRUN_CHECK_GIT_VERSION=1
         -Dpre_configure_dir=${pre_configure_dir}
-        -Dpost_configure_file=${post_configure_dir}
+        -Dpost_configure_dir=${post_configure_dir}
         -DGIT_HASH_CACHE=${GIT_HASH_CACHE}
-        -P ${CURRENT_LIST_DIR}/CheckGit.cmake
-        BYPRODUCTS ${post_configure_file}
-        )
+        -P ${CMAKE_CURRENT_LIST_DIR}/CheckGit.cmake
+        BYPRODUCTS ${post_configure_file})
 
     add_library(git_version ${CMAKE_BINARY_DIR}/generated/git_version.cpp)
     target_include_directories(git_version PUBLIC ${CMAKE_BINARY_DIR}/generated)

--- a/CheckGit.cmake
+++ b/CheckGit.cmake
@@ -43,7 +43,6 @@ function(CheckGitVersion)
         set(GIT_HASH UNKNOWN)
     endif()
 
-
     # Only update the git_version.cpp if the hash has changed. This will
     # prevent us from rebuilding the project more than we need to.
     if (NOT GIT_HASH STREQUAL GIT_HASH_CACHE OR

--- a/CheckGit.cmake
+++ b/CheckGit.cmake
@@ -23,11 +23,11 @@ endfunction()
 
 if (NOT DEFINED pre_configure_dir)
     set(pre_configure_dir ${CMAKE_CURRENT_LIST_DIR}/src/felix86/common)
-endif ()
+endif()
 
 if (NOT DEFINED post_configure_dir)
     set(post_configure_dir ${CMAKE_BINARY_DIR}/generated)
-endif ()
+endif()
 
 set(pre_configure_file ${pre_configure_dir}/git_version.cpp.in)
 set(post_configure_file ${post_configure_dir}/git_version.cpp)
@@ -37,7 +37,12 @@ function(CheckGitVersion)
 
     if (NOT EXISTS ${post_configure_dir})
         file(MAKE_DIRECTORY ${post_configure_dir})
-    endif ()
+    endif()
+
+    if (NOT GIT_HASH)
+        set(GIT_HASH UNKNOWN)
+    endif()
+
 
     # Only update the git_version.cpp if the hash has changed. This will
     # prevent us from rebuilding the project more than we need to.
@@ -70,5 +75,4 @@ endfunction()
 # This is used to run this function from an external cmake process.
 if (RUN_CHECK_GIT_VERSION)
     CheckGitVersion()
-endif ()
-
+endif()


### PR DESCRIPTION
Rather than dealing with a file; also does misc. cleanups and removes
unnecessary checks

Signed-off-by: crueter <crueter@eden-emu.dev>
