### PR TITLE
Warn if `CLONE_VM` is used without `CLONE_THREAD` 

### DIFF
--- a/src/felix86/hle/thread.cpp
+++ b/src/felix86/hle/thread.cpp
@@ -160,6 +160,9 @@ static std::string flags_to_string(u64 f) {
 
 long CloneMe(CloneArgs& host_clone_args) {
     ASSERT(host_clone_args.guest_flags & CLONE_VM);
+    if (!(host_clone_args.guest_flags & CLONE_THREAD)) {
+        WARN("Starting thread with CLONE_VM but without CLONE_THREAD");
+    }
     ASSERT(!(host_clone_args.guest_flags & CLONE_VFORK)); // should be handled in a vfork handler
     void* host_stack = malloc(1024 * 1024);
 


### PR DESCRIPTION
To create a TLS for our new process, if it lives in the same VM, we use pthread_create after running the clone. Normally this seems to not have issues, however if CLONE_THREAD is not set it will result in a process that should be a thread group leader but is not, because it was created with pthread_create. If such a program causes us problems we should figure out a way to fix this, but warn for now