### PR TITLE
Mount home in rootfs by default

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -94,6 +94,6 @@ jobs:
           ROOTFSPATH=$($FELIX86PATH -g)
           git clone https://github.com/felix86-emu/binary_tests $RUNNER_TEMP/tests
           cd $RUNNER_TEMP/tests
-          bash ./install-tests.sh $ROOTFSPATH/$HOME/felix86_test_binaries
-          bash ./run-tests.sh $FELIX86PATH $ROOTFSPATH/$HOME/felix86_test_binaries
+          bash ./install-tests.sh $HOME/felix86_test_binaries
+          bash ./run-tests.sh $FELIX86PATH $HOME/felix86_test_binaries
 

--- a/src/felix86/common/config.inc
+++ b/src/felix86/common/config.inc
@@ -7,6 +7,7 @@ X(General, std::string, environment, "", FELIX86_ENVIRONMENT, "Environment varia
 X(General, std::string, host_environment, "", FELIX86_HOST_ENVIRONMENT, "Environment variables, separated by ';', to export in the host")
 X(General, bool, binfmt_misc_installed, false, FELIX86_BINFMT_MISC_INSTALLED, "Whether binfmt_misc is installed, do NOT change this manually unless if you know what you're doing -- install with `felix86 --binfmt-misc` instead")
 X(General, bool, no_rootfs, false, FELIX86_NO_ROOTFS, "Do not use a rootfs, passthrough all filesystem syscalls to the host")
+X(General, bool, mount_home, true, FELIX86_MOUNT_HOME, "Mount the host /home directory inside the rootfs, helps with ease of use for example for running applications from inside ~/Downloads or ~/Desktop without trusting the directory")
 
 X(Logging, bool, verbose, false, FELIX86_VERBOSE, "Enable verbose logging")
 X(Logging, bool, quiet, false, FELIX86_QUIET, "Disable all logging")

--- a/src/felix86/common/elf.cpp
+++ b/src/felix86/common/elf.cpp
@@ -578,10 +578,10 @@ Elf::PeekResult Elf::Peek(const std::filesystem::path& path) {
     if (!file && path == g_executable_path_absolute) {
         u64 fd = getauxval(AT_EXECFD);
         if (fd == 0 && errno == ENOENT) {
-            WARN("Failed to open ELF at %s and no EXECFD", path.c_str());
             if (!g_config.binfmt_misc_installed) {
                 WARN("If this is an execute-only file you need to install felix86 in binfmt_misc");
             }
+            ERROR("Failed to open ELF at %s and no EXECFD", path.c_str());
         }
 
         file = fdopen(fd, "r");

--- a/src/felix86/common/global.cpp
+++ b/src/felix86/common/global.cpp
@@ -403,6 +403,14 @@ void initialize_globals() {
         ASSERT_MSG(Filesystem::FakeMount("/run", original_rootfs / "run"), "Failed to fake-mount /run");
         ASSERT_MSG(Filesystem::FakeMount("/tmp", original_rootfs / "tmp"), "Failed to fake-mount /tmp");
 
+        if (g_config.mount_home) {
+            // Not as important to succeed, so warn if failed
+            bool done = Filesystem::FakeMount("/home", original_rootfs / "home");
+            if (!done) {
+                WARN("Failed to mount the home directory");
+            }
+        }
+
         if (getenv("__FELIX86_MOUNT_0")) {
             size_t current_mount = 0;
             for (;;) {
@@ -501,15 +509,6 @@ void initialize_globals() {
 
     g_fs = std::make_unique<Filesystem>();
     g_mapper = std::make_unique<Mapper>();
-
-    if (!g_execve_process) {
-        // Check if $HOME exists inside the rootfs, and create it if not
-        if (getenv("HOME")) {
-            std::error_code ec;
-            std::filesystem::path home_path = getenv("HOME");
-            std::filesystem::create_directories(g_config.rootfs_path / home_path.relative_path(), ec);
-        }
-    }
 }
 
 bool parse_extensions(const char* arg) {

--- a/src/felix86/common/global.cpp
+++ b/src/felix86/common/global.cpp
@@ -49,7 +49,6 @@ std::filesystem::path g_executable_path_absolute{};
 std::filesystem::path g_executable_path_guest_override{};
 std::filesystem::path g_mounts_path{};
 std::vector<FakeMountNode> g_fake_mounts{};
-bool g_dont_chdir = false;
 bool g_testing = false;
 
 // g_output_fd should be replaced upon connecting to the server, however if an error occurs before then we should at least log it
@@ -425,7 +424,6 @@ void initialize_globals() {
             g_process_globals.mount_paths.push_back(g_config.rootfs_path);
         }
     } else {
-        g_dont_chdir = true;
         g_rootfs_fd = -1;
     }
 

--- a/src/felix86/common/global.hpp
+++ b/src/felix86/common/global.hpp
@@ -91,7 +91,6 @@ extern int g_linux_minor;
 extern std::filesystem::path g_executable_path_absolute;
 extern std::filesystem::path g_executable_path_guest_override;
 extern std::filesystem::path g_mounts_path;
-extern bool g_dont_chdir;
 extern bool g_testing;
 
 struct FakeMountNode {

--- a/src/felix86/common/script.cpp
+++ b/src/felix86/common/script.cpp
@@ -9,10 +9,10 @@ Script::PeekResult Script::Peek(const std::filesystem::path& path) {
     if (!file && path == g_executable_path_absolute) {
         u64 fd = getauxval(AT_EXECFD);
         if (fd == 0 && errno == ENOENT) {
-            WARN("Failed to open ELF at %s and no EXECFD", path.c_str());
             if (!g_config.binfmt_misc_installed) {
                 WARN("If this is an execute-only file you need to install felix86 in binfmt_misc");
             }
+            ERROR("Failed to open ELF at %s and no EXECFD", path.c_str());
         }
 
         file = fdopen(fd, "r");
@@ -60,10 +60,10 @@ Script::Script(const std::filesystem::path& script) {
     if (!file && script == g_executable_path_absolute) {
         u64 fd = getauxval(AT_EXECFD);
         if (fd == 0 && errno == ENOENT) {
-            WARN("Failed to open ELF at %s and no EXECFD", script.c_str());
             if (!g_config.binfmt_misc_installed) {
                 WARN("If this is an execute-only file you need to install felix86 in binfmt_misc");
             }
+            ERROR("Failed to open ELF at %s and no EXECFD", script.c_str());
         }
 
         file = fdopen(fd, "r");

--- a/src/felix86/emulator.cpp
+++ b/src/felix86/emulator.cpp
@@ -273,10 +273,31 @@ void Emulator::Start() {
     BRK::allocate();
 
     if (!g_execve_process) {
-        if (!g_dont_chdir) {
-            // Go inside the rootfs
-            ASSERT(g_rootfs_fd > 0);
-            ASSERT(fchdir(g_rootfs_fd) == 0);
+        if (!g_config.no_rootfs) {
+            char buffer[PATH_MAX];
+            char* cwd = getcwd(buffer, PATH_MAX);
+            ASSERT(cwd == buffer);
+            std::string scwd = cwd;
+            bool ok = false;
+            if (!is_subpath(scwd, g_config.rootfs_path)) {
+                for (auto& mount : g_fake_mounts) {
+                    if (is_subpath(scwd, mount.src_path)) {
+                        // Current directory is inside fakemount, which is fine
+                        ok = true;
+                        break;
+                    }
+                }
+            } else {
+                // Current directory is inside rootfs
+                ok = true;
+            }
+
+            if (!ok) {
+                // If current directory is not inside rootfs or a fakemount, we need to go inside
+                WARN("Chdiring inside rootfs");
+                ASSERT(g_rootfs_fd > 0);
+                ASSERT(fchdir(g_rootfs_fd) == 0);
+            }
         }
     }
 

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -608,17 +608,6 @@ int main(int argc, char* argv[]) {
         g_params.executable_path = std::filesystem::absolute(g_params.executable_path);
         if (is_subpath(g_params.executable_path, g_config.rootfs_path)) {
             // All is good
-            std::string scwd;
-            {
-                char buffer[PATH_MAX];
-                char* cwd = getcwd(buffer, PATH_MAX);
-                ASSERT(cwd == buffer);
-                scwd = cwd;
-            }
-
-            if (is_subpath(scwd, g_config.rootfs_path)) {
-                g_dont_chdir = true; // don't change the dir, cwd is already inside rootfs
-            }
         } else {
             // Executable path might be outside the rootfs but in a fakemount (e.g. in /tmp or in a trusted folder)
             std::error_code ec;
@@ -630,15 +619,6 @@ int main(int argc, char* argv[]) {
 
             for (const auto& fake_mount : g_fake_mounts) {
                 if (is_subpath(canonical_path, fake_mount.src_path)) {
-                    if (!g_execve_process) {
-                        std::filesystem::path parent_path = canonical_path.parent_path();
-                        if (chdir(parent_path.c_str()) != 0) {
-                            WARN("Failed to chdir into %s", parent_path.c_str());
-                        } else {
-                            g_dont_chdir = true;
-                        }
-                    }
-
                     std::filesystem::path cutoff_path = canonical_path.string().substr(fake_mount.src_path.string().size());
                     std::filesystem::path executable = fake_mount.dst_path / cutoff_path.relative_path();
                     if (is_subpath(executable, g_config.rootfs_path)) {
@@ -692,11 +672,6 @@ int main(int argc, char* argv[]) {
                             if (is_subpath(canonical_path, fake_mount.src_path)) {
                                 std::filesystem::path cutoff_path = canonical_path.string().substr(fake_mount.src_path.string().size());
                                 std::filesystem::path executable = fake_mount.dst_path / cutoff_path.relative_path();
-                                if (chdir(executable.parent_path().c_str()) != 0) {
-                                    WARN("Failed to chdir into %s", executable.parent_path().c_str());
-                                } else {
-                                    g_dont_chdir = true;
-                                }
                                 if (is_subpath(executable, g_config.rootfs_path)) {
                                     executable = executable.string().substr(g_config.rootfs_path.string().size());
                                 }


### PR DESCRIPTION
Fakemount host `/home` to guest `/home` by default. This allows for running things more seamlessly, without being prompted for trusting a directory, for example from ~/Desktop. Also nice for allowing apps to install things in your host Desktop such as shortcuts.

Also check if inside trusted dir before chdiring