### PR TITLE
Move ThreadState from `s11` to `gp`

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,6 +47,11 @@ if (CMAKE_SYSTEM_PROCESSOR MATCHES "riscv64")
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -march=rv64gcv_zicsr_zifencei -mno-relax")
         set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -march=rv64gcv_zicsr_zifencei -mno-relax")
     endif()
+
+    # Just an extra layer of making sure the compiler doesn't decide to use GP as an allocatable reg
+    # -mno-relax should be enough but you never know
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -ffixed-gp")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -ffixed-gp")
 endif()
 
 

--- a/src/felix86/common/global.cpp
+++ b/src/felix86/common/global.cpp
@@ -33,7 +33,6 @@ u64 g_current_brk = 0;
 u64 g_current_brk_size = 0;
 u64 g_dispatcher_exit_count = 0;
 std::unordered_map<u64, std::vector<u64>> g_breakpoints{};
-pthread_key_t g_thread_state_key = -1;
 ProcessGlobals g_process_globals{};
 std::unique_ptr<Mapper> g_mapper{};
 std::unique_ptr<GDBJIT> g_gdbjit;
@@ -499,8 +498,6 @@ void initialize_globals() {
 
         LOG("Extensions enabled for the recompiler: %s", extensions.c_str());
     }
-
-    ThreadState::InitializeKey();
 
     g_fs = std::make_unique<Filesystem>();
     g_mapper = std::make_unique<Mapper>();

--- a/src/felix86/common/global.hpp
+++ b/src/felix86/common/global.hpp
@@ -80,7 +80,6 @@ extern u64 g_interpreter_start, g_interpreter_end;
 extern u64 g_executable_start, g_executable_end;
 extern const char* g_git_hash;
 extern std::unordered_map<u64, std::vector<u64>> g_breakpoints;
-extern pthread_key_t g_thread_state_key;
 extern u64 g_guest_auxv;
 extern size_t g_guest_auxv_size;
 extern bool g_execve_process;

--- a/src/felix86/common/state.cpp
+++ b/src/felix86/common/state.cpp
@@ -5,12 +5,11 @@
 
 constexpr size_t trampoline_storage_size = 1024 * 512;
 
-void ThreadState::InitializeKey() {
-    int result = pthread_key_create(&g_thread_state_key, [](void*) {});
-    if (result != 0) {
-        ERROR("Failed to create thread state key: %s", strerror(result));
-        exit(1);
-    }
+__attribute__((naked)) static void set_thread_state(ThreadState* state) {
+    asm volatile(R"(
+        mv gp, a0
+        ret
+    )");
 }
 
 ThreadState* ThreadState::Create(ThreadState* copy_state) {
@@ -77,15 +76,17 @@ ThreadState* ThreadState::Create(ThreadState* copy_state) {
 
     auto lock = g_process_globals.states_lock.lock();
     g_process_globals.states.push_back(state);
-    ASSERT(g_thread_state_key != (pthread_key_t)-1);
-    ASSERT(pthread_getspecific(g_thread_state_key) == nullptr);
-    pthread_setspecific(g_thread_state_key, state);
+    set_thread_state(state);
     return state;
 }
 
-ThreadState* ThreadState::Get() {
-    return (ThreadState*)pthread_getspecific(g_thread_state_key);
+__attribute__((naked)) ThreadState* ThreadState::Get() {
+    asm volatile(R"(
+        mv a0, gp
+        ret
+    )");
 }
+static_assert(Recompiler::threadStatePointer() == gp);
 
 void ThreadState::Destroy(ThreadState* state) {
     auto lock = g_process_globals.states_lock.lock();
@@ -93,7 +94,7 @@ void ThreadState::Destroy(ThreadState* state) {
     if (it != g_process_globals.states.end()) {
         g_process_globals.states.erase(it);
     } else {
-        WARN("Thread state %ld not found in global list", state->tid);
+        WARN("Thread state %ld not found in global list", gettid());
     }
     munmap(state->riscv_trampoline_storage_start, trampoline_storage_size);
     munmap(state->x86_trampoline_storage_start, trampoline_storage_size);

--- a/src/felix86/common/state.hpp
+++ b/src/felix86/common/state.hpp
@@ -212,7 +212,6 @@ struct ThreadState {
 
     pid_t* clear_tid_address = nullptr;
     pthread_t thread{}; // The pthread this state belongs to
-    u64 tid{};
     stack_t alt_stack{};
     bool cpuid_bit{}; // stupid rflags bit that is modifiable when cpuid is present, so we need to store its state here. SDL2 modifies it to
                       // check presence of cpuid... on x86-64 processors... lol...
@@ -427,8 +426,6 @@ struct ThreadState {
         flags |= of << 11;
         return flags;
     }
-
-    static void InitializeKey();
 
     static ThreadState* Create(ThreadState* copy_state = nullptr);
 

--- a/src/felix86/common/utility.cpp
+++ b/src/felix86/common/utility.cpp
@@ -551,7 +551,7 @@ void dump_states() {
     auto& states = g_process_globals.states;
     int i = 0;
     for (auto& state : states) {
-        dprintf(g_output_fd, ANSI_COLOR_RED "State %d (%ld):" ANSI_COLOR_RESET "\n", i, state->tid);
+        dprintf(g_output_fd, ANSI_COLOR_RED "State %d (%ld):" ANSI_COLOR_RESET "\n", i, gettid());
 
         if (g_config.calltrace) {
             auto it = state->recompiler->getCalltrace().rbegin();
@@ -797,7 +797,7 @@ void push_calltrace(ThreadState* state, u64 address) {
     }
 
     if (g_print_all_calls) {
-        dprintf(g_output_fd, "Thread %ld calling: ", state->tid);
+        dprintf(g_output_fd, "Thread %d calling: ", gettid());
         print_address(state->rip);
     }
 }
@@ -808,7 +808,7 @@ void pop_calltrace(ThreadState* state) {
     }
 
     if (g_print_all_calls) {
-        dprintf(g_output_fd, "Thread %ld returning: ", state->tid);
+        dprintf(g_output_fd, "Thread %d returning: ", gettid());
         print_address(state->rip);
     }
 

--- a/src/felix86/hle/abi.cpp
+++ b/src/felix86/hle/abi.cpp
@@ -155,7 +155,7 @@ void GuestToHostMarshaller::emitPrologue(biscuit::Assembler& as) {
 
     if (g_config.print_thunks) {
         biscuit::Label after;
-        as.MV(a0, s11);
+        as.MV(a0, Recompiler::threadStatePointer());
         as.LI(t0, (u64)my_printer);
         as.AUIPC(a1, 0);
         as.ADDI(a1, a1, 16);
@@ -469,52 +469,11 @@ void* ABIMadness::hostToGuestTrampoline(const char* signature, const void* guest
     void* trampoline = as.GetCursorPointer();
     as.ADDI(sp, sp, -32);
     as.SD(ra, 24, sp);
-    as.SD(s11, 0, sp);
     as.SD(s10, 8, sp);
 
-    biscuit::GPR thread_state_pointer = s11;
+    // Since ThreadState is always in gp, we can just access it here
+    biscuit::GPR thread_state_pointer = Recompiler::threadStatePointer();
     biscuit::GPR guest_stack_pointer = t1;
-
-    // ThreadState* in s11, RSP in t1
-    // This is yucky... we need to store all of our saved registers to get the ThreadState at runtime
-    // We can't just call ThreadState::Get because it will ruin our arguments.
-    as.ADDI(sp, sp, -16 * 8);
-    as.SD(a0, 0 * 8, sp);
-    as.SD(a1, 1 * 8, sp);
-    as.SD(a2, 2 * 8, sp);
-    as.SD(a3, 3 * 8, sp);
-    as.SD(a4, 4 * 8, sp);
-    as.SD(a5, 5 * 8, sp);
-    as.SD(a6, 6 * 8, sp);
-    as.SD(a7, 7 * 8, sp);
-    as.FSD(fa0, 8 * 8, sp);
-    as.FSD(fa1, 9 * 8, sp);
-    as.FSD(fa2, 10 * 8, sp);
-    as.FSD(fa3, 11 * 8, sp);
-    as.FSD(fa4, 12 * 8, sp);
-    as.FSD(fa5, 13 * 8, sp);
-    as.FSD(fa6, 14 * 8, sp);
-    as.FSD(fa7, 15 * 8, sp);
-    as.LI(t1, (u64)ThreadState::Get);
-    as.JALR(t1);
-    as.MV(thread_state_pointer, a0);
-    as.LD(a0, 0 * 8, sp);
-    as.LD(a1, 1 * 8, sp);
-    as.LD(a2, 2 * 8, sp);
-    as.LD(a3, 3 * 8, sp);
-    as.LD(a4, 4 * 8, sp);
-    as.LD(a5, 5 * 8, sp);
-    as.LD(a6, 6 * 8, sp);
-    as.LD(a7, 7 * 8, sp);
-    as.FLD(fa0, 8 * 8, sp);
-    as.FLD(fa1, 9 * 8, sp);
-    as.FLD(fa2, 10 * 8, sp);
-    as.FLD(fa3, 11 * 8, sp);
-    as.FLD(fa4, 12 * 8, sp);
-    as.FLD(fa5, 13 * 8, sp);
-    as.FLD(fa6, 14 * 8, sp);
-    as.FLD(fa7, 15 * 8, sp);
-    as.ADDI(sp, sp, 16 * 8);
 
     as.LD(guest_stack_pointer, offsetof(ThreadState, gprs) + (X86_REF_RSP - X86_REF_RAX) * 8, thread_state_pointer);
 
@@ -622,7 +581,7 @@ void* ABIMadness::hostToGuestTrampoline(const char* signature, const void* guest
     as.LI(t0, (u64)x86_code);
     as.SD(t0, offsetof(ThreadState, rip), thread_state_pointer);
 
-    as.MV(a0, s11);
+    as.MV(a0, thread_state_pointer);
     as.LI(t2, (u64)enter_dispatcher_for_callback);
 
     // Finally we "jump" to the guest code
@@ -666,7 +625,6 @@ void* ABIMadness::hostToGuestTrampoline(const char* signature, const void* guest
     }
     }
 
-    as.LD(s11, 0, sp);
     as.LD(s10, 8, sp);
     as.LD(ra, 24, sp);
     as.ADDI(sp, sp, 32);

--- a/src/felix86/hle/signals.cpp
+++ b/src/felix86/hle/signals.cpp
@@ -879,7 +879,7 @@ void prepare_guest_signal(int sig, siginfo_t* guest_info, ucontext_t* uctx) {
 }
 
 void prepare_synchronous_signal(ThreadState* state, int sig, siginfo_t* info, void* ctx, u64 rip) {
-    // Set GP to actual instruction that faulted so that prepare_guest_signal picks it up for the context
+    // Set the RIP register to actual instruction that faulted so that prepare_guest_signal picks it up for the context
     get_regs(ctx)[Recompiler::allocatedGPR(X86_REF_RIP).Index()] = rip;
     prepare_guest_signal(sig, info, (ucontext_t*)ctx);
 }

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -690,7 +690,7 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
         if (g_config.calltrace_on_exit) {
             dump_states();
         }
-        LOG("Process %d called exit_group", state->tid);
+        LOG("Process %d called exit_group", gettid());
         SYSCALL(exit_group, arg1);
         UNREACHABLE();
         break;
@@ -1066,7 +1066,7 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
         if (g_config.calltrace_on_exit) {
             dump_states();
         }
-        LOG("Thread %ld exited with SYS_exit", state->tid);
+        LOG("Thread %ld exited with SYS_exit", gettid());
         if (state->clear_tid_address) {
             __atomic_store_n(state->clear_tid_address, 0, __ATOMIC_SEQ_CST);
             syscall(SYS_futex, state->clear_tid_address, FUTEX_WAKE, ~0ULL, 0, 0, 0);

--- a/src/felix86/hle/thread.cpp
+++ b/src/felix86/hle/thread.cpp
@@ -40,16 +40,15 @@ void* pthread_handler(void* args) {
         state->signal_table = SignalHandlerTable::Create(clone_args.parent_state->signal_table);
     }
 
-    state->tid = gettid();
-
     Signals::sigprocmask(state, SIG_SETMASK, &state->signal_mask, nullptr);
 
+    int tid = gettid();
     if (clone_args.guest_flags & CLONE_CHILD_SETTID && clone_args.child_tid) {
-        *clone_args.child_tid = state->tid;
+        *clone_args.child_tid = tid;
     }
 
     if (clone_args.guest_flags & CLONE_PARENT_SETTID && clone_args.parent_tid) {
-        *clone_args.parent_tid = state->tid;
+        *clone_args.parent_tid = tid;
     }
 
     if (clone_args.guest_flags & CLONE_PIDFD) {
@@ -83,9 +82,9 @@ void* pthread_handler(void* args) {
 
     // Once we are finished with initialization we can signal to the parent thread that we are done
     std::atomic_signal_fence(std::memory_order_seq_cst); // Don't let the compiler reorder the copy after this fence
-    __atomic_store_n(finished, state->tid, __ATOMIC_SEQ_CST);
+    __atomic_store_n(finished, tid, __ATOMIC_SEQ_CST);
 
-    LOG("Thread %ld started", state->tid);
+    LOG("Thread %ld started", tid);
     Threads::StartThread(state);
     UNREACHABLE();
     return nullptr;
@@ -226,7 +225,6 @@ long ForkMe(CloneArgs& host_clone_args) {
         // it's fine to just return to felix86_syscall, which will set the result to 0 and continue execution
         // in this new process
         SIGLOG("%d forked to %d", parent_pid, getpid());
-        state->tid = gettid();
     } else {
         if (ret < 0) {
             ERROR("clone (probably fork) failed with %d", errno);
@@ -256,8 +254,6 @@ long VForkMe(CloneArgs& args) {
         if (args.new_rsp) {
             state->gprs[X86_REF_RSP] = args.new_rsp;
         }
-
-        state->tid = gettid();
 
         if (args.guest_flags & CLONE_SETTLS) {
             WARN("vfork giving us new TLS?");
@@ -421,7 +417,6 @@ std::pair<u8*, size_t> Threads::AllocateStack(bool mode32) {
 }
 
 void Threads::StartThread(ThreadState* state) {
-    state->tid = gettid();
     state->recompiler->enterDispatcher(state);
 }
 

--- a/src/felix86/v2/recompiler.hpp
+++ b/src/felix86/v2/recompiler.hpp
@@ -202,7 +202,9 @@ struct Recompiler {
     int invalidateRange(u64 start, u64 end);
 
     constexpr static biscuit::GPR threadStatePointer() {
-        return x27; // saved register so that when we exit VM we don't have to save it
+        return gp; // due to -mno-relax, this register won't be modified in C++ code
+                   // which is great because it means we can access it at any time during
+                   // the process's lifetime
     }
 
     // TODO: move these elsewhere
@@ -218,7 +220,7 @@ struct Recompiler {
         // !!! --- WARN: If any allocations are changed here, change them in the docs as well
         switch (reg) {
         case X86_REF_RIP: {
-            return biscuit::gp; // we set --no-relax flag so that we can allocate gp
+            return biscuit::s11;
         }
         case X86_REF_RAX: {
             return biscuit::x5;

--- a/tests/FEX/fex_test_loader.cpp
+++ b/tests/FEX/fex_test_loader.cpp
@@ -225,7 +225,6 @@ FEXTestLoader::~FEXTestLoader() {
     ThreadState* state = ThreadState::Get();
     ASSERT(state);
     ThreadState::Destroy(state);
-    pthread_setspecific(g_thread_state_key, nullptr);
 }
 
 void FEXTestLoader::Run() {


### PR DESCRIPTION
We use `-mno-relax` for compilation, which frees up the `gp` register. The ThreadState is much better in that register than in `s11` that it currently resides in. This way, we can access the ThreadState of the thread at any point in time, unlike s11 which needs us to be in JIT code (this is useful for debuggers that can just use `(ThreadState*)$gp` even in C++ code, now). The `gp` register is a special case, this can't be achieved with flags like `-ffixed-reg` because shared libraries will not adhere to those restrictions, but shared libraries won't make use of the `gp` register. This will also allow us to access the ThreadState from a tracer in ptrace emulation without any IPC like shm. It also solves a problem in `ABIMadness::hostToGuestTrampoline`, since it can obtain the ThreadState by just accessing gp instead of doing a `pthread_getspecific` call