### PR TITLE
Allow running executable-only files, close leaked fds

### DIFF
--- a/src/felix86/common/elf.cpp
+++ b/src/felix86/common/elf.cpp
@@ -5,6 +5,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/auxv.h>
 #include <sys/mman.h>
 #include <sys/personality.h>
 #include <sys/prctl.h>
@@ -303,20 +304,21 @@ Elf::~Elf() {
 }
 
 void Elf::Load(const std::filesystem::path& path) {
-    if (!std::filesystem::exists(path)) {
-        WARN("File %s does not exist", path.c_str());
-        return;
-    }
-
-    if (!std::filesystem::is_regular_file(path)) {
-        WARN("File %s is not a regular file", path.c_str());
-        return;
-    }
-
     u64 lowest_vaddr = 0xFFFFFFFFFFFFFFFF;
     u64 highest_vaddr = 0;
 
     FILE* file = fopen(path.c_str(), "rb");
+    if (!file && path == g_executable_path_absolute) {
+        u64 fd = getauxval(AT_EXECFD);
+        if (fd == 0 && errno == ENOENT) {
+            WARN("Failed to open ELF at %s and no EXECFD", path.c_str());
+            if (!g_config.binfmt_misc_installed) {
+                WARN("If this is an execute-only file you need to install felix86 in binfmt_misc");
+            }
+        }
+
+        file = fdopen(fd, "r");
+    }
     int fd = fileno(file);
 
     if (!file) {
@@ -567,6 +569,18 @@ void Elf::Load(const std::filesystem::path& path) {
 
 Elf::PeekResult Elf::Peek(const std::filesystem::path& path) {
     FILE* file = fopen(path.c_str(), "rb");
+    if (!file && path == g_executable_path_absolute) {
+        u64 fd = getauxval(AT_EXECFD);
+        if (fd == 0 && errno == ENOENT) {
+            WARN("Failed to open ELF at %s and no EXECFD", path.c_str());
+            if (!g_config.binfmt_misc_installed) {
+                WARN("If this is an execute-only file you need to install felix86 in binfmt_misc");
+            }
+        }
+
+        file = fdopen(fd, "r");
+    }
+
     if (!file) {
         VERBOSE("Failed to open file %s: %s", path.c_str(), strerror(errno));
         return PeekResult::NotElf;

--- a/src/felix86/common/elf.cpp
+++ b/src/felix86/common/elf.cpp
@@ -307,23 +307,24 @@ void Elf::Load(const std::filesystem::path& path) {
     u64 lowest_vaddr = 0xFFFFFFFFFFFFFFFF;
     u64 highest_vaddr = 0;
 
+    bool open_execfd = false;
     FILE* file = fopen(path.c_str(), "rb");
     if (!file && path == g_executable_path_absolute) {
         u64 fd = getauxval(AT_EXECFD);
         if (fd == 0 && errno == ENOENT) {
-            WARN("Failed to open ELF at %s and no EXECFD", path.c_str());
             if (!g_config.binfmt_misc_installed) {
                 WARN("If this is an execute-only file you need to install felix86 in binfmt_misc");
             }
+            ERROR("Failed to open ELF at %s and no EXECFD", path.c_str());
         }
 
         file = fdopen(fd, "r");
+        open_execfd = true;
     }
-    int fd = fileno(file);
-
     if (!file) {
         ERROR("Failed to open file %s", path.c_str());
     }
+    int fd = fileno(file);
 
     fseek(file, 0, SEEK_END);
     u64 size = ftell(file);
@@ -562,12 +563,17 @@ void Elf::Load(const std::filesystem::path& path) {
     phnum = ehdr.phnum();
     phent = ehdr.phentsize();
 
-    fclose(file);
+    if (!open_execfd) {
+        fclose(file);
+    } else {
+        // Don't close our execfd here, we close it right before Threads::StartThread
+    }
 
     ok = true;
 }
 
 Elf::PeekResult Elf::Peek(const std::filesystem::path& path) {
+    bool open_execfd = false;
     FILE* file = fopen(path.c_str(), "rb");
     if (!file && path == g_executable_path_absolute) {
         u64 fd = getauxval(AT_EXECFD);
@@ -579,6 +585,7 @@ Elf::PeekResult Elf::Peek(const std::filesystem::path& path) {
         }
 
         file = fdopen(fd, "r");
+        open_execfd = true;
     }
 
     if (!file) {
@@ -593,14 +600,23 @@ Elf::PeekResult Elf::Peek(const std::filesystem::path& path) {
     }
 
     if (e_ident[0] != 0x7F || e_ident[1] != 'E' || e_ident[2] != 'L' || e_ident[3] != 'F') {
-        fclose(file);
+        if (!open_execfd) {
+            fclose(file);
+        } else {
+            // Don't close our execfd here, we close it right before Threads::StartThread
+        }
         return PeekResult::NotElf;
     }
 
     bool mode32 = e_ident[4] == ELFCLASS32;
     fseek(file, 0, SEEK_SET);
     Elf_Ehdr ehdr(mode32, file);
-    fclose(file);
+
+    if (!open_execfd) {
+        fclose(file);
+    } else {
+        // Don't close our execfd here, we close it right before Threads::StartThread
+    }
 
     if (ehdr.machine() != EM_386 && ehdr.machine() != EM_X86_64) {
         return PeekResult::NotElf;

--- a/src/felix86/common/log.cpp
+++ b/src/felix86/common/log.cpp
@@ -50,6 +50,8 @@ void Logger::startServer(bool detach) {
             prctl(PR_SET_PDEATHSIG, SIGTERM);
             serverLoop(fd);
         } else {
+            // Close the log file from this side
+            ASSERT(close(fd) == 0);
             // Open write end of pipe -- we need to do it here otherwise the thing will hang (both ends need to be opened simultaneously)
             g_output_fd = open(g_pipe_name.c_str(), O_WRONLY, 0644);
             ASSERT(g_output_fd > 0);

--- a/src/felix86/common/script.cpp
+++ b/src/felix86/common/script.cpp
@@ -1,10 +1,21 @@
-#include <climits>
 #include <cstring>
+#include <sys/auxv.h>
 #include "felix86/common/log.hpp"
 #include "felix86/common/script.hpp"
 
 Script::PeekResult Script::Peek(const std::filesystem::path& path) {
     FILE* file = fopen(path.c_str(), "r");
+    if (!file && path == g_executable_path_absolute) {
+        u64 fd = getauxval(AT_EXECFD);
+        if (fd == 0 && errno == ENOENT) {
+            WARN("Failed to open ELF at %s and no EXECFD", path.c_str());
+            if (!g_config.binfmt_misc_installed) {
+                WARN("If this is an execute-only file you need to install felix86 in binfmt_misc");
+            }
+        }
+
+        file = fdopen(fd, "r");
+    }
 
     if (!file) {
         ERROR("Failed to open file %s", path.c_str());
@@ -39,6 +50,17 @@ Script::PeekResult Script::Peek(const std::filesystem::path& path) {
 
 Script::Script(const std::filesystem::path& script) {
     FILE* file = fopen(script.c_str(), "r");
+    if (!file && script == g_executable_path_absolute) {
+        u64 fd = getauxval(AT_EXECFD);
+        if (fd == 0 && errno == ENOENT) {
+            WARN("Failed to open ELF at %s and no EXECFD", script.c_str());
+            if (!g_config.binfmt_misc_installed) {
+                WARN("If this is an execute-only file you need to install felix86 in binfmt_misc");
+            }
+        }
+
+        file = fdopen(fd, "r");
+    }
 
     if (!file) {
         ERROR("Failed to open file %s", script.c_str());

--- a/src/felix86/common/script.cpp
+++ b/src/felix86/common/script.cpp
@@ -5,6 +5,7 @@
 
 Script::PeekResult Script::Peek(const std::filesystem::path& path) {
     FILE* file = fopen(path.c_str(), "r");
+    bool open_execfd = false;
     if (!file && path == g_executable_path_absolute) {
         u64 fd = getauxval(AT_EXECFD);
         if (fd == 0 && errno == ENOENT) {
@@ -15,6 +16,7 @@ Script::PeekResult Script::Peek(const std::filesystem::path& path) {
         }
 
         file = fdopen(fd, "r");
+        open_execfd = true;
     }
 
     if (!file) {
@@ -30,7 +32,11 @@ Script::PeekResult Script::Peek(const std::filesystem::path& path) {
     u8 data[PATH_MAX];
     size = std::min((size_t)PATH_MAX, size);
     size_t size_read = fread(data, 1, size, file);
-    fclose(file);
+    if (!open_execfd) {
+        fclose(file);
+    } else {
+        // Don't close our execfd here, we close it right before Threads::StartThread
+    }
 
     if (size_read != size) {
         ERROR("Failed to read file %s", path.c_str());
@@ -49,6 +55,7 @@ Script::PeekResult Script::Peek(const std::filesystem::path& path) {
 }
 
 Script::Script(const std::filesystem::path& script) {
+    bool open_execfd = false;
     FILE* file = fopen(script.c_str(), "r");
     if (!file && script == g_executable_path_absolute) {
         u64 fd = getauxval(AT_EXECFD);
@@ -60,6 +67,7 @@ Script::Script(const std::filesystem::path& script) {
         }
 
         file = fdopen(fd, "r");
+        open_execfd = true;
     }
 
     if (!file) {
@@ -76,7 +84,11 @@ Script::Script(const std::filesystem::path& script) {
     fseek(file, 2, SEEK_SET); // skip #!
     size = std::min((size_t)PATH_MAX, size - 2);
     size_t size_read = fread(data, 1, size, file);
-    fclose(file);
+    if (!open_execfd) {
+        fclose(file);
+    } else {
+        // Don't close our execfd here, we close it right before Threads::StartThread
+    }
 
     if (size_read != size) {
         ERROR("Failed to read file %s", script.c_str());

--- a/src/felix86/emulator.cpp
+++ b/src/felix86/emulator.cpp
@@ -7,6 +7,7 @@
 #include <fmt/format.h>
 #include <linux/prctl.h>
 #include <stdlib.h>
+#include <sys/auxv.h>
 #include <sys/mman.h>
 #include <sys/prctl.h>
 #include <sys/random.h>
@@ -308,6 +309,10 @@ void Emulator::Start() {
 
     VERBOSE("Entering main thread :)");
 
+    u64 fd = getauxval(AT_EXECFD);
+    if (fd != 0 || errno != ENOENT /* it's possible fd==0 is the execfd if all other fds are closed */) {
+        close(fd);
+    }
     Threads::StartThread(main_state);
     UNREACHABLE();
 }

--- a/src/felix86/hle/fd.cpp
+++ b/src/felix86/hle/fd.cpp
@@ -112,6 +112,7 @@ int FD::moveToHighNumber(int fd) {
             // We can use this FD
             int new_fd = ::dup2(fd, high_fd);
             ASSERT_MSG(new_fd > 0, "Failed to duplicate fd %d to %d with error %s", fd, high_fd, strerror(errno));
+            close(fd);
             return new_fd;
         }
         high_fd++;

--- a/src/felix86/hle/fd.cpp
+++ b/src/felix86/hle/fd.cpp
@@ -112,7 +112,7 @@ int FD::moveToHighNumber(int fd) {
             // We can use this FD
             int new_fd = ::dup2(fd, high_fd);
             ASSERT_MSG(new_fd > 0, "Failed to duplicate fd %d to %d with error %s", fd, high_fd, strerror(errno));
-            close(fd);
+            ::close(fd);
             return new_fd;
         }
         high_fd++;

--- a/src/felix86/hle/filesystem.cpp
+++ b/src/felix86/hle/filesystem.cpp
@@ -846,12 +846,12 @@ int Filesystem::openatInternal(int fd, const char* filename, int flags, u64 mode
     int opened_fd = ::syscall(SYS_openat, fd, filename, flags, mode);
     if (opened_fd != -1) {
         struct statx stat;
-        ASSERT(statx(opened_fd, "", AT_EMPTY_PATH, STATX_TYPE | STATX_INO | STATX_MNT_ID, &stat) == 0);
+        ASSERT(::statx(opened_fd, "", AT_EMPTY_PATH, STATX_TYPE | STATX_INO | STATX_MNT_ID, &stat) == 0);
         for (int i = 0; i < EMULATED_NODE_COUNT; i++) {
             EmulatedNode& node = emulated_nodes[i];
             if (statx_inode_same(&stat, &node.stat)) {
                 // This is one of our emulated files, close the opened fd and replace it with our own
-                close(opened_fd);
+                ::close(opened_fd);
                 int new_fd = node.open_func(filename, flags);
                 ASSERT_MSG(new_fd >= 0, "Our emulated fd has a negative number: %d", new_fd);
                 return new_fd;
@@ -1164,12 +1164,12 @@ FdPath Filesystem::resolveImpl(int fd, const char* path, bool resolve_final) {
                 int result2_error = errno;
 
                 // TODO: maybe optimize some cases using close_range
-                close(dirfd);
+                ::close(dirfd);
                 if (result1 > 0) {
-                    close(result1);
+                    ::close(result1);
                 }
                 if (result2 > 0) {
-                    close(result2);
+                    ::close(result2);
                 }
 
                 if (result1 > 0 && result2 > 0) {

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -498,8 +498,11 @@ int main(int argc, char* argv[]) {
         g_params.argv[0] = argv0_original;
     } else {
         ASSERT(!g_execve_process);
-        replace_all(g_params.argv[0], g_config.rootfs_path, "");
+        if (g_params.argv[0].find(g_config.rootfs_path) == 0) {
+            replace_all(g_params.argv[0], g_config.rootfs_path, "");
+        }
     }
+    VERBOSE("Arg[0]: %s", g_params.argv[0].c_str());
 
     std::string args = "Arguments: ";
     for (const auto& arg : g_params.argv) {

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -448,13 +448,7 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
 
 static struct argp argp = {options, parse_opt, args_doc, doc};
 
-void pauseme(int i) {
-    printf("%d\n", getpid());
-    pause();
-}
-
 int main(int argc, char* argv[]) {
-    signal(SIGSEGV, pauseme);
     if (getenv("__FELIX86_TEST_BINFMT_MISC")) {
         // This shouldn't be printed as when we run /bin/env in detect_binfmt_misc we mute stdout and stderr
         WARN("__FELIX86_TEST_BINFMT_MISC was detected, if you see this then something is wrong");

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -448,6 +448,10 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
 static struct argp argp = {options, parse_opt, args_doc, doc};
 
 int main(int argc, char* argv[]) {
+    for (int i = 0; i < argc; i++) {
+        printf("%s\n", argv[i]);
+    }
+
     if (getenv("__FELIX86_TEST_BINFMT_MISC")) {
         // This shouldn't be printed as when we run /bin/env in detect_binfmt_misc we mute stdout and stderr
         WARN("__FELIX86_TEST_BINFMT_MISC was detected, if you see this then something is wrong");

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -502,7 +502,6 @@ int main(int argc, char* argv[]) {
             replace_all(g_params.argv[0], g_config.rootfs_path, "");
         }
     }
-    VERBOSE("Arg[0]: %s", g_params.argv[0].c_str());
 
     std::string args = "Arguments: ";
     for (const auto& arg : g_params.argv) {

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -5,6 +5,7 @@
 #include <fmt/format.h>
 #include <grp.h>
 #include <spawn.h>
+#include <sys/auxv.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -448,10 +449,8 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
 static struct argp argp = {options, parse_opt, args_doc, doc};
 
 int main(int argc, char* argv[]) {
-    for (int i = 0; i <= argc; i++) {
-        printf("%s\n", argv[i]);
-    }
-
+    unsigned long fd = getauxval(AT_EXECFD);
+    printf("%d\n", fd);
     if (getenv("__FELIX86_TEST_BINFMT_MISC")) {
         // This shouldn't be printed as when we run /bin/env in detect_binfmt_misc we mute stdout and stderr
         WARN("__FELIX86_TEST_BINFMT_MISC was detected, if you see this then something is wrong");

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -448,7 +448,7 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
 static struct argp argp = {options, parse_opt, args_doc, doc};
 
 int main(int argc, char* argv[]) {
-    for (int i = 0; i < argc; i++) {
+    for (int i = 0; i <= argc; i++) {
         printf("%s\n", argv[i]);
     }
 

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -448,9 +448,13 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
 
 static struct argp argp = {options, parse_opt, args_doc, doc};
 
+void pauseme(int i) {
+    printf("%d\n", getpid());
+    pause();
+}
+
 int main(int argc, char* argv[]) {
-    unsigned long fd = getauxval(AT_EXECFD);
-    printf("%d\n", fd);
+    signal(SIGSEGV, pauseme);
     if (getenv("__FELIX86_TEST_BINFMT_MISC")) {
         // This shouldn't be printed as when we run /bin/env in detect_binfmt_misc we mute stdout and stderr
         WARN("__FELIX86_TEST_BINFMT_MISC was detected, if you see this then something is wrong");


### PR DESCRIPTION
Allows running executable-only files when binfmt_misc is installed using the passed file descriptor.
Closes that descriptor and the duplicated fakemount fds and the log file fd before running the program.

Fixes #395 