### PR TITLE
Move x86 context to separate struct inside ThreadState

### DIFF
--- a/src/felix86/common/print.cpp
+++ b/src/felix86/common/print.cpp
@@ -109,27 +109,27 @@ const char* print_guest_register(x86_ref_e guest) {
 extern "C" __attribute__((visibility("default"))) void print_gprs(ThreadState* state) {
     for (int i = 0; i < 16; i++) {
         const char* guest = print_guest_register((x86_ref_e)(X86_REF_RAX + i));
-        PLAIN("%s = %lx", guest, state->gprs[i]);
+        PLAIN("%s = %lx", guest, state->ctx.gprs[i]);
     }
 
-    PLAIN("rip = %lx", state->rip);
-    PLAIN("cf = %d", state->cf);
-    PLAIN("pf = %d", state->pf);
-    PLAIN("af = %d", state->af);
-    PLAIN("zf = %d", state->zf);
-    PLAIN("sf = %d", state->sf);
-    PLAIN("df = %d", state->df);
-    PLAIN("of = %d", state->of);
+    PLAIN("rip = %lx", state->ctx.rip);
+    PLAIN("cf = %d", state->ctx.cf);
+    PLAIN("pf = %d", state->ctx.pf);
+    PLAIN("af = %d", state->ctx.af);
+    PLAIN("zf = %d", state->ctx.zf);
+    PLAIN("sf = %d", state->ctx.sf);
+    PLAIN("df = %d", state->ctx.df);
+    PLAIN("of = %d", state->ctx.of);
 }
 
 extern "C" __attribute__((visibility("default"))) void print_state(ThreadState* state) {
     print_gprs(state);
 
     for (int i = 0; i < 16; i++) {
-        if (state->xmm[i].data[1] == 0) {
-            PLAIN("xmm%d = %lx", i, state->xmm[i].data[0]);
+        if (state->ctx.xmm[i].data[1] == 0) {
+            PLAIN("xmm%d = %lx", i, state->ctx.xmm[i].data[0]);
         } else {
-            PLAIN("xmm%d = %lx%lx", i, state->xmm[i].data[1], state->xmm[i].data[0]);
+            PLAIN("xmm%d = %lx%lx", i, state->ctx.xmm[i].data[1], state->ctx.xmm[i].data[0]);
         }
     }
 

--- a/src/felix86/common/state.cpp
+++ b/src/felix86/common/state.cpp
@@ -28,38 +28,7 @@ ThreadState* ThreadState::Create(ThreadState* copy_state) {
     sigemptyset(&state->signal_mask);
 
     if (copy_state) {
-        for (size_t i = 0; i < sizeof(state->gprs) / sizeof(state->gprs[0]); i++) {
-            state->gprs[i] = copy_state->gprs[i];
-        }
-
-        for (size_t i = 0; i < sizeof(state->xmm) / sizeof(state->xmm[0]); i++) {
-            state->xmm[i] = copy_state->xmm[i];
-        }
-
-        for (size_t i = 0; i < sizeof(state->fp) / sizeof(state->fp[0]); i++) {
-            state->fp[i] = copy_state->fp[i];
-        }
-
-        state->cf = copy_state->cf;
-        state->zf = copy_state->zf;
-        state->sf = copy_state->sf;
-        state->of = copy_state->of;
-        state->pf = copy_state->pf;
-        state->af = copy_state->af;
-
-        state->fsbase = copy_state->fsbase;
-        state->gsbase = copy_state->gsbase;
-        state->dsbase = copy_state->dsbase;
-        state->csbase = copy_state->csbase;
-        state->ssbase = copy_state->ssbase;
-        state->esbase = copy_state->esbase;
-
-        state->fs = copy_state->fs;
-        state->gs = copy_state->gs;
-        state->ds = copy_state->ds;
-        state->cs = copy_state->cs;
-        state->ss = copy_state->ss;
-        state->es = copy_state->es;
+        state->ctx = copy_state->ctx;
 
         state->alt_stack = copy_state->alt_stack;
         state->signal_mask = copy_state->signal_mask;

--- a/src/felix86/common/state.hpp
+++ b/src/felix86/common/state.hpp
@@ -169,8 +169,7 @@ typedef enum : u8 {
     X(felix86_crash_and_burn)                                                                                                                        \
     X(felix86_exit_dispatcher)
 
-// TODO: Please make me standard layout type? offsetof warnings...
-struct ThreadState {
+struct UserContext {
     u64 gprs[16]{};
     u64 rip{};
     u64 fp[8]{}; // we support 64-bit precision instead of 80-bit for speed and simplicity
@@ -197,14 +196,30 @@ struct ThreadState {
     u64 ssbase{};
     u64 esbase{};
     u32 mxcsr{0x1F80}; // default value
-    biscuit::RMode rmode_sse{biscuit::RMode::RNE};
-    biscuit::RMode rmode_x87{biscuit::RMode::RNE};
     u16 fpu_cw{};
     u16 fpu_tw{};
     u16 fpu_sw{};
-    u8 fpu_top{};
 
+    u64 GetFlags() {
+        u64 flags = 0;
+        flags |= cf;
+        flags |= pf << 2;
+        flags |= af << 4;
+        flags |= zf << 6;
+        flags |= sf << 7;
+        flags |= df << 10;
+        flags |= of << 11;
+        return flags;
+    }
+};
+
+// TODO: Please make me standard layout type? offsetof warnings...
+struct ThreadState {
+    UserContext ctx{};
     u64 first_frame{};
+    biscuit::RMode rmode_sse{biscuit::RMode::RNE};
+    biscuit::RMode rmode_x87{biscuit::RMode::RNE};
+    u8 fpu_top{};
 
     // This is important so that we know whether the current values in the fp array are MMX registers or x87 registers
     // Because if they are x87 registers we need to f64_to_f80 them when saving using fsave or when reading from signal handlers
@@ -267,7 +282,7 @@ struct ThreadState {
             return 0;
         }
 
-        return gprs[ref - X86_REF_RAX];
+        return ctx.gprs[ref - X86_REF_RAX];
     }
 
     void SetGpr(x86_ref_e ref, u64 value) {
@@ -275,25 +290,25 @@ struct ThreadState {
             ERROR("Invalid GPR reference: %d", ref);
         }
 
-        gprs[ref - X86_REF_RAX] = value;
+        ctx.gprs[ref - X86_REF_RAX] = value;
     }
 
     bool GetFlag(x86_ref_e flag) const {
         switch (flag) {
         case X86_REF_CF:
-            return cf;
+            return ctx.cf;
         case X86_REF_PF:
-            return pf;
+            return ctx.pf;
         case X86_REF_AF:
-            return af;
+            return ctx.af;
         case X86_REF_ZF:
-            return zf;
+            return ctx.zf;
         case X86_REF_SF:
-            return sf;
+            return ctx.sf;
         case X86_REF_DF:
-            return df;
+            return ctx.df;
         case X86_REF_OF:
-            return of;
+            return ctx.of;
         default:
             ERROR("Invalid flag reference: %d", flag);
             return false;
@@ -303,25 +318,25 @@ struct ThreadState {
     void SetFlag(x86_ref_e flag, bool value) {
         switch (flag) {
         case X86_REF_CF:
-            cf = value;
+            ctx.cf = value;
             break;
         case X86_REF_PF:
-            pf = value;
+            ctx.pf = value;
             break;
         case X86_REF_AF:
-            af = value;
+            ctx.af = value;
             break;
         case X86_REF_ZF:
-            zf = value;
+            ctx.zf = value;
             break;
         case X86_REF_SF:
-            sf = value;
+            ctx.sf = value;
             break;
         case X86_REF_DF:
-            df = value;
+            ctx.df = value;
             break;
         case X86_REF_OF:
-            of = value;
+            ctx.of = value;
             break;
         default:
             ERROR("Invalid flag reference: %d", flag);
@@ -334,7 +349,7 @@ struct ThreadState {
             return {};
         }
 
-        return xmm[ref - X86_REF_XMM0];
+        return ctx.xmm[ref - X86_REF_XMM0];
     }
 
     void SetXmm(x86_ref_e ref, const XmmReg& value) {
@@ -343,7 +358,7 @@ struct ThreadState {
             return;
         }
 
-        xmm[ref - X86_REF_XMM0] = value;
+        ctx.xmm[ref - X86_REF_XMM0] = value;
     }
 
     u64 GetMm(x86_ref_e ref) const {
@@ -352,7 +367,7 @@ struct ThreadState {
             return {};
         }
 
-        return fp[ref - X86_REF_MM0];
+        return ctx.fp[ref - X86_REF_MM0];
     }
 
     void SetMm(x86_ref_e ref, u64 value) {
@@ -361,22 +376,22 @@ struct ThreadState {
             return;
         }
 
-        fp[ref - X86_REF_MM0] = value;
+        ctx.fp[ref - X86_REF_MM0] = value;
     }
 
     u64 GetRip() const {
-        return rip;
+        return ctx.rip;
     }
 
     void SetRip(u64 value) {
-        rip = value;
+        ctx.rip = value;
     }
 
     void SetTLS(u64 address) {
         if (g_mode32) {
             ASSERT(SetUserDesc((x86_user_desc*)address) == 0);
         } else {
-            fsbase = address;
+            ctx.fsbase = address;
         }
     }
 
@@ -404,27 +419,19 @@ struct ThreadState {
     if ((name >> 3) == index) {                                                                                                                      \
         name##base = udesc->base_addr;                                                                                                               \
     }
-        CHECK_SEG(fs);
-        CHECK_SEG(gs);
-        CHECK_SEG(es);
-        CHECK_SEG(ss);
-        CHECK_SEG(cs);
-        CHECK_SEG(ds);
+        CHECK_SEG(ctx.fs);
+        CHECK_SEG(ctx.gs);
+        CHECK_SEG(ctx.es);
+        CHECK_SEG(ctx.ss);
+        CHECK_SEG(ctx.cs);
+        CHECK_SEG(ctx.ds);
 #undef CHECK_SEG
 
         return 0;
     }
 
     u64 GetFlags() {
-        u64 flags = 0;
-        flags |= cf;
-        flags |= pf << 2;
-        flags |= af << 4;
-        flags |= zf << 6;
-        flags |= sf << 7;
-        flags |= df << 10;
-        flags |= of << 11;
-        return flags;
+        return ctx.GetFlags();
     }
 
     static ThreadState* Create(ThreadState* copy_state = nullptr);

--- a/src/felix86/common/state.hpp
+++ b/src/felix86/common/state.hpp
@@ -216,7 +216,6 @@ struct UserContext {
 // TODO: Please make me standard layout type? offsetof warnings...
 struct ThreadState {
     UserContext ctx{};
-    u64 first_frame{};
     biscuit::RMode rmode_sse{biscuit::RMode::RNE};
     biscuit::RMode rmode_x87{biscuit::RMode::RNE};
     u8 fpu_top{};

--- a/src/felix86/common/utility.cpp
+++ b/src/felix86/common/utility.cpp
@@ -173,19 +173,20 @@ static inline uint64_t libdivide_128_div_64_to_64(uint64_t numhi, uint64_t numlo
 void felix86_div128(ThreadState* state, u64 divisor) {
     // TODO: make this use the above function too, see __divti4
     ASSERT(divisor != 0);
-    __int128_t dividend = ((__int128_t)state->gprs[X86_REF_RDX - X86_REF_RAX] << 64) | state->gprs[X86_REF_RAX - X86_REF_RAX];
+    __int128_t dividend = ((__int128_t)state->ctx.gprs[X86_REF_RDX - X86_REF_RAX] << 64) | state->ctx.gprs[X86_REF_RAX - X86_REF_RAX];
     u64 quotient = dividend / (i64)divisor;
     u64 remainder = dividend % (i64)divisor;
-    state->gprs[X86_REF_RAX - X86_REF_RAX] = quotient;
-    state->gprs[X86_REF_RDX - X86_REF_RAX] = remainder;
+    state->ctx.gprs[X86_REF_RAX - X86_REF_RAX] = quotient;
+    state->ctx.gprs[X86_REF_RDX - X86_REF_RAX] = remainder;
 }
 
 void felix86_divu128(ThreadState* state, u64 divisor) {
     ASSERT(divisor != 0);
     u64 remainder;
-    u64 quotient = libdivide_128_div_64_to_64(state->gprs[X86_REF_RDX - X86_REF_RAX], state->gprs[X86_REF_RAX - X86_REF_RAX], divisor, &remainder);
-    state->gprs[X86_REF_RAX - X86_REF_RAX] = quotient;
-    state->gprs[X86_REF_RDX - X86_REF_RAX] = remainder;
+    u64 quotient =
+        libdivide_128_div_64_to_64(state->ctx.gprs[X86_REF_RDX - X86_REF_RAX], state->ctx.gprs[X86_REF_RAX - X86_REF_RAX], divisor, &remainder);
+    state->ctx.gprs[X86_REF_RAX - X86_REF_RAX] = quotient;
+    state->ctx.gprs[X86_REF_RDX - X86_REF_RAX] = remainder;
 }
 
 u64 sext(u64 value, u8 size) {
@@ -306,7 +307,7 @@ int clear_breakpoints() {
 
 void felix86_iret(struct ThreadState* state) {
     int size = g_mode32 ? 4 : 8;
-    u64 rsp = state->gprs[X86_REF_RSP];
+    u64 rsp = state->ctx.gprs[X86_REF_RSP];
     u8* rsp_ptr = (u8*)rsp;
     u64 rip = 0, rflags = 0, cs = 0, ss = 0, new_rsp = 0;
     memcpy(&rip, rsp_ptr, size);
@@ -334,34 +335,34 @@ void felix86_iret(struct ThreadState* state) {
 
 void felix86_fstenv_16(ThreadState* state, u64 address) {
     fenv_data_16* env = (fenv_data_16*)address;
-    env->cw = state->fpu_cw;
-    env->tw = state->fpu_tw;
-    env->sw = (state->fpu_top << 11) | (state->fpu_sw & ~(0b111 << 11));
+    env->cw = state->ctx.fpu_cw;
+    env->tw = state->ctx.fpu_tw;
+    env->sw = (state->fpu_top << 11) | (state->ctx.fpu_sw & ~(0b111 << 11));
 }
 
 void felix86_fstenv_32(ThreadState* state, u64 address) {
     fenv_data_32* env = (fenv_data_32*)address;
-    env->cw = state->fpu_cw;
-    env->tw = state->fpu_tw;
-    env->sw = (state->fpu_top << 11) | (state->fpu_sw & ~(0b111 << 11));
+    env->cw = state->ctx.fpu_cw;
+    env->tw = state->ctx.fpu_tw;
+    env->sw = (state->fpu_top << 11) | (state->ctx.fpu_sw & ~(0b111 << 11));
 }
 
 void felix86_fldenv_16(struct ThreadState* state, u64 address) {
     fenv_data_16* env = (fenv_data_16*)address;
-    state->fpu_cw = env->cw;
-    state->fpu_tw = env->tw;
-    state->fpu_sw = env->sw;
+    state->ctx.fpu_cw = env->cw;
+    state->ctx.fpu_tw = env->tw;
+    state->ctx.fpu_sw = env->sw;
     state->fpu_top = (env->sw >> 11) & 0b111;
-    state->rmode_x87 = rounding_mode(x86RoundingMode((state->fpu_cw >> 10) & 0b11));
+    state->rmode_x87 = rounding_mode(x86RoundingMode((state->ctx.fpu_cw >> 10) & 0b11));
 }
 
 void felix86_fldenv_32(struct ThreadState* state, u64 address) {
     fenv_data_32* env = (fenv_data_32*)address;
-    state->fpu_cw = env->cw;
-    state->fpu_tw = env->tw;
-    state->fpu_sw = env->sw;
+    state->ctx.fpu_cw = env->cw;
+    state->ctx.fpu_tw = env->tw;
+    state->ctx.fpu_sw = env->sw;
     state->fpu_top = (env->sw >> 11) & 0b111;
-    state->rmode_x87 = rounding_mode(x86RoundingMode((state->fpu_cw >> 10) & 0b11));
+    state->rmode_x87 = rounding_mode(x86RoundingMode((state->ctx.fpu_cw >> 10) & 0b11));
 }
 
 void felix86_pmaddwd(i16* dst, i16* src) {
@@ -798,7 +799,7 @@ void push_calltrace(ThreadState* state, u64 address) {
 
     if (g_print_all_calls) {
         dprintf(g_output_fd, "Thread %d calling: ", gettid());
-        print_address(state->rip);
+        print_address(state->ctx.rip);
     }
 }
 
@@ -809,7 +810,7 @@ void pop_calltrace(ThreadState* state) {
 
     if (g_print_all_calls) {
         dprintf(g_output_fd, "Thread %d returning: ", gettid());
-        print_address(state->rip);
+        print_address(state->ctx.rip);
     }
 
     state->recompiler->getCalltrace().pop_back();
@@ -919,78 +920,78 @@ bool felix86_btc(u64 address, i64 offset) {
 
 void felix86_fsin(ThreadState* state) {
     double boop;
-    memcpy(&boop, &state->fp[TOP(0)], sizeof(double));
+    memcpy(&boop, &state->ctx.fp[TOP(0)], sizeof(double));
     double result = ::sin(boop);
-    memcpy(&state->fp[TOP(0)], &result, sizeof(double));
-    state->fpu_sw &= ~C2_BIT;
+    memcpy(&state->ctx.fp[TOP(0)], &result, sizeof(double));
+    state->ctx.fpu_sw &= ~C2_BIT;
 }
 
 void felix86_fcos(ThreadState* state) {
     double boop;
-    memcpy(&boop, &state->fp[TOP(0)], sizeof(double));
+    memcpy(&boop, &state->ctx.fp[TOP(0)], sizeof(double));
     double result = ::cos(boop);
-    memcpy(&state->fp[TOP(0)], &result, sizeof(double));
-    state->fpu_sw &= ~C2_BIT;
+    memcpy(&state->ctx.fp[TOP(0)], &result, sizeof(double));
+    state->ctx.fpu_sw &= ~C2_BIT;
 }
 
 void felix86_fsincos(ThreadState* state) {
     double boop;
-    memcpy(&boop, &state->fp[TOP(0)], sizeof(double));
+    memcpy(&boop, &state->ctx.fp[TOP(0)], sizeof(double));
     state->fpu_top -= 1;
-    state->fpu_tw &= ~(0b11 << (state->fpu_top * 2));
-    sincos(boop, (double*)&state->fp[TOP(1)], (double*)&state->fp[TOP(0)]);
-    state->fpu_sw &= ~C2_BIT;
+    state->ctx.fpu_tw &= ~(0b11 << (state->fpu_top * 2));
+    sincos(boop, (double*)&state->ctx.fp[TOP(1)], (double*)&state->ctx.fp[TOP(0)]);
+    state->ctx.fpu_sw &= ~C2_BIT;
 }
 
 void felix86_fptan(ThreadState* state) {
     double st0;
-    memcpy(&st0, &state->fp[TOP(0)], sizeof(double));
+    memcpy(&st0, &state->ctx.fp[TOP(0)], sizeof(double));
     double result = ::tan(st0);
-    memcpy(&state->fp[TOP(0)], &result, sizeof(double));
-    state->fpu_sw &= ~C2_BIT;
+    memcpy(&state->ctx.fp[TOP(0)], &result, sizeof(double));
+    state->ctx.fpu_sw &= ~C2_BIT;
 }
 
 void felix86_fpatan(ThreadState* state) {
     double st0, st1;
-    memcpy(&st0, &state->fp[TOP(0)], sizeof(double));
-    memcpy(&st1, &state->fp[TOP(1)], sizeof(double));
+    memcpy(&st0, &state->ctx.fp[TOP(0)], sizeof(double));
+    memcpy(&st1, &state->ctx.fp[TOP(1)], sizeof(double));
     double result = ::atan2(st1, st0);
-    memcpy(&state->fp[TOP(1)], &result, sizeof(double));
+    memcpy(&state->ctx.fp[TOP(1)], &result, sizeof(double));
 }
 
 void felix86_f2xm1(ThreadState* state) {
     double st0;
-    memcpy(&st0, &state->fp[TOP(0)], sizeof(double));
+    memcpy(&st0, &state->ctx.fp[TOP(0)], sizeof(double));
     double result = ::expm1(M_LN2 * st0);
-    memcpy(&state->fp[TOP(0)], &result, sizeof(double));
+    memcpy(&state->ctx.fp[TOP(0)], &result, sizeof(double));
 }
 
 void felix86_fscale(ThreadState* state) {
     double st0, st1, result;
-    memcpy(&st0, &state->fp[TOP(0)], sizeof(double));
+    memcpy(&st0, &state->ctx.fp[TOP(0)], sizeof(double));
     if (st0 == 0) {
         result = 0.0;
     } else {
-        memcpy(&st1, &state->fp[TOP(1)], sizeof(double));
+        memcpy(&st1, &state->ctx.fp[TOP(1)], sizeof(double));
         result = st0 * ::exp2(trunc(st1));
     }
-    memcpy(&state->fp[TOP(0)], &result, sizeof(double));
+    memcpy(&state->ctx.fp[TOP(0)], &result, sizeof(double));
 }
 
 void felix86_fyl2x(ThreadState* state) {
     double st0, st1;
-    memcpy(&st0, &state->fp[TOP(0)], sizeof(double));
-    memcpy(&st1, &state->fp[TOP(1)], sizeof(double));
+    memcpy(&st0, &state->ctx.fp[TOP(0)], sizeof(double));
+    memcpy(&st1, &state->ctx.fp[TOP(1)], sizeof(double));
     double result = st1 * log2(st0);
-    memcpy(&state->fp[TOP(1)], &result, sizeof(double));
+    memcpy(&state->ctx.fp[TOP(1)], &result, sizeof(double));
 }
 
 void felix86_fyl2xp1(ThreadState* state) {
     double st0, st1;
-    memcpy(&st0, &state->fp[TOP(0)], sizeof(double));
-    memcpy(&st1, &state->fp[TOP(1)], sizeof(double));
+    memcpy(&st0, &state->ctx.fp[TOP(0)], sizeof(double));
+    memcpy(&st1, &state->ctx.fp[TOP(1)], sizeof(double));
     double result = (st1 * log1p(st0)) / M_LN2;
-    memcpy(&state->fp[TOP(1)], &result, sizeof(double));
+    memcpy(&state->ctx.fp[TOP(1)], &result, sizeof(double));
 }
 
 template <class Int, int Count = 128 / (sizeof(Int) * 8), int UpperBound = Count - 1 /* 7 or 15 */, u32 Mask = (1u << Count) - 1u>
@@ -1043,8 +1044,8 @@ void pcmpxstrx_impl(ThreadState* state, pcmpxstrx type, Int* dst, Int* src, u8 c
             }
         }
     } else {
-        dst_length = (i64)state->gprs[0]; // eax
-        src_length = (i64)state->gprs[2]; // edx
+        dst_length = (i64)state->ctx.gprs[0]; // eax
+        src_length = (i64)state->ctx.gprs[2]; // edx
 
         if (std::abs(dst_length) > Count) {
             dst_length = Count;
@@ -1176,24 +1177,24 @@ void pcmpxstrx_impl(ThreadState* state, pcmpxstrx type, Int* dst, Int* src, u8 c
         // pcmpxstri instructions
         static_assert(X86_REF_RCX == 1);
         if (intres2 == 0) {
-            state->gprs[1] = Count;
+            state->ctx.gprs[1] = Count;
         } else {
             if (!output_selection) {
-                state->gprs[1] = __builtin_ctz(intres2);
+                state->ctx.gprs[1] = __builtin_ctz(intres2);
             } else {
                 u32 shifted = intres2 << (32 - Count);
-                state->gprs[1] = (Count - 1) - __builtin_clz(shifted);
+                state->ctx.gprs[1] = (Count - 1) - __builtin_clz(shifted);
             }
         }
     } else {
         // pcmpxstrm instructions
         if (!output_selection) {
-            state->xmm[0].data[1] = 0;
-            state->xmm[0].data[0] = intres2;
+            state->ctx.xmm[0].data[1] = 0;
+            state->ctx.xmm[0].data[0] = intres2;
         } else {
             static_assert(Count == 8 || Count == 16);
             if (Count == 16) {
-                u8* xmm0 = (u8*)&state->xmm[0].data[0];
+                u8* xmm0 = (u8*)&state->ctx.xmm[0].data[0];
                 for (int i = 0; i < 16; i++) {
                     u32 bit = (intres2 >> i) & 1;
                     if (bit) {
@@ -1203,7 +1204,7 @@ void pcmpxstrx_impl(ThreadState* state, pcmpxstrx type, Int* dst, Int* src, u8 c
                     }
                 }
             } else {
-                u16* xmm0 = (u16*)&state->xmm[0].data[0];
+                u16* xmm0 = (u16*)&state->ctx.xmm[0].data[0];
                 for (int i = 0; i < 8; i++) {
                     u32 bit = (intres2 >> i) & 1;
                     if (bit) {
@@ -1216,13 +1217,13 @@ void pcmpxstrx_impl(ThreadState* state, pcmpxstrx type, Int* dst, Int* src, u8 c
         }
     }
 
-    state->cf = intres2 != 0;
+    state->ctx.cf = intres2 != 0;
     // Works for both implicit and explicit variants
-    state->zf = src_length < Count;
-    state->sf = dst_length < Count;
-    state->of = intres2 & 1;
-    state->af = 0;
-    state->pf = 0;
+    state->ctx.zf = src_length < Count;
+    state->ctx.sf = dst_length < Count;
+    state->ctx.of = intres2 & 1;
+    state->ctx.af = 0;
+    state->ctx.pf = 0;
 }
 
 void felix86_pcmpxstrx(ThreadState* state, pcmpxstrx type, u8* dst, u8* src, u8 control) {
@@ -1280,33 +1281,33 @@ void felix86_set_segment(ThreadState* state, u64 value, int segment) {
 
     switch (segment) {
     case ZYDIS_REGISTER_CS: {
-        state->cs = value;
-        state->csbase = base;
+        state->ctx.cs = value;
+        state->ctx.csbase = base;
         break;
     }
     case ZYDIS_REGISTER_DS: {
-        state->ds = value;
-        state->dsbase = base;
+        state->ctx.ds = value;
+        state->ctx.dsbase = base;
         break;
     }
     case ZYDIS_REGISTER_SS: {
-        state->ss = value;
-        state->ssbase = base;
+        state->ctx.ss = value;
+        state->ctx.ssbase = base;
         break;
     }
     case ZYDIS_REGISTER_ES: {
-        state->es = value;
-        state->esbase = base;
+        state->ctx.es = value;
+        state->ctx.esbase = base;
         break;
     }
     case ZYDIS_REGISTER_FS: {
-        state->fs = value;
-        state->fsbase = base;
+        state->ctx.fs = value;
+        state->ctx.fsbase = base;
         break;
     }
     case ZYDIS_REGISTER_GS: {
-        state->gs = value;
-        state->gsbase = base;
+        state->ctx.gs = value;
+        state->ctx.gsbase = base;
         break;
     }
     default: {
@@ -1317,8 +1318,8 @@ void felix86_set_segment(ThreadState* state, u64 value, int segment) {
 }
 
 void felix86_fprem(ThreadState* state) {
-    const u64 st0 = state->fp[TOP(0)];
-    const u64 st1 = state->fp[TOP(1)];
+    const u64 st0 = state->ctx.fp[TOP(0)];
+    const u64 st1 = state->ctx.fp[TOP(1)];
     double st0d, st1d;
     memcpy(&st0d, &st0, 8);
     memcpy(&st1d, &st1, 8);
@@ -1328,23 +1329,23 @@ void felix86_fprem(ThreadState* state) {
     if (D < 64) {
         const i64 Q = (i64)(trunc(st0d / st1d));
         st0d -= st1d * Q;
-        state->fpu_sw &= ~(C0_BIT | C1_BIT | C2_BIT | C3_BIT);
-        state->fpu_sw |= (Q & 1) ? C1_BIT : 0;
-        state->fpu_sw |= (Q & 2) ? C3_BIT : 0;
-        state->fpu_sw |= (Q & 4) ? C0_BIT : 0;
+        state->ctx.fpu_sw &= ~(C0_BIT | C1_BIT | C2_BIT | C3_BIT);
+        state->ctx.fpu_sw |= (Q & 1) ? C1_BIT : 0;
+        state->ctx.fpu_sw |= (Q & 2) ? C3_BIT : 0;
+        state->ctx.fpu_sw |= (Q & 4) ? C0_BIT : 0;
     } else {
         const double p2 = exp2(D - 32);
         const i64 Q = trunc((st0d / st1d) / p2);
         st0d -= st1d * Q * p2;
-        state->fpu_sw |= C2_BIT;
+        state->ctx.fpu_sw |= C2_BIT;
     }
 
     // Writeback the new ST(0) value
-    memcpy(&state->fp[TOP(0)], &st0d, 8);
+    memcpy(&state->ctx.fp[TOP(0)], &st0d, 8);
 }
 
 void felix86_fxam(ThreadState* state) {
-    u64 st0 = state->fp[TOP(0)];
+    u64 st0 = state->ctx.fp[TOP(0)];
     bool sign = st0 >> 63;
     double st0d;
     memcpy(&st0d, &st0, 8);
@@ -1352,7 +1353,7 @@ void felix86_fxam(ThreadState* state) {
     u16 mask = 0b11 << state->fpu_top;
 
     u8 c3c2c0;
-    if ((state->fpu_tw & mask) == mask) {
+    if ((state->ctx.fpu_tw & mask) == mask) {
         c3c2c0 = 0b101;
     } else if (st0d == 0.0) {
         c3c2c0 = 0b100;
@@ -1367,11 +1368,11 @@ void felix86_fxam(ThreadState* state) {
     bool c2 = (c3c2c0 >> 1) & 1;
     bool c3 = (c3c2c0 >> 2) & 1;
 
-    state->fpu_sw &= ~(C0_BIT | C1_BIT | C2_BIT | C3_BIT);
-    state->fpu_sw |= c0 ? C0_BIT : 0;
-    state->fpu_sw |= c1 ? C1_BIT : 0;
-    state->fpu_sw |= c2 ? C2_BIT : 0;
-    state->fpu_sw |= c3 ? C3_BIT : 0;
+    state->ctx.fpu_sw &= ~(C0_BIT | C1_BIT | C2_BIT | C3_BIT);
+    state->ctx.fpu_sw |= c0 ? C0_BIT : 0;
+    state->ctx.fpu_sw |= c1 ? C1_BIT : 0;
+    state->ctx.fpu_sw |= c2 ? C2_BIT : 0;
+    state->ctx.fpu_sw |= c3 ? C3_BIT : 0;
 }
 
 // TODO: One day we need to make this better. It serves to hide some felix86 related files from /proc/self/maps

--- a/src/felix86/common/xsave.cpp
+++ b/src/felix86/common/xsave.cpp
@@ -8,17 +8,17 @@ void felix86_fsave_16(ThreadState* state, void* address) {
     for (int i = 0; i < 8; i++) {
         if (is_mmx) {
             u16 ones = 0xFFFF;
-            memcpy(&data->st[i], &state->fp[i], sizeof(double));
+            memcpy(&data->st[i], &state->ctx.fp[i], sizeof(double));
             memcpy(&data->st[i].exponent, &ones, sizeof(u16));
         } else {
-            Float80 f80 = f64_to_80(state->fp[i]);
+            Float80 f80 = f64_to_80(state->ctx.fp[i]);
             memcpy(&data->st[i], &f80, sizeof(Float80));
         }
     }
 
-    data->cw = state->fpu_cw;
-    data->tw = state->fpu_tw;
-    data->sw = (state->fpu_top << 11) | (state->fpu_sw & ~(0b111 << 11));
+    data->cw = state->ctx.fpu_cw;
+    data->tw = state->ctx.fpu_tw;
+    data->sw = (state->fpu_top << 11) | (state->ctx.fpu_sw & ~(0b111 << 11));
 
     // We use this reserved bit in FCW to signify we stored the registers as MMX and thus
     // will not need f80->f64 conversion if loaded with frstor
@@ -33,17 +33,17 @@ void felix86_fsave_32(ThreadState* state, void* address) {
     for (int i = 0; i < 8; i++) {
         if (is_mmx) {
             u16 ones = 0xFFFF;
-            memcpy(&data->st[i], &state->fp[i], sizeof(double));
+            memcpy(&data->st[i], &state->ctx.fp[i], sizeof(double));
             memcpy(&data->st[i].exponent, &ones, sizeof(u16));
         } else {
-            Float80 f80 = f64_to_80(state->fp[i]);
+            Float80 f80 = f64_to_80(state->ctx.fp[i]);
             memcpy(&data->st[i], &f80, sizeof(Float80));
         }
     }
 
-    data->cw = state->fpu_cw;
-    data->tw = state->fpu_tw;
-    data->sw = (state->fpu_top << 11) | (state->fpu_sw & ~(0b111 << 11));
+    data->cw = state->ctx.fpu_cw;
+    data->tw = state->ctx.fpu_tw;
+    data->sw = (state->fpu_top << 11) | (state->ctx.fpu_sw & ~(0b111 << 11));
 
     // We use this reserved bit in FCW to signify we stored the registers as MMX and thus
     // will not need f80->f64 conversion if loaded with frstor
@@ -56,17 +56,17 @@ void felix86_frstor_16(ThreadState* state, void* address) {
     fsave_frame_16* data = (fsave_frame_16*)address;
 
     state->fpu_top = (data->sw >> 11) & 0b111;
-    state->fpu_cw = data->cw;
-    state->fpu_tw = data->tw;
-    state->fpu_sw = data->sw;
-    state->rmode_x87 = rounding_mode(x86RoundingMode((state->fpu_cw >> 10) & 0b11));
+    state->ctx.fpu_cw = data->cw;
+    state->ctx.fpu_tw = data->tw;
+    state->ctx.fpu_sw = data->sw;
+    state->rmode_x87 = rounding_mode(x86RoundingMode((state->ctx.fpu_cw >> 10) & 0b11));
 
     for (int i = 0; i < 8; i++) {
-        if (state->fpu_cw & 0x8000) {
-            memcpy(&state->fp[i], &data->st[i], sizeof(double));
+        if (state->ctx.fpu_cw & 0x8000) {
+            memcpy(&state->ctx.fp[i], &data->st[i], sizeof(double));
         } else {
             double f64 = f80_to_64(&data->st[i]);
-            memcpy(&state->fp[i], &f64, sizeof(double));
+            memcpy(&state->ctx.fp[i], &f64, sizeof(double));
         }
     }
 }
@@ -75,17 +75,17 @@ void felix86_frstor_32(ThreadState* state, void* address) {
     fsave_frame_32* data = (fsave_frame_32*)address;
 
     state->fpu_top = (data->sw >> 11) & 0b111;
-    state->fpu_cw = data->cw;
-    state->fpu_tw = data->tw;
-    state->fpu_sw = data->sw;
-    state->rmode_x87 = rounding_mode(x86RoundingMode((state->fpu_cw >> 10) & 0b11));
+    state->ctx.fpu_cw = data->cw;
+    state->ctx.fpu_tw = data->tw;
+    state->ctx.fpu_sw = data->sw;
+    state->rmode_x87 = rounding_mode(x86RoundingMode((state->ctx.fpu_cw >> 10) & 0b11));
 
     for (int i = 0; i < 8; i++) {
-        if (state->fpu_cw & 0x8000) {
-            memcpy(&state->fp[i], &data->st[i], sizeof(double));
+        if (state->ctx.fpu_cw & 0x8000) {
+            memcpy(&state->ctx.fp[i], &data->st[i], sizeof(double));
         } else {
             double f64 = f80_to_64(&data->st[i]);
-            memcpy(&state->fp[i], &f64, sizeof(double));
+            memcpy(&state->ctx.fp[i], &f64, sizeof(double));
         }
     }
 }
@@ -104,14 +104,14 @@ void felix86_fxsave(ThreadState* state, void* address, bool save_x87, bool save_
     if (save_x87) {
         for (int i = 0; i < 8; i++) {
             if (is_x87) {
-                Float80 f80 = f64_to_80(state->fp[i]);
+                Float80 f80 = f64_to_80(state->ctx.fp[i]);
                 memcpy(&data->st[i].st[0], &f80, sizeof(Float80));
             } else {
                 if (!is_mmx) {
                     WARN("Unknown x87 state during fxsave");
                 }
                 u16 ones = 0xFFFF;
-                memcpy(&data->st[i].st[0], &state->fp[i], sizeof(double));
+                memcpy(&data->st[i].st[0], &state->ctx.fp[i], sizeof(double));
                 memcpy(&data->st[i].st[8], &ones, sizeof(u16));
             }
         }
@@ -120,14 +120,14 @@ void felix86_fxsave(ThreadState* state, void* address, bool save_x87, bool save_
         data->ftw = 0;
         for (int i = 0; i < 8; i++) {
             u16 mask = 0b11 << (i * 2);
-            bool empty = (mask & state->fpu_tw) == mask;
+            bool empty = (mask & state->ctx.fpu_tw) == mask;
             if (!empty) {
                 data->ftw |= 1 << i;
             }
         }
 
-        data->fcw = state->fpu_cw;
-        data->fsw = (state->fpu_top << 11) | (state->fpu_sw & ~(0b111 << 11));
+        data->fcw = state->ctx.fpu_cw;
+        data->fsw = (state->fpu_top << 11) | (state->ctx.fpu_sw & ~(0b111 << 11));
 
         // We use this reserved bit in FCW to signify we stored the registers as MMX and thus
         // will not need f80->f64 conversion if loaded with fxrstor
@@ -137,7 +137,7 @@ void felix86_fxsave(ThreadState* state, void* address, bool save_x87, bool save_
     }
 
     if (save_mxcsr) {
-        data->mxcsr = state->mxcsr;
+        data->mxcsr = state->ctx.mxcsr;
     }
 }
 
@@ -146,38 +146,38 @@ void felix86_fxrstor(ThreadState* state, void* address, bool restore_x87, bool r
 
     if (restore_xmm) {
         for (int i = 0; i < (g_mode32 ? 8 : 16); i++) {
-            state->xmm[i].data[0] = data->xmms[i].val[0];
-            state->xmm[i].data[1] = data->xmms[i].val[1];
+            state->ctx.xmm[i].data[0] = data->xmms[i].val[0];
+            state->ctx.xmm[i].data[1] = data->xmms[i].val[1];
         }
     }
 
     if (restore_x87) {
-        state->fpu_tw = 0;
+        state->ctx.fpu_tw = 0;
         for (int i = 0; i < 8; i++) {
             if (!((data->ftw >> i) & 0b1)) {
-                state->fpu_tw |= 0b11 << (i * 2);
+                state->ctx.fpu_tw |= 0b11 << (i * 2);
             }
         }
 
-        state->fpu_cw = data->fcw;
-        state->fpu_sw = data->fsw;
+        state->ctx.fpu_cw = data->fcw;
+        state->ctx.fpu_sw = data->fsw;
         state->fpu_top = (data->fsw >> 11) & 7;
 
         for (int i = 0; i < 8; i++) {
-            if (state->fpu_cw & 0x8000) {
-                memcpy(&state->fp[i], &data->st[i].st[0], sizeof(double));
+            if (state->ctx.fpu_cw & 0x8000) {
+                memcpy(&state->ctx.fp[i], &data->st[i].st[0], sizeof(double));
             } else {
                 double f64 = f80_to_64((Float80*)&data->st[i].st[0]);
-                memcpy(&state->fp[i], &f64, sizeof(double));
+                memcpy(&state->ctx.fp[i], &f64, sizeof(double));
             }
         }
 
-        state->rmode_x87 = rounding_mode(x86RoundingMode((state->fpu_cw >> 10) & 0b11));
+        state->rmode_x87 = rounding_mode(x86RoundingMode((state->ctx.fpu_cw >> 10) & 0b11));
     }
 
     if (restore_mxcsr) {
-        state->mxcsr = data->mxcsr;
-        state->rmode_sse = rounding_mode(x86RoundingMode((state->mxcsr >> 13) & 0b11));
+        state->ctx.mxcsr = data->mxcsr;
+        state->rmode_sse = rounding_mode(x86RoundingMode((state->ctx.mxcsr >> 13) & 0b11));
     }
 }
 
@@ -186,7 +186,7 @@ bool felix86_xsave_contains_ymms() {
 }
 
 void felix86_xsave(ThreadState* state, void* address, bool save_all) {
-    u64 rfbm = (u64)(u32)state->gprs[X86_REF_RDX] << 32 | (u32)state->gprs[X86_REF_RAX];
+    u64 rfbm = (u64)(u32)state->ctx.gprs[X86_REF_RDX] << 32 | (u32)state->ctx.gprs[X86_REF_RAX];
     bool save_x87 = (rfbm & 0b001) || save_all;
     bool save_xmm = (rfbm & 0b010) || save_all;
     bool save_avx = (rfbm & 0b100) || save_all;
@@ -198,13 +198,13 @@ void felix86_xsave(ThreadState* state, void* address, bool save_all) {
         header->xcomp_bv = 0; // use standard form
         ymm_hi* ymm_storage = (ymm_hi*)((u8*)address + sizeof(fxsave_frame) + sizeof(xsave_header));
         for (int i = 0; i < 16; i++) {
-            memcpy((u8*)ymm_storage->data + 16 * i, &state->xmm[i].data[2], sizeof(u64) * 2);
+            memcpy((u8*)ymm_storage->data + 16 * i, &state->ctx.xmm[i].data[2], sizeof(u64) * 2);
         }
     }
 }
 
 void felix86_xrstor(ThreadState* state, void* address, bool restore_all) {
-    u64 rfbm = (u64)(u32)state->gprs[X86_REF_RDX] << 32 | (u32)state->gprs[X86_REF_RAX];
+    u64 rfbm = (u64)(u32)state->ctx.gprs[X86_REF_RDX] << 32 | (u32)state->ctx.gprs[X86_REF_RAX];
     bool restore_x87 = (rfbm & 0b001) || restore_all;
     bool restore_xmm = (rfbm & 0b010) || restore_all;
     bool restore_avx = (rfbm & 0b100) || restore_all;
@@ -213,7 +213,7 @@ void felix86_xrstor(ThreadState* state, void* address, bool restore_all) {
     if (felix86_xsave_contains_ymms() && restore_avx) {
         ymm_hi* ymm_storage = (ymm_hi*)((u8*)address + sizeof(fxsave_frame) + sizeof(xsave_header));
         for (int i = 0; i < 16; i++) {
-            memcpy(&state->xmm[i].data[2], (u8*)ymm_storage->data + 16 * i, sizeof(u64) * 2);
+            memcpy(&state->ctx.xmm[i].data[2], (u8*)ymm_storage->data + 16 * i, sizeof(u64) * 2);
         }
     }
 }

--- a/src/felix86/emulator.cpp
+++ b/src/felix86/emulator.cpp
@@ -346,7 +346,7 @@ void Emulator::StartTest(const TestConfig& config, u64 stack) {
     main_state->SetRip(config.entrypoint);
 
     if (config.fill_ymm_with_trash) {
-        for (auto& ymm : main_state->xmm) {
+        for (auto& ymm : main_state->ctx.xmm) {
             ymm.data[2] = 0xCCCC'CCCC'CCCC'CCCC;
             ymm.data[3] = 0xABCD'EF01'2345'6789;
         }

--- a/src/felix86/hle/abi.cpp
+++ b/src/felix86/hle/abi.cpp
@@ -140,7 +140,7 @@ void my_printer(ThreadState* state, const char* name) {
             break;
         }
         x86_ref_e ref = x86arg(i - 2);
-        u64 gpr = state->gprs[ref];
+        u64 gpr = state->ctx.gprs[ref];
         size += sprintf(buffer + size, "arg%d = %lx, ", i - 2, gpr);
     }
     size += sprintf(buffer + size, "}");
@@ -282,9 +282,9 @@ void GuestToHostMarshaller::emitPrologue(biscuit::Assembler& as) {
         } else {
             address_reg = Recompiler::threadStatePointer();
             if (marshalling.x86.value.reg >= X86_REF_RAX && marshalling.x86.value.reg <= X86_REF_R15) {
-                offset = offsetof(ThreadState, gprs) + (marshalling.x86.value.reg - X86_REF_RAX) * 8;
+                offset = offsetof(ThreadState, ctx.gprs) + (marshalling.x86.value.reg - X86_REF_RAX) * 8;
             } else if (marshalling.x86.value.reg >= X86_REF_XMM0 && marshalling.x86.value.reg <= X86_REF_XMM15) {
-                offset = offsetof(ThreadState, xmm) + (marshalling.x86.value.reg - X86_REF_XMM0) * sizeof(XmmReg);
+                offset = offsetof(ThreadState, ctx.xmm) + (marshalling.x86.value.reg - X86_REF_XMM0) * sizeof(XmmReg);
             } else {
                 UNREACHABLE();
             }
@@ -384,31 +384,31 @@ void GuestToHostMarshaller::emitEpilogue(biscuit::Assembler& as) {
         switch (return_type) {
         case 'b':
             // Preserves top bits in x86-64
-            as.SB(a0, offsetof(ThreadState, gprs) + 0, Recompiler::threadStatePointer());
+            as.SB(a0, offsetof(ThreadState, ctx.gprs) + 0, Recompiler::threadStatePointer());
             break;
         case 'w':
             // Preserves top bits in x86-64
-            as.SH(a0, offsetof(ThreadState, gprs) + 0, Recompiler::threadStatePointer());
+            as.SH(a0, offsetof(ThreadState, ctx.gprs) + 0, Recompiler::threadStatePointer());
             break;
         case 'd':
-            as.SW(a0, offsetof(ThreadState, gprs) + 0, Recompiler::threadStatePointer());
-            as.SW(x0, offsetof(ThreadState, gprs) + 4, Recompiler::threadStatePointer()); // store 0 into bits 32-63
+            as.SW(a0, offsetof(ThreadState, ctx.gprs) + 0, Recompiler::threadStatePointer());
+            as.SW(x0, offsetof(ThreadState, ctx.gprs) + 4, Recompiler::threadStatePointer()); // store 0 into bits 32-63
             break;
         case 'q':
-            as.SD(a0, offsetof(ThreadState, gprs) + 0, Recompiler::threadStatePointer());
+            as.SD(a0, offsetof(ThreadState, ctx.gprs) + 0, Recompiler::threadStatePointer());
             break;
         case 'F': {
-            as.FSW(fa0, offsetof(ThreadState, xmm) + 0, Recompiler::threadStatePointer());
-            as.SW(x0, offsetof(ThreadState, xmm) + 4, Recompiler::threadStatePointer()); // store 0 into bits 32-63
+            as.FSW(fa0, offsetof(ThreadState, ctx.xmm) + 0, Recompiler::threadStatePointer());
+            as.SW(x0, offsetof(ThreadState, ctx.xmm) + 4, Recompiler::threadStatePointer()); // store 0 into bits 32-63
             for (u32 i = 1; i < sizeof(XmmReg) / 8; i++) {
-                as.SD(x0, offsetof(ThreadState, xmm) + (i * 8), Recompiler::threadStatePointer());
+                as.SD(x0, offsetof(ThreadState, ctx.xmm) + (i * 8), Recompiler::threadStatePointer());
             }
             break;
         }
         case 'D': {
-            as.FSD(fa0, offsetof(ThreadState, xmm) + 0, Recompiler::threadStatePointer());
+            as.FSD(fa0, offsetof(ThreadState, ctx.xmm) + 0, Recompiler::threadStatePointer());
             for (u32 i = 1; i < sizeof(XmmReg) / 8; i++) {
-                as.SD(x0, offsetof(ThreadState, xmm) + (i * 8), Recompiler::threadStatePointer());
+                as.SD(x0, offsetof(ThreadState, ctx.xmm) + (i * 8), Recompiler::threadStatePointer());
             }
             break;
         }
@@ -425,7 +425,7 @@ void GuestToHostMarshaller::emitEpilogue(biscuit::Assembler& as) {
 }
 
 void enter_dispatcher_for_callback(ThreadState* state) {
-    u64 rip = state->rip;
+    u64 rip = state->ctx.rip;
     VERBOSE("Entering dispatcher for callback at %p", rip);
     state->recompiler->enterDispatcher(state);
     VERBOSE("Finished callback %p", rip);
@@ -475,7 +475,7 @@ void* ABIMadness::hostToGuestTrampoline(const char* signature, const void* guest
     biscuit::GPR thread_state_pointer = Recompiler::threadStatePointer();
     biscuit::GPR guest_stack_pointer = t1;
 
-    as.LD(guest_stack_pointer, offsetof(ThreadState, gprs) + (X86_REF_RSP - X86_REF_RAX) * 8, thread_state_pointer);
+    as.LD(guest_stack_pointer, offsetof(ThreadState, ctx.gprs) + (X86_REF_RSP - X86_REF_RAX) * 8, thread_state_pointer);
 
     // Marshal host arguments to guest arguments
     size_t size = strlen(signature);
@@ -522,7 +522,7 @@ void* ABIMadness::hostToGuestTrampoline(const char* signature, const void* guest
     int riscv_stack_offset = 32; // we decremented sp to push arguments, add it back here when pulling stack args
     if (x86_stack_size > 0) {
         as.ADDI(guest_stack_pointer, guest_stack_pointer, -x86_stack_size);
-        as.SD(guest_stack_pointer, offsetof(ThreadState, gprs) + (X86_REF_RSP - X86_REF_RAX) * 8, thread_state_pointer);
+        as.SD(guest_stack_pointer, offsetof(ThreadState, ctx.gprs) + (X86_REF_RSP - X86_REF_RAX) * 8, thread_state_pointer);
     }
 
     for (size_t i = 2; i < size; i++) {
@@ -555,7 +555,7 @@ void* ABIMadness::hostToGuestTrampoline(const char* signature, const void* guest
                     as.SRLI(riscv_reg, riscv_reg, 32);
                 }
                 x86_ref_e arg = x86arg(gpr_count);
-                as.SD(riscv_reg, offsetof(ThreadState, gprs) + (arg - X86_REF_RAX) * 8, thread_state_pointer);
+                as.SD(riscv_reg, offsetof(ThreadState, ctx.gprs) + (arg - X86_REF_RAX) * 8, thread_state_pointer);
             }
             gpr_count++;
             break;
@@ -577,9 +577,9 @@ void* ABIMadness::hostToGuestTrampoline(const char* signature, const void* guest
     ASSERT(x86_stack_size == x86_stack_offset);
 
     // Save old RIP, set new RIP -- TODO: why do we even save the old rip? delete this
-    as.LD(s10, offsetof(ThreadState, rip), thread_state_pointer);
+    as.LD(s10, offsetof(ThreadState, ctx.rip), thread_state_pointer);
     as.LI(t0, (u64)x86_code);
-    as.SD(t0, offsetof(ThreadState, rip), thread_state_pointer);
+    as.SD(t0, offsetof(ThreadState, ctx.rip), thread_state_pointer);
 
     as.MV(a0, thread_state_pointer);
     as.LI(t2, (u64)enter_dispatcher_for_callback);
@@ -590,13 +590,13 @@ void* ABIMadness::hostToGuestTrampoline(const char* signature, const void* guest
 
     // Eventually we will return here when ExitDispatcher is called due to invlpg [rdx]
     // Restore old RIP (is this saving/restoring even necessary?)
-    as.SD(s10, offsetof(ThreadState, rip), thread_state_pointer);
+    as.SD(s10, offsetof(ThreadState, ctx.rip), thread_state_pointer);
 
     if (x86_stack_size > 0) {
         // Restore the old stack
-        as.LD(guest_stack_pointer, offsetof(ThreadState, gprs) + (X86_REF_RSP - X86_REF_RAX) * 8, thread_state_pointer);
+        as.LD(guest_stack_pointer, offsetof(ThreadState, ctx.gprs) + (X86_REF_RSP - X86_REF_RAX) * 8, thread_state_pointer);
         as.ADDI(guest_stack_pointer, guest_stack_pointer, x86_stack_size);
-        as.SD(guest_stack_pointer, offsetof(ThreadState, gprs) + (X86_REF_RSP - X86_REF_RAX) * 8, thread_state_pointer);
+        as.SD(guest_stack_pointer, offsetof(ThreadState, ctx.gprs) + (X86_REF_RSP - X86_REF_RAX) * 8, thread_state_pointer);
     }
 
     // Load the return value from the state struct to a RISC-V register
@@ -604,17 +604,17 @@ void* ABIMadness::hostToGuestTrampoline(const char* signature, const void* guest
     switch (return_type) {
     case 'd': {
         // RAX
-        as.LW(a0, offsetof(ThreadState, gprs), thread_state_pointer);
+        as.LW(a0, offsetof(ThreadState, ctx.gprs), thread_state_pointer);
         break;
     }
     case 'q': {
         // RAX
-        as.LD(a0, offsetof(ThreadState, gprs), thread_state_pointer);
+        as.LD(a0, offsetof(ThreadState, ctx.gprs), thread_state_pointer);
         break;
     }
     case 'D': {
         // XMM0
-        as.FLD(fa0, offsetof(ThreadState, xmm), thread_state_pointer);
+        as.FLD(fa0, offsetof(ThreadState, ctx.xmm), thread_state_pointer);
         break;
     }
     case 'v': {

--- a/src/felix86/hle/signals.cpp
+++ b/src/felix86/hle/signals.cpp
@@ -482,12 +482,12 @@ void setupFrame_x86_rt(RegisteredSignal& signal, int sig, ThreadState* state, si
     frame->uc.uc_mcontext.sp_at_signal = state->GetGpr(X86_REF_RSP);
     frame->uc.uc_mcontext.ip = state->GetRip();
     frame->uc.uc_mcontext.flags = state->GetFlags();
-    frame->uc.uc_mcontext.fs = state->fs;
-    frame->uc.uc_mcontext.gs = state->gs;
-    frame->uc.uc_mcontext.cs = state->cs;
-    frame->uc.uc_mcontext.ds = state->ds;
-    frame->uc.uc_mcontext.ss = state->ss;
-    frame->uc.uc_mcontext.es = state->es;
+    frame->uc.uc_mcontext.fs = state->ctx.fs;
+    frame->uc.uc_mcontext.gs = state->ctx.gs;
+    frame->uc.uc_mcontext.cs = state->ctx.cs;
+    frame->uc.uc_mcontext.ds = state->ctx.ds;
+    frame->uc.uc_mcontext.ss = state->ctx.ss;
+    frame->uc.uc_mcontext.es = state->ctx.es;
     frame->uc.uc_mcontext.__fsh = 0;
     frame->uc.uc_mcontext.__gsh = 0;
     frame->uc.uc_mcontext.__csh = 0;
@@ -542,7 +542,7 @@ void setupFrame_x86(RegisteredSignal& signal, int sig, ThreadState* state, sigin
     };
 
     // Kernel mentions some legacy altstack switching method, ensure it's not used until we find a program that does
-    ASSERT(!(state->ss != state->ds && !(signal.flags & SA_RESTORER) && signal.restorer));
+    ASSERT(!(state->ctx.ss != state->ctx.ds && !(signal.flags & SA_RESTORER) && signal.restorer));
     u64 rsp = state->GetGpr(X86_REF_RSP);
     bool use_altstack = signal.flags & SA_ONSTACK;
     if (use_altstack) {
@@ -580,12 +580,12 @@ void setupFrame_x86(RegisteredSignal& signal, int sig, ThreadState* state, sigin
     frame->sc.sp_at_signal = state->GetGpr(X86_REF_RSP);
     frame->sc.ip = state->GetRip();
     frame->sc.flags = state->GetFlags();
-    frame->sc.fs = state->fs;
-    frame->sc.gs = state->gs;
-    frame->sc.cs = state->cs;
-    frame->sc.ds = state->ds;
-    frame->sc.ss = state->ss;
-    frame->sc.es = state->es;
+    frame->sc.fs = state->ctx.fs;
+    frame->sc.gs = state->ctx.gs;
+    frame->sc.cs = state->ctx.cs;
+    frame->sc.ds = state->ctx.ds;
+    frame->sc.ss = state->ctx.ss;
+    frame->sc.es = state->ctx.es;
     frame->sc.__fsh = 0;
     frame->sc.__gsh = 0;
     frame->sc.__csh = 0;
@@ -663,12 +663,12 @@ void restore_sigcontext_32(ThreadState* state, x86_sigcontext_32* ctx) {
     state->SetFlag(X86_REF_OF, of);
     state->SetFlag(X86_REF_DF, df);
 
-    state->cs = ctx->cs;
-    state->ss = ctx->ss;
-    state->ds = ctx->ds;
-    state->es = ctx->es;
-    state->fs = ctx->fs;
-    state->gs = ctx->gs;
+    state->ctx.cs = ctx->cs;
+    state->ctx.ss = ctx->ss;
+    state->ctx.ds = ctx->ds;
+    state->ctx.es = ctx->es;
+    state->ctx.fs = ctx->fs;
+    state->ctx.gs = ctx->gs;
 }
 
 void Signals::sigreturn(ThreadState* state, bool rt) {
@@ -871,7 +871,8 @@ void prepare_guest_signal(int sig, siginfo_t* guest_info, ucontext_t* uctx) {
     sigandset(&host_new_mask, &state->signal_mask, Signals::hostSignalMask());
     uctx->uc_sigmask = host_new_mask;
 
-    SIGLOG("Preparing signal %s (%d) during RIP=%lx, RSP=%lx, handler at %lx", sigdescr_np(sig), sig, rip, state->gprs[X86_REF_RSP], handler->func);
+    SIGLOG("Preparing signal %s (%d) during RIP=%lx, RSP=%lx, handler at %lx", sigdescr_np(sig), sig, rip, state->ctx.gprs[X86_REF_RSP],
+           handler->func);
 
     if (handler->flags & SA_RESETHAND) {
         Signals::registerSignalHandler(state, sig, (u64)SIG_DFL, handler->mask, handler->flags, handler->restorer);
@@ -1049,7 +1050,7 @@ bool handle_wild_sigsegv(ThreadState* current_state, siginfo_t* info, ucontext_t
 #endif
                 }
             } else {
-                print_address(current_state->rip);
+                print_address(current_state->ctx.rip);
             }
         }
 
@@ -1103,7 +1104,7 @@ bool handle_wild_sigabrt(ThreadState* current_state, siginfo_t* info, ucontext_t
 #endif
                 }
             } else {
-                print_address(current_state->rip);
+                print_address(current_state->ctx.rip);
             }
         }
 
@@ -1153,7 +1154,7 @@ bool handle_synchronous(ThreadState* current_state, siginfo_t* info, ucontext_t*
     }
 
     BlockMetadata* current_block = get_block_metadata(current_state, pc);
-    ASSERT_MSG(current_block, "Failed to get current block during synchronous signal with PC=%lx, RIP=%lx", pc, current_state->rip);
+    ASSERT_MSG(current_block, "Failed to get current block during synchronous signal with PC=%lx, RIP=%lx", pc, current_state->ctx.rip);
     u64 actual_rip = get_actual_rip(*current_block, pc);
 
     int sig;
@@ -1230,11 +1231,12 @@ void signal_handler(int sig, siginfo_t* info, void* ctx) {
         // Synchronous signal, handle immediately
         if (is_in_jit_code(state, (u8*)pc)) {
             BlockMetadata* current_block = get_block_metadata(state, pc);
-            ASSERT_MSG(current_block, "Failed to get current block during synchronous signal with PC=%lx, RIP=%lx", pc, state->rip);
+            ASSERT_MSG(current_block, "Failed to get current block during synchronous signal with PC=%lx, RIP=%lx", pc, state->ctx.rip);
             u64 actual_rip = get_actual_rip(*current_block, pc);
             return prepare_synchronous_signal(state, sig, info, ctx, actual_rip);
         } else {
-            ERROR("Synchronous signal %s with code %d but not in JIT code during RIP=%lx, PC=%lx", sigdescr_np(sig), info->si_code, state->rip, pc);
+            ERROR("Synchronous signal %s with code %d but not in JIT code during RIP=%lx, PC=%lx", sigdescr_np(sig), info->si_code, state->ctx.rip,
+                  pc);
         }
     } else {
         // Asynchronous signal, defer

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -1236,7 +1236,7 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
         VERBOSE("----- sigaltstack was called -----");
         stack_t* new_ss = (stack_t*)arg1;
         stack_t* old_ss = (stack_t*)arg2;
-        u64 current_rsp = state->gprs[X86_REF_RSP];
+        u64 current_rsp = state->ctx.gprs[X86_REF_RSP];
 
         bool on_stack = false;
         if (!(state->alt_stack.ss_flags & SS_DISABLE) && current_rsp >= (u64)state->alt_stack.ss_sp &&
@@ -1384,7 +1384,7 @@ Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u6
             .child_tid = (pid_t*)child_tid,
             .new_tls = arg5,
             .new_rsp = arg2,
-            .new_rip = state->gprs[X86_REF_RCX],
+            .new_rip = state->ctx.gprs[X86_REF_RCX],
             .new_thread = 0,
             .new_tid = 0,
         };
@@ -1900,21 +1900,21 @@ void felix86_syscall(felix86_frame* frame) {
         case felix86_x86_64_arch_prctl: {
             switch (arg1) {
             case felix86_x86_64_ARCH_SET_GS: {
-                state->gsbase = arg2;
+                state->ctx.gsbase = arg2;
                 result = 0;
                 break;
             }
             case felix86_x86_64_ARCH_SET_FS: {
-                state->fsbase = arg2;
+                state->ctx.fsbase = arg2;
                 result = 0;
                 break;
             }
             case felix86_x86_64_ARCH_GET_FS: {
-                result = state->fsbase;
+                result = state->ctx.fsbase;
                 break;
             }
             case felix86_x86_64_ARCH_GET_GS: {
-                result = state->gsbase;
+                result = state->ctx.gsbase;
                 break;
             }
             default: {
@@ -2446,7 +2446,7 @@ void felix86_syscall32(felix86_frame* frame, u32 rip_next) {
                 WARN("SS_AUTODISARM when establishing alt stack");
             }
 
-            u64 current_rsp = state->gprs[X86_REF_RSP];
+            u64 current_rsp = state->ctx.gprs[X86_REF_RSP];
 
             bool on_stack = false;
             if (!(state->alt_stack.ss_flags & SS_DISABLE) && current_rsp >= (u64)state->alt_stack.ss_sp &&

--- a/src/felix86/hle/thread.cpp
+++ b/src/felix86/hle/thread.cpp
@@ -59,9 +59,9 @@ void* pthread_handler(void* args) {
         state->clear_tid_address = clone_args.child_tid;
     }
 
-    state->gprs[X86_REF_RAX] = 0; // return value
-    state->rip = clone_args.new_rip;
-    state->gprs[X86_REF_RSP] = clone_args.new_rsp;
+    state->ctx.gprs[X86_REF_RAX] = 0; // return value
+    state->ctx.rip = clone_args.new_rip;
+    state->ctx.gprs[X86_REF_RSP] = clone_args.new_rsp;
     state->thread = clone_args.new_thread;
 
     if (clone_args.guest_flags & CLONE_SETTLS) {
@@ -218,7 +218,7 @@ long ForkMe(CloneArgs& host_clone_args) {
         g_process_globals.states.push_back(state);
 
         if (host_clone_args.new_rsp) {
-            state->gprs[X86_REF_RSP] = host_clone_args.new_rsp;
+            state->ctx.gprs[X86_REF_RSP] = host_clone_args.new_rsp;
         }
 
         if (host_clone_args.guest_flags & CLONE_SETTLS) {
@@ -255,7 +255,7 @@ long VForkMe(CloneArgs& args) {
         ThreadState* state = ThreadState::Get();
         // TODO: probably clean up states here, but it doesn't matter cus it gets execve'd anyway
         if (args.new_rsp) {
-            state->gprs[X86_REF_RSP] = args.new_rsp;
+            state->ctx.gprs[X86_REF_RSP] = args.new_rsp;
         }
 
         if (args.guest_flags & CLONE_SETTLS) {

--- a/src/felix86/v2/handlers.cpp
+++ b/src/felix86/v2/handlers.cpp
@@ -550,27 +550,27 @@ FAST_HANDLE(MOV) {
             int offset = 0;
             switch (operands[1].reg.value) {
             case ZYDIS_REGISTER_CS: {
-                offset = offsetof(ThreadState, cs);
+                offset = offsetof(ThreadState, ctx.cs);
                 break;
             }
             case ZYDIS_REGISTER_DS: {
-                offset = offsetof(ThreadState, ds);
+                offset = offsetof(ThreadState, ctx.ds);
                 break;
             }
             case ZYDIS_REGISTER_SS: {
-                offset = offsetof(ThreadState, ss);
+                offset = offsetof(ThreadState, ctx.ss);
                 break;
             }
             case ZYDIS_REGISTER_ES: {
-                offset = offsetof(ThreadState, es);
+                offset = offsetof(ThreadState, ctx.es);
                 break;
             }
             case ZYDIS_REGISTER_FS: {
-                offset = offsetof(ThreadState, fs);
+                offset = offsetof(ThreadState, ctx.fs);
                 break;
             }
             case ZYDIS_REGISTER_GS: {
-                offset = offsetof(ThreadState, gs);
+                offset = offsetof(ThreadState, ctx.gs);
                 break;
             }
             default: {
@@ -1400,7 +1400,7 @@ FAST_HANDLE(XOR) {
         if (rec.shouldEmitFlag(rip, X86_REF_PF)) {
             biscuit::GPR pf = rec.scratch();
             as.LI(pf, 1);
-            as.SB(pf, offsetof(ThreadState, pf), rec.threadStatePointer());
+            as.SB(pf, offsetof(ThreadState, ctx.pf), rec.threadStatePointer());
             rec.popScratch();
         }
 
@@ -1767,27 +1767,27 @@ FAST_HANDLE(PUSH) {
         int offset = 0;
         switch (operands[0].reg.value) {
         case ZYDIS_REGISTER_CS: {
-            offset = offsetof(ThreadState, cs);
+            offset = offsetof(ThreadState, ctx.cs);
             break;
         }
         case ZYDIS_REGISTER_DS: {
-            offset = offsetof(ThreadState, ds);
+            offset = offsetof(ThreadState, ctx.ds);
             break;
         }
         case ZYDIS_REGISTER_SS: {
-            offset = offsetof(ThreadState, ss);
+            offset = offsetof(ThreadState, ctx.ss);
             break;
         }
         case ZYDIS_REGISTER_ES: {
-            offset = offsetof(ThreadState, es);
+            offset = offsetof(ThreadState, ctx.es);
             break;
         }
         case ZYDIS_REGISTER_FS: {
-            offset = offsetof(ThreadState, fs);
+            offset = offsetof(ThreadState, ctx.fs);
             break;
         }
         case ZYDIS_REGISTER_GS: {
-            offset = offsetof(ThreadState, gs);
+            offset = offsetof(ThreadState, ctx.gs);
             break;
         }
         default: {
@@ -1968,10 +1968,10 @@ FAST_HANDLE(PREFETCHWT1) {}
 
 FAST_HANDLE(FNCLEX) {
     biscuit::GPR sw = rec.scratch();
-    as.LHU(sw, offsetof(ThreadState, fpu_sw), Recompiler::threadStatePointer());
+    as.LHU(sw, offsetof(ThreadState, ctx.fpu_sw), Recompiler::threadStatePointer());
     as.ANDI(sw, sw, ~0xFF);
     as.BCLRI(sw, sw, 15);
-    as.SH(sw, offsetof(ThreadState, fpu_sw), Recompiler::threadStatePointer());
+    as.SH(sw, offsetof(ThreadState, ctx.fpu_sw), Recompiler::threadStatePointer());
 }
 
 FAST_HANDLE(SHL_imm) {
@@ -2548,13 +2548,13 @@ FAST_HANDLE(LEA) {
 
 FAST_HANDLE(RDFSBASE) {
     biscuit::GPR fs = rec.scratch();
-    as.LD(fs, offsetof(ThreadState, fsbase), rec.threadStatePointer());
+    as.LD(fs, offsetof(ThreadState, ctx.fsbase), rec.threadStatePointer());
     rec.setGPR(&operands[0], fs);
 }
 
 FAST_HANDLE(RDGSBASE) {
     biscuit::GPR gs = rec.scratch();
-    as.LD(gs, offsetof(ThreadState, gsbase), rec.threadStatePointer());
+    as.LD(gs, offsetof(ThreadState, ctx.gsbase), rec.threadStatePointer());
     rec.setGPR(&operands[0], gs);
 }
 
@@ -3030,11 +3030,11 @@ FAST_HANDLE(SAHF) {
     biscuit::GPR pf = rec.scratch();
     as.SRLI(pf, ah, 2);
     as.ANDI(pf, pf, 1);
-    as.SB(pf, offsetof(ThreadState, pf), rec.threadStatePointer());
+    as.SB(pf, offsetof(ThreadState, ctx.pf), rec.threadStatePointer());
 
     as.SRLI(af, ah, 4);
     as.ANDI(af, af, 1);
-    as.SB(af, offsetof(ThreadState, af), rec.threadStatePointer());
+    as.SB(af, offsetof(ThreadState, ctx.af), rec.threadStatePointer());
 
     as.SRLI(zf, ah, 6);
     as.ANDI(zf, zf, 1);
@@ -3203,13 +3203,13 @@ FAST_HANDLE(XCHG) {
 }
 
 FAST_HANDLE(CLD) {
-    as.SB(x0, offsetof(ThreadState, df), rec.threadStatePointer());
+    as.SB(x0, offsetof(ThreadState, ctx.df), rec.threadStatePointer());
 }
 
 FAST_HANDLE(STD) {
     biscuit::GPR df = rec.scratch();
     as.LI(df, 1);
-    as.SB(df, offsetof(ThreadState, df), rec.threadStatePointer());
+    as.SB(df, offsetof(ThreadState, ctx.df), rec.threadStatePointer());
 }
 
 FAST_HANDLE(CLC) {
@@ -4887,7 +4887,7 @@ FAST_HANDLE(MOVSB) {
     biscuit::GPR temp = rec.scratch();
     biscuit::GPR data = rec.scratch();
     biscuit::GPR df = rec.scratch();
-    as.LBU(df, offsetof(ThreadState, df), rec.threadStatePointer());
+    as.LBU(df, offsetof(ThreadState, ctx.df), rec.threadStatePointer());
 
     Label end;
     as.LI(temp, -width / 8);
@@ -4967,7 +4967,7 @@ FAST_HANDLE(CMPSB) {
 
     x86_size_e size = rec.zydisToSize(width);
     biscuit::GPR df = rec.scratch();
-    as.LBU(df, offsetof(ThreadState, df), rec.threadStatePointer());
+    as.LBU(df, offsetof(ThreadState, ctx.df), rec.threadStatePointer());
 
     Label end;
     as.LI(temp, -width / 8);
@@ -5026,7 +5026,7 @@ FAST_HANDLE(SCASB) {
     biscuit::GPR src2 = rec.scratch();
     biscuit::GPR result = rec.scratch();
     biscuit::GPR df = rec.scratch();
-    as.LBU(df, offsetof(ThreadState, df), rec.threadStatePointer());
+    as.LBU(df, offsetof(ThreadState, ctx.df), rec.threadStatePointer());
 
     Label end;
     as.LI(temp, -width / 8);
@@ -5081,7 +5081,7 @@ FAST_HANDLE(LODSB) {
     biscuit::GPR temp = rec.scratch();
     biscuit::GPR loaded = rec.scratch();
     biscuit::GPR df = rec.scratch();
-    as.LBU(df, offsetof(ThreadState, df), rec.threadStatePointer());
+    as.LBU(df, offsetof(ThreadState, ctx.df), rec.threadStatePointer());
 
     Label end;
     as.LI(temp, -width / 8);
@@ -5119,7 +5119,7 @@ FAST_HANDLE(STOSB) {
     biscuit::GPR rax = rec.getGPR(X86_REF_RAX, rec.zydisToSize(width));
     biscuit::GPR temp = rec.scratch();
     biscuit::GPR df = rec.scratch();
-    as.LBU(df, offsetof(ThreadState, df), rec.threadStatePointer());
+    as.LBU(df, offsetof(ThreadState, ctx.df), rec.threadStatePointer());
 
     Label end;
     as.LI(temp, -width / 8);
@@ -5497,7 +5497,7 @@ FAST_HANDLE(NEG) {
         biscuit::GPR af = rec.scratch();
         as.ANDI(af, dst, 0xF);
         as.SNEZ(af, af);
-        as.SB(af, offsetof(ThreadState, af), rec.threadStatePointer());
+        as.SB(af, offsetof(ThreadState, ctx.af), rec.threadStatePointer());
         rec.popScratch();
     }
 
@@ -5740,7 +5740,7 @@ FAST_HANDLE(PTEST) {
     }
 
     if (rec.shouldEmitFlag(rip, X86_REF_AF)) {
-        as.SB(x0, offsetof(ThreadState, af), rec.threadStatePointer());
+        as.SB(x0, offsetof(ThreadState, ctx.af), rec.threadStatePointer());
     }
 
     if (rec.shouldEmitFlag(rip, X86_REF_OF)) {
@@ -5754,7 +5754,7 @@ FAST_HANDLE(PTEST) {
     }
 
     if (rec.shouldEmitFlag(rip, X86_REF_PF)) {
-        as.SB(x0, offsetof(ThreadState, pf), rec.threadStatePointer());
+        as.SB(x0, offsetof(ThreadState, ctx.pf), rec.threadStatePointer());
     }
 }
 
@@ -7592,7 +7592,7 @@ void COMIS(Recompiler& rec, u64 rip, Assembler& as, ZydisDecodedInstruction& ins
     biscuit::GPR of = rec.flag(X86_REF_OF);
 
     if (rec.shouldEmitFlag(rip, X86_REF_AF)) {
-        as.SB(x0, offsetof(ThreadState, af), rec.threadStatePointer());
+        as.SB(x0, offsetof(ThreadState, ctx.af), rec.threadStatePointer());
     }
 
     if (rec.shouldEmitFlag(rip, X86_REF_OF)) {
@@ -7648,7 +7648,7 @@ void COMIS(Recompiler& rec, u64 rip, Assembler& as, ZydisDecodedInstruction& ins
     as.XORI(nan_bit, nan_bit, 1);
 
     if (rec.shouldEmitFlag(rip, X86_REF_PF)) {
-        as.SB(nan_bit, offsetof(ThreadState, pf), rec.threadStatePointer());
+        as.SB(nan_bit, offsetof(ThreadState, ctx.pf), rec.threadStatePointer());
     }
 
     // If the NaN bit is set we also overwrite the value of cf and zf with 1
@@ -8094,7 +8094,7 @@ FAST_HANDLE(EMMS) {
     // Set FPU tag word to empty
     biscuit::GPR ones = rec.scratch();
     as.LI(ones, -1);
-    as.SH(ones, offsetof(ThreadState, fpu_tw), rec.threadStatePointer());
+    as.SH(ones, offsetof(ThreadState, ctx.fpu_tw), rec.threadStatePointer());
     rec.switchToX87();
 }
 
@@ -8401,12 +8401,12 @@ FAST_HANDLE(XLAT) {
         as.ADD(address, rbx, al);
         switch (seg) {
         case ZYDIS_REGISTER_FS: {
-            rec.readMemory(segment, Recompiler::threadStatePointer(), offsetof(ThreadState, fsbase), X86_SIZE_QWORD);
+            rec.readMemory(segment, Recompiler::threadStatePointer(), offsetof(ThreadState, ctx.fsbase), X86_SIZE_QWORD);
             as.ADD(address, address, segment);
             break;
         }
         case ZYDIS_REGISTER_GS: {
-            rec.readMemory(segment, Recompiler::threadStatePointer(), offsetof(ThreadState, gsbase), X86_SIZE_QWORD);
+            rec.readMemory(segment, Recompiler::threadStatePointer(), offsetof(ThreadState, ctx.gsbase), X86_SIZE_QWORD);
             as.ADD(address, address, segment);
             break;
         }
@@ -8426,27 +8426,27 @@ FAST_HANDLE(XLAT) {
         biscuit::GPR segment = rec.scratch();
         switch (seg) {
         case ZYDIS_REGISTER_FS: {
-            rec.readMemory(segment, Recompiler::threadStatePointer(), offsetof(ThreadState, fsbase), X86_SIZE_QWORD);
+            rec.readMemory(segment, Recompiler::threadStatePointer(), offsetof(ThreadState, ctx.fsbase), X86_SIZE_QWORD);
             break;
         }
         case ZYDIS_REGISTER_GS: {
-            rec.readMemory(segment, Recompiler::threadStatePointer(), offsetof(ThreadState, gsbase), X86_SIZE_QWORD);
+            rec.readMemory(segment, Recompiler::threadStatePointer(), offsetof(ThreadState, ctx.gsbase), X86_SIZE_QWORD);
             break;
         }
         case ZYDIS_REGISTER_DS: {
-            rec.readMemory(segment, Recompiler::threadStatePointer(), offsetof(ThreadState, dsbase), X86_SIZE_QWORD);
+            rec.readMemory(segment, Recompiler::threadStatePointer(), offsetof(ThreadState, ctx.dsbase), X86_SIZE_QWORD);
             break;
         }
         case ZYDIS_REGISTER_ES: {
-            rec.readMemory(segment, Recompiler::threadStatePointer(), offsetof(ThreadState, esbase), X86_SIZE_QWORD);
+            rec.readMemory(segment, Recompiler::threadStatePointer(), offsetof(ThreadState, ctx.esbase), X86_SIZE_QWORD);
             break;
         }
         case ZYDIS_REGISTER_SS: {
-            rec.readMemory(segment, Recompiler::threadStatePointer(), offsetof(ThreadState, ssbase), X86_SIZE_QWORD);
+            rec.readMemory(segment, Recompiler::threadStatePointer(), offsetof(ThreadState, ctx.ssbase), X86_SIZE_QWORD);
             break;
         }
         case ZYDIS_REGISTER_CS: {
-            rec.readMemory(segment, Recompiler::threadStatePointer(), offsetof(ThreadState, csbase), X86_SIZE_QWORD);
+            rec.readMemory(segment, Recompiler::threadStatePointer(), offsetof(ThreadState, ctx.csbase), X86_SIZE_QWORD);
             break;
         }
         default: {
@@ -9138,9 +9138,9 @@ FAST_HANDLE(WRFSBASE) {
     biscuit::GPR reg = rec.getGPR(&operands[0]);
 
     if (instruction.operand_width == 32) {
-        as.SW(reg, offsetof(ThreadState, fsbase), rec.threadStatePointer());
+        as.SW(reg, offsetof(ThreadState, ctx.fsbase), rec.threadStatePointer());
     } else if (instruction.operand_width == 64) {
-        as.SD(reg, offsetof(ThreadState, fsbase), rec.threadStatePointer());
+        as.SD(reg, offsetof(ThreadState, ctx.fsbase), rec.threadStatePointer());
     } else {
         UNREACHABLE();
     }
@@ -9150,9 +9150,9 @@ FAST_HANDLE(WRGSBASE) {
     biscuit::GPR reg = rec.getGPR(&operands[0]);
 
     if (instruction.operand_width == 32) {
-        as.SW(reg, offsetof(ThreadState, gsbase), rec.threadStatePointer());
+        as.SW(reg, offsetof(ThreadState, ctx.gsbase), rec.threadStatePointer());
     } else if (instruction.operand_width == 64) {
-        as.SD(reg, offsetof(ThreadState, gsbase), rec.threadStatePointer());
+        as.SD(reg, offsetof(ThreadState, ctx.gsbase), rec.threadStatePointer());
     } else {
         UNREACHABLE();
     }
@@ -9988,7 +9988,7 @@ FAST_HANDLE(SHRD) {
 void PCMPXSTRX(Recompiler& rec, u64 rip, Assembler& as, ZydisDecodedInstruction& instruction, ZydisDecodedOperand* operands, pcmpxstrx type) {
     rec.writebackState();
     if (operands[1].type == ZYDIS_OPERAND_TYPE_REGISTER) {
-        as.ADDI(a3, rec.threadStatePointer(), offsetof(ThreadState, xmm) + (sizeof(XmmReg) * (operands[1].reg.value - ZYDIS_REGISTER_XMM0)));
+        as.ADDI(a3, rec.threadStatePointer(), offsetof(ThreadState, ctx.xmm) + (sizeof(XmmReg) * (operands[1].reg.value - ZYDIS_REGISTER_XMM0)));
     } else {
         biscuit::GPR scratch = rec.lea(&operands[1]);
         ASSERT(scratch != a0 && scratch != a1 && scratch != a2);
@@ -9997,7 +9997,7 @@ void PCMPXSTRX(Recompiler& rec, u64 rip, Assembler& as, ZydisDecodedInstruction&
     as.MV(a0, rec.threadStatePointer());
     as.LI(a1, (int)type);
     ASSERT(operands[0].reg.value >= ZYDIS_REGISTER_XMM0 && operands[0].reg.value <= ZYDIS_REGISTER_XMM15);
-    as.ADDI(a2, rec.threadStatePointer(), offsetof(ThreadState, xmm) + (sizeof(XmmReg) * (operands[0].reg.value - ZYDIS_REGISTER_XMM0)));
+    as.ADDI(a2, rec.threadStatePointer(), offsetof(ThreadState, ctx.xmm) + (sizeof(XmmReg) * (operands[0].reg.value - ZYDIS_REGISTER_XMM0)));
     as.LI(a4, operands[2].imm.value.u);
 
     rec.callPointer(offsetof(ThreadState, felix86_pcmpxstrx));
@@ -10023,7 +10023,7 @@ FAST_HANDLE(PCMPESTRM) {
 FAST_HANDLE(STMXCSR) {
     biscuit::GPR mxcsr = rec.scratch();
     // TODO: are overflow/inexact/underflow etc flags set in fcsr? if then we need to copy them over
-    as.LWU(mxcsr, offsetof(ThreadState, mxcsr), rec.threadStatePointer());
+    as.LWU(mxcsr, offsetof(ThreadState, ctx.mxcsr), rec.threadStatePointer());
     rec.setGPR(&operands[0], mxcsr);
 }
 
@@ -10052,7 +10052,7 @@ FAST_HANDLE(LDMXCSR) {
 
     // Also save the converted rounding mode for quick access
     as.ANDI(masked, src, 0xFFC0); // ignore low bits
-    as.SW(masked, offsetof(ThreadState, mxcsr), rec.threadStatePointer());
+    as.SW(masked, offsetof(ThreadState, ctx.mxcsr), rec.threadStatePointer());
     as.SB(temp, offsetof(ThreadState, rmode_sse), rec.threadStatePointer());
 
     rec.setFsrmSSE(true);
@@ -10233,12 +10233,13 @@ FAST_HANDLE(MPSADBW) {
         rec.writebackState();
         if (operands[1].type == ZYDIS_OPERAND_TYPE_REGISTER) {
             as.ADDI(a1, rec.threadStatePointer(),
-                    offsetof(ThreadState, xmm) + sizeof(XmmReg) * (rec.zydisToRef(operands[1].reg.value) - X86_REF_XMM0));
+                    offsetof(ThreadState, ctx.xmm) + sizeof(XmmReg) * (rec.zydisToRef(operands[1].reg.value) - X86_REF_XMM0));
         } else {
             biscuit::GPR address = rec.lea(&operands[1]);
             as.MV(a1, address);
         }
-        as.ADDI(a0, rec.threadStatePointer(), offsetof(ThreadState, xmm) + sizeof(XmmReg) * (rec.zydisToRef(operands[0].reg.value) - X86_REF_XMM0));
+        as.ADDI(a0, rec.threadStatePointer(),
+                offsetof(ThreadState, ctx.xmm) + sizeof(XmmReg) * (rec.zydisToRef(operands[0].reg.value) - X86_REF_XMM0));
         as.LI(a2, rec.getImmediate(&operands[2]));
         rec.callPointer(offsetof(ThreadState, felix86_mpsadbw));
         rec.restoreState();
@@ -10473,12 +10474,12 @@ FAST_HANDLE(AESKEYGENASSIST) {
     rec.writebackState();
     if (operands[1].type == ZYDIS_OPERAND_TYPE_REGISTER) {
         x86_ref_e src = rec.zydisToRef(operands[0].reg.value);
-        as.ADDI(a1, Recompiler::threadStatePointer(), offsetof(ThreadState, xmm) + (src - X86_REF_XMM0) * sizeof(XmmReg));
+        as.ADDI(a1, Recompiler::threadStatePointer(), offsetof(ThreadState, ctx.xmm) + (src - X86_REF_XMM0) * sizeof(XmmReg));
     } else {
         biscuit::GPR address = rec.lea(&operands[1]);
         as.MV(a1, address);
     }
-    as.ADDI(a0, Recompiler::threadStatePointer(), offsetof(ThreadState, xmm) + (reg - X86_REF_XMM0) * sizeof(XmmReg));
+    as.ADDI(a0, Recompiler::threadStatePointer(), offsetof(ThreadState, ctx.xmm) + (reg - X86_REF_XMM0) * sizeof(XmmReg));
     as.LI(a2, imm);
     rec.callPointer(offsetof(ThreadState, felix86_aeskeygenassist));
     rec.restoreState();
@@ -10929,7 +10930,7 @@ FAST_HANDLE(FTST) {
     biscuit::GPR nan_bit = rec.scratch();
     as.LI(rmask, mask);
     biscuit::GPR fsw = rec.scratch();
-    as.LHU(fsw, offsetof(ThreadState, fpu_sw), rec.threadStatePointer());
+    as.LHU(fsw, offsetof(ThreadState, ctx.fpu_sw), rec.threadStatePointer());
     as.FCLASS_D(class_bits, st0);
     as.AND(fsw, fsw, rmask);
 
@@ -10955,7 +10956,7 @@ FAST_HANDLE(FTST) {
     as.OR(fsw, fsw, negative_bit);
     as.OR(fsw, fsw, equal_bit);
 
-    as.SH(fsw, offsetof(ThreadState, fpu_sw), rec.threadStatePointer());
+    as.SH(fsw, offsetof(ThreadState, ctx.fpu_sw), rec.threadStatePointer());
 }
 
 FAST_HANDLE(FPATAN) {
@@ -11052,7 +11053,7 @@ FAST_HANDLE(FNSTENV) {
 
 FAST_HANDLE(FNSTSW) {
     biscuit::GPR temp = rec.scratch();
-    as.LHU(temp, offsetof(ThreadState, fpu_sw), rec.threadStatePointer());
+    as.LHU(temp, offsetof(ThreadState, ctx.fpu_sw), rec.threadStatePointer());
     rec.setGPR(&operands[0], temp);
 }
 
@@ -11116,7 +11117,7 @@ void FCOMI(Recompiler& rec, Assembler& as, ZydisDecodedOperand* operands, bool p
     Label less_than, equal, greater_than, unordered, end;
 
     // Most likely result - not unordered
-    as.SB(x0, offsetof(ThreadState, pf), rec.threadStatePointer());
+    as.SB(x0, offsetof(ThreadState, ctx.pf), rec.threadStatePointer());
 
     as.FEQ_D(cond, st0, st0);
     as.FEQ_D(cond2, sti, sti);
@@ -11142,7 +11143,7 @@ void FCOMI(Recompiler& rec, Assembler& as, ZydisDecodedOperand* operands, bool p
     as.Bind(&unordered);
     as.LI(zf, 1);
     as.LI(cf, 1);
-    as.SB(cf, offsetof(ThreadState, pf), rec.threadStatePointer());
+    as.SB(cf, offsetof(ThreadState, ctx.pf), rec.threadStatePointer());
     as.J(&end);
 
     as.Bind(&less_than);
@@ -11212,7 +11213,7 @@ void FCOM(Recompiler& rec, Assembler& as, ZydisDecodedOperand* operands, int pop
     as.OR(c0, c0, c2);
     as.OR(c0, c0, c3);
 
-    as.SH(c0, offsetof(ThreadState, fpu_sw), rec.threadStatePointer());
+    as.SH(c0, offsetof(ThreadState, ctx.fpu_sw), rec.threadStatePointer());
 
     rec.resetScratch();
     if (pop_count == 1) {
@@ -11328,7 +11329,7 @@ FAST_HANDLE(FABS) {
 FAST_HANDLE(FNSTCW) {
     biscuit::GPR address = rec.lea(&operands[0]);
     biscuit::GPR temp = rec.scratch();
-    as.LHU(temp, offsetof(ThreadState, fpu_cw), Recompiler::threadStatePointer());
+    as.LHU(temp, offsetof(ThreadState, ctx.fpu_cw), Recompiler::threadStatePointer());
     as.SH(temp, 0, address);
 }
 
@@ -11336,7 +11337,7 @@ FAST_HANDLE(FLDCW) {
     biscuit::GPR address = rec.lea(&operands[0]);
     biscuit::GPR temp = rec.scratch();
     as.LHU(temp, 0, address);
-    as.SH(temp, offsetof(ThreadState, fpu_cw), Recompiler::threadStatePointer());
+    as.SH(temp, offsetof(ThreadState, ctx.fpu_cw), Recompiler::threadStatePointer());
 
     biscuit::GPR rc = rec.scratch();
     // Extract rounding mode from FPU control word
@@ -11364,10 +11365,10 @@ FAST_HANDLE(FLDCW) {
 FAST_HANDLE(FNINIT) {
     biscuit::GPR temp = rec.scratch();
     as.LI(temp, 0x037F);
-    as.SH(temp, offsetof(ThreadState, fpu_cw), Recompiler::threadStatePointer());
+    as.SH(temp, offsetof(ThreadState, ctx.fpu_cw), Recompiler::threadStatePointer());
 
     as.LI(temp, -1);
-    as.SH(temp, offsetof(ThreadState, fpu_tw), Recompiler::threadStatePointer());
+    as.SH(temp, offsetof(ThreadState, ctx.fpu_tw), Recompiler::threadStatePointer());
 
     as.SB(x0, offsetof(ThreadState, fpu_top), Recompiler::threadStatePointer());
 
@@ -15227,7 +15228,7 @@ FAST_HANDLE(VPTEST) {
     }
 
     if (rec.shouldEmitFlag(rip, X86_REF_AF)) {
-        as.SB(x0, offsetof(ThreadState, af), rec.threadStatePointer());
+        as.SB(x0, offsetof(ThreadState, ctx.af), rec.threadStatePointer());
     }
 
     if (rec.shouldEmitFlag(rip, X86_REF_OF)) {
@@ -15241,7 +15242,7 @@ FAST_HANDLE(VPTEST) {
     }
 
     if (rec.shouldEmitFlag(rip, X86_REF_PF)) {
-        as.SB(x0, offsetof(ThreadState, pf), rec.threadStatePointer());
+        as.SB(x0, offsetof(ThreadState, ctx.pf), rec.threadStatePointer());
     }
 }
 
@@ -15279,7 +15280,7 @@ void VTEST(Recompiler& rec, u64 rip, Assembler& as, ZydisDecodedInstruction& ins
     }
 
     if (rec.shouldEmitFlag(rip, X86_REF_AF)) {
-        as.SB(x0, offsetof(ThreadState, af), rec.threadStatePointer());
+        as.SB(x0, offsetof(ThreadState, ctx.af), rec.threadStatePointer());
     }
 
     if (rec.shouldEmitFlag(rip, X86_REF_OF)) {
@@ -15293,7 +15294,7 @@ void VTEST(Recompiler& rec, u64 rip, Assembler& as, ZydisDecodedInstruction& ins
     }
 
     if (rec.shouldEmitFlag(rip, X86_REF_PF)) {
-        as.SB(x0, offsetof(ThreadState, pf), rec.threadStatePointer());
+        as.SB(x0, offsetof(ThreadState, ctx.pf), rec.threadStatePointer());
     }
 }
 

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -204,13 +204,6 @@ void Recompiler::emitDispatcher() {
 
     as.MV(threadStatePointer(), a0);
 
-    // Store the first frame so we can exit to it from a signal handler if needed
-    biscuit::Label ahead;
-    as.LD(t1, offsetof(ThreadState, first_frame), threadStatePointer());
-    as.BNEZ(t1, &ahead);
-    as.SD(sp, offsetof(ThreadState, first_frame), threadStatePointer());
-    as.Bind(&ahead);
-
     restoreState();
 
     // Align this to cache line boundary since it's hit often

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -357,7 +357,7 @@ void Recompiler::invalidateAt(ThreadState* state, u8* linked_block) {
             state->recompiler->as.SetCursorPointer(link_location);
             // Because there was a writebackState before entering this function, state->rip contains the guest address that we tried
             // to jump to before getting hit by this invalidation. So we can jumpAndLink there.
-            state->recompiler->jumpAndLink(state->rip);
+            state->recompiler->jumpAndLink(state->ctx.rip);
             state->recompiler->as.SetCursorPointer(cursor);
             flush_icache();
         }
@@ -594,7 +594,7 @@ u64 Recompiler::compileSequence(u64 rip) {
         if (is_mmx) {
             if (!ran_mmx_once) {
                 // Set FPU tag word to valid for the first MMX instruction in this block
-                as.SH(x0, offsetof(ThreadState, fpu_tw), threadStatePointer());
+                as.SH(x0, offsetof(ThreadState, ctx.fpu_tw), threadStatePointer());
             }
             ran_mmx_once = true;
             ASSERT_MSG(Extensions::V, "TODO: Implement MMX for no RVV");
@@ -733,7 +733,7 @@ void Recompiler::flushX87() {
                 top = getTOP();
                 tag_word = scratch();
                 if (x87_reg_cache[i].modify_tag) {
-                    as.LHU(tag_word, offsetof(ThreadState, fpu_tw), threadStatePointer());
+                    as.LHU(tag_word, offsetof(ThreadState, ctx.fpu_tw), threadStatePointer());
                     tag_dirty = true;
                 }
                 top_got = true;
@@ -743,7 +743,7 @@ void Recompiler::flushX87() {
             as.ADDI(st, top, index);
             as.ANDI(st, st, 0b111);
             as.SH3ADD(address, st, threadStatePointer());
-            as.FSD(x87_reg_cache[i].reg, offsetof(ThreadState, fp), address);
+            as.FSD(x87_reg_cache[i].reg, offsetof(ThreadState, ctx.fp), address);
 
             if (x87_reg_cache[i].modify_tag) {
                 ASSERT(pushed_this_block > 0);
@@ -770,14 +770,14 @@ void Recompiler::flushX87() {
             ASSERT(mmx_reg_cache[i].loaded);
             setVectorState(SEW::E64, 1);
             biscuit::Vec vec = mmx_reg_cache[i].reg;
-            as.ADDI(address, threadStatePointer(), offsetof(ThreadState, fp) + i * 8);
+            as.ADDI(address, threadStatePointer(), offsetof(ThreadState, ctx.fp) + i * 8);
             as.VSE64(vec, address);
         }
     }
 
     if (top_got) {
         if (tag_dirty) {
-            as.SH(tag_word, offsetof(ThreadState, fpu_tw), threadStatePointer());
+            as.SH(tag_word, offsetof(ThreadState, ctx.fpu_tw), threadStatePointer());
         }
         popScratch();
         popScratch();
@@ -1270,7 +1270,7 @@ biscuit::GPR Recompiler::getElementGPR(ZydisDecodedOperand* operand, x86_size_e 
     if (operand->type == ZYDIS_OPERAND_TYPE_REGISTER) {
         ASSERT(operand->reg.value >= ZYDIS_REGISTER_XMM0 && operand->reg.value <= ZYDIS_REGISTER_XMM15);
         x86_ref_e ref = zydisToRef(operand->reg.value);
-        offset = offsetof(ThreadState, xmm) + (ref - X86_REF_XMM0) * sizeof(XmmReg) + (getBitSize(size) / 8) * element;
+        offset = offsetof(ThreadState, ctx.xmm) + (ref - X86_REF_XMM0) * sizeof(XmmReg) + (getBitSize(size) / 8) * element;
         address = threadStatePointer();
     } else if (operand->type == ZYDIS_OPERAND_TYPE_MEMORY) {
         address = lea(operand, false);
@@ -1322,7 +1322,7 @@ biscuit::FPR Recompiler::getElementFPR(ZydisDecodedOperand* operand, x86_size_e 
     if (operand->type == ZYDIS_OPERAND_TYPE_REGISTER) {
         ASSERT(operand->reg.value >= ZYDIS_REGISTER_XMM0 && operand->reg.value <= ZYDIS_REGISTER_XMM15);
         x86_ref_e ref = zydisToRef(operand->reg.value);
-        offset = offsetof(ThreadState, xmm) + (ref - X86_REF_XMM0) * sizeof(XmmReg) + (getBitSize(size) / 8) * element;
+        offset = offsetof(ThreadState, ctx.xmm) + (ref - X86_REF_XMM0) * sizeof(XmmReg) + (getBitSize(size) / 8) * element;
         address = threadStatePointer();
     } else if (operand->type == ZYDIS_OPERAND_TYPE_MEMORY) {
         address = lea(operand, false);
@@ -1354,7 +1354,7 @@ void Recompiler::setElementGPR(ZydisDecodedOperand* operand, x86_size_e size, in
     if (operand->type == ZYDIS_OPERAND_TYPE_REGISTER) {
         ASSERT(operand->reg.value >= ZYDIS_REGISTER_XMM0 && operand->reg.value <= ZYDIS_REGISTER_XMM15);
         x86_ref_e ref = zydisToRef(operand->reg.value);
-        offset = offsetof(ThreadState, xmm) + (ref - X86_REF_XMM0) * sizeof(XmmReg) + (getBitSize(size) / 8) * element;
+        offset = offsetof(ThreadState, ctx.xmm) + (ref - X86_REF_XMM0) * sizeof(XmmReg) + (getBitSize(size) / 8) * element;
         address = threadStatePointer();
     } else if (operand->type == ZYDIS_OPERAND_TYPE_MEMORY) {
         address = lea(operand, false);
@@ -1392,7 +1392,7 @@ void Recompiler::setElementFPR(ZydisDecodedOperand* operand, x86_size_e size, in
     if (operand->type == ZYDIS_OPERAND_TYPE_REGISTER) {
         ASSERT(operand->reg.value >= ZYDIS_REGISTER_XMM0 && operand->reg.value <= ZYDIS_REGISTER_XMM15);
         x86_ref_e ref = zydisToRef(operand->reg.value);
-        offset = offsetof(ThreadState, xmm) + (ref - X86_REF_XMM0) * sizeof(XmmReg) + (getBitSize(size) / 8) * element;
+        offset = offsetof(ThreadState, ctx.xmm) + (ref - X86_REF_XMM0) * sizeof(XmmReg) + (getBitSize(size) / 8) * element;
         address = threadStatePointer();
     } else if (operand->type == ZYDIS_OPERAND_TYPE_MEMORY) {
         address = lea(operand, false);
@@ -1424,11 +1424,11 @@ u64 Recompiler::getImmediate(ZydisDecodedOperand* operand) {
 biscuit::GPR Recompiler::flag(x86_ref_e ref) {
     if (ref == X86_REF_PF) {
         biscuit::GPR reg = scratch();
-        as.LBU(reg, offsetof(ThreadState, pf), threadStatePointer());
+        as.LBU(reg, offsetof(ThreadState, ctx.pf), threadStatePointer());
         return reg;
     } else if (ref == X86_REF_AF) {
         biscuit::GPR reg = scratch();
-        as.LBU(reg, offsetof(ThreadState, af), threadStatePointer());
+        as.LBU(reg, offsetof(ThreadState, ctx.af), threadStatePointer());
         return reg;
     }
 
@@ -1734,9 +1734,9 @@ biscuit::GPR Recompiler::lea(const ZydisDecodedOperand* operand, bool use_temp) 
     // Cover the case of just a segment register
     if (has_segment && !has_base && !has_index && !has_disp) {
         if (operand->mem.segment == ZYDIS_REGISTER_FS) {
-            as.LD(address, offsetof(ThreadState, fsbase), threadStatePointer());
+            as.LD(address, offsetof(ThreadState, ctx.fsbase), threadStatePointer());
         } else if (operand->mem.segment == ZYDIS_REGISTER_GS) {
-            as.LD(address, offsetof(ThreadState, gsbase), threadStatePointer());
+            as.LD(address, offsetof(ThreadState, ctx.gsbase), threadStatePointer());
         } else {
             UNREACHABLE();
         }
@@ -1866,31 +1866,31 @@ biscuit::GPR Recompiler::lea(const ZydisDecodedOperand* operand, bool use_temp) 
         int offset;
         switch (operand->mem.segment) {
         case ZYDIS_REGISTER_FS: {
-            offset = offsetof(ThreadState, fsbase);
+            offset = offsetof(ThreadState, ctx.fsbase);
             break;
         }
         case ZYDIS_REGISTER_GS: {
-            offset = offsetof(ThreadState, gsbase);
+            offset = offsetof(ThreadState, ctx.gsbase);
             break;
         }
         case ZYDIS_REGISTER_SS: {
             ASSERT(g_mode32);
-            offset = offsetof(ThreadState, ssbase);
+            offset = offsetof(ThreadState, ctx.ssbase);
             break;
         }
         case ZYDIS_REGISTER_ES: {
             ASSERT(g_mode32);
-            offset = offsetof(ThreadState, esbase);
+            offset = offsetof(ThreadState, ctx.esbase);
             break;
         }
         case ZYDIS_REGISTER_DS: {
             ASSERT(g_mode32);
-            offset = offsetof(ThreadState, dsbase);
+            offset = offsetof(ThreadState, ctx.dsbase);
             break;
         }
         case ZYDIS_REGISTER_CS: {
             ASSERT(g_mode32);
-            offset = offsetof(ThreadState, csbase);
+            offset = offsetof(ThreadState, ctx.csbase);
             break;
         }
         default: {
@@ -1926,11 +1926,11 @@ void Recompiler::writebackState() {
     flushX87();
 
     biscuit::GPR rip = allocatedGPR(X86_REF_RIP);
-    as.SD(rip, offsetof(ThreadState, rip), threadStatePointer());
+    as.SD(rip, offsetof(ThreadState, ctx.rip), threadStatePointer());
 
     for (int i = 0; i < 16; i++) {
         x86_ref_e ref = (x86_ref_e)(X86_REF_RAX + i);
-        as.SD(allocatedGPR(ref), offsetof(ThreadState, gprs) + i * sizeof(u64), threadStatePointer());
+        as.SD(allocatedGPR(ref), offsetof(ThreadState, ctx.gprs) + i * sizeof(u64), threadStatePointer());
     }
 
     biscuit::GPR address = scratch();
@@ -1941,9 +1941,9 @@ void Recompiler::writebackState() {
         as.VSETVLI(address, x0, SEW::E64, LMUL::M8);
         biscuit::Vec xmm0 = allocatedVec(X86_REF_XMM0);
         biscuit::Vec xmm8 = allocatedVec(X86_REF_XMM8);
-        as.ADDI(address, threadStatePointer(), offsetof(ThreadState, xmm) + 0 * sizeof(XmmReg));
+        as.ADDI(address, threadStatePointer(), offsetof(ThreadState, ctx.xmm) + 0 * sizeof(XmmReg));
         as.VSE64(xmm0, address);
-        as.ADDI(address, threadStatePointer(), offsetof(ThreadState, xmm) + 8 * sizeof(XmmReg));
+        as.ADDI(address, threadStatePointer(), offsetof(ThreadState, ctx.xmm) + 8 * sizeof(XmmReg));
         as.VSE64(xmm8, address);
         resetVectorState();
     } else {
@@ -1955,7 +1955,7 @@ void Recompiler::writebackState() {
         }
         for (int i = 0; i < 16; i++) {
             biscuit::Vec vec = allocatedVec((x86_ref_e)(X86_REF_XMM0 + i));
-            as.ADDI(address, threadStatePointer(), offsetof(ThreadState, xmm) + i * sizeof(XmmReg));
+            as.ADDI(address, threadStatePointer(), offsetof(ThreadState, ctx.xmm) + i * sizeof(XmmReg));
             as.VSE64(vec, address);
         }
     }
@@ -1965,10 +1965,10 @@ void Recompiler::writebackState() {
     biscuit::GPR sf = allocatedGPR(X86_REF_SF);
     biscuit::GPR of = allocatedGPR(X86_REF_OF);
 
-    as.SB(cf, offsetof(ThreadState, cf), threadStatePointer());
-    as.SB(zf, offsetof(ThreadState, zf), threadStatePointer());
-    as.SB(sf, offsetof(ThreadState, sf), threadStatePointer());
-    as.SB(of, offsetof(ThreadState, of), threadStatePointer());
+    as.SB(cf, offsetof(ThreadState, ctx.cf), threadStatePointer());
+    as.SB(zf, offsetof(ThreadState, ctx.zf), threadStatePointer());
+    as.SB(sf, offsetof(ThreadState, ctx.sf), threadStatePointer());
+    as.SB(of, offsetof(ThreadState, ctx.of), threadStatePointer());
 
     resetVectorState();
     cached_lea_operand = nullptr;
@@ -1978,11 +1978,11 @@ void Recompiler::restoreState() {
     resetVectorState();
 
     biscuit::GPR rip = allocatedGPR(X86_REF_RIP);
-    as.LD(rip, offsetof(ThreadState, rip), threadStatePointer());
+    as.LD(rip, offsetof(ThreadState, ctx.rip), threadStatePointer());
 
     for (int i = 0; i < 16; i++) {
         x86_ref_e ref = (x86_ref_e)(X86_REF_RAX + i);
-        as.LD(allocatedGPR(ref), offsetof(ThreadState, gprs) + i * sizeof(u64), threadStatePointer());
+        as.LD(allocatedGPR(ref), offsetof(ThreadState, ctx.gprs) + i * sizeof(u64), threadStatePointer());
     }
 
     biscuit::GPR address = scratch();
@@ -1993,9 +1993,9 @@ void Recompiler::restoreState() {
         as.VSETVLI(address, x0, SEW::E64, LMUL::M8);
         biscuit::Vec xmm0 = allocatedVec(X86_REF_XMM0);
         biscuit::Vec xmm8 = allocatedVec(X86_REF_XMM8);
-        as.ADDI(address, threadStatePointer(), offsetof(ThreadState, xmm) + 0 * sizeof(XmmReg));
+        as.ADDI(address, threadStatePointer(), offsetof(ThreadState, ctx.xmm) + 0 * sizeof(XmmReg));
         as.VLE64(xmm0, address);
-        as.ADDI(address, threadStatePointer(), offsetof(ThreadState, xmm) + 8 * sizeof(XmmReg));
+        as.ADDI(address, threadStatePointer(), offsetof(ThreadState, ctx.xmm) + 8 * sizeof(XmmReg));
         as.VLE64(xmm8, address);
         resetVectorState();
     } else {
@@ -2006,7 +2006,7 @@ void Recompiler::restoreState() {
         }
         for (int i = 0; i < 16; i++) {
             biscuit::Vec vec = allocatedVec((x86_ref_e)(X86_REF_XMM0 + i));
-            as.ADDI(address, threadStatePointer(), offsetof(ThreadState, xmm) + sizeof(XmmReg) * i);
+            as.ADDI(address, threadStatePointer(), offsetof(ThreadState, ctx.xmm) + sizeof(XmmReg) * i);
             as.VLE64(vec, address);
         }
     }
@@ -2018,10 +2018,10 @@ void Recompiler::restoreState() {
     biscuit::GPR sf = allocatedGPR(X86_REF_SF);
     biscuit::GPR of = allocatedGPR(X86_REF_OF);
 
-    as.LBU(cf, offsetof(ThreadState, cf), threadStatePointer());
-    as.LBU(zf, offsetof(ThreadState, zf), threadStatePointer());
-    as.LBU(sf, offsetof(ThreadState, sf), threadStatePointer());
-    as.LBU(of, offsetof(ThreadState, of), threadStatePointer());
+    as.LBU(cf, offsetof(ThreadState, ctx.cf), threadStatePointer());
+    as.LBU(zf, offsetof(ThreadState, ctx.zf), threadStatePointer());
+    as.LBU(sf, offsetof(ThreadState, ctx.sf), threadStatePointer());
+    as.LBU(of, offsetof(ThreadState, ctx.of), threadStatePointer());
 
     // Restore the rounding mode
     if (fsrm_sse) {
@@ -2400,7 +2400,7 @@ void Recompiler::updateAuxiliaryAdd(biscuit::GPR lhs, biscuit::GPR result) {
     as.ANDI(af, result, 0xF);
     as.ANDI(temp, lhs, 0xF);
     as.SLTU(af, af, temp);
-    as.SB(af, offsetof(ThreadState, af), threadStatePointer());
+    as.SB(af, offsetof(ThreadState, ctx.af), threadStatePointer());
     popScratch();
     popScratch();
 }
@@ -2411,7 +2411,7 @@ void Recompiler::updateAuxiliarySub(biscuit::GPR lhs, biscuit::GPR rhs) {
     as.ANDI(af, rhs, 0xF);
     as.ANDI(temp, lhs, 0xF);
     as.SLTU(af, temp, af);
-    as.SB(af, offsetof(ThreadState, af), threadStatePointer());
+    as.SB(af, offsetof(ThreadState, ctx.af), threadStatePointer());
     popScratch();
     popScratch();
 }
@@ -2425,7 +2425,7 @@ void Recompiler::updateAuxiliaryAdc(biscuit::GPR lhs, biscuit::GPR result, biscu
     as.ANDI(temp, result_2, 0xF);
     as.SLTU(temp, temp, cf);
     as.OR(af, af, temp);
-    as.SB(af, offsetof(ThreadState, af), threadStatePointer());
+    as.SB(af, offsetof(ThreadState, ctx.af), threadStatePointer());
     popScratch();
     popScratch();
 }
@@ -2439,7 +2439,7 @@ void Recompiler::updateAuxiliarySbb(biscuit::GPR lhs, biscuit::GPR rhs, biscuit:
     as.ANDI(temp, result, 0xF);
     as.SLTU(temp, temp, cf);
     as.OR(af, af, temp);
-    as.SB(af, offsetof(ThreadState, af), threadStatePointer());
+    as.SB(af, offsetof(ThreadState, ctx.af), threadStatePointer());
     popScratch();
     popScratch();
 }
@@ -2470,10 +2470,10 @@ void Recompiler::updateCarryAdc(biscuit::GPR lhs, biscuit::GPR result, biscuit::
 
 void Recompiler::clearFlag(x86_ref_e ref) {
     if (ref == X86_REF_PF) {
-        as.SB(x0, offsetof(ThreadState, pf), threadStatePointer());
+        as.SB(x0, offsetof(ThreadState, ctx.pf), threadStatePointer());
         return;
     } else if (ref == X86_REF_AF) {
-        as.SB(x0, offsetof(ThreadState, af), threadStatePointer());
+        as.SB(x0, offsetof(ThreadState, ctx.af), threadStatePointer());
         return;
     }
 
@@ -2485,12 +2485,12 @@ void Recompiler::setFlag(x86_ref_e ref) {
     if (ref == X86_REF_PF) {
         biscuit::GPR one = scratch();
         as.LI(one, 1);
-        as.SB(one, offsetof(ThreadState, pf), threadStatePointer());
+        as.SB(one, offsetof(ThreadState, ctx.pf), threadStatePointer());
         return;
     } else if (ref == X86_REF_AF) {
         biscuit::GPR one = scratch();
         as.LI(one, 1);
-        as.SB(one, offsetof(ThreadState, af), threadStatePointer());
+        as.SB(one, offsetof(ThreadState, ctx.af), threadStatePointer());
         return;
     }
 
@@ -2555,7 +2555,7 @@ void Recompiler::updateParity(biscuit::GPR result) {
     as.CPOPW(pf, pf);
     as.ANDI(pf, pf, 1);
     as.XORI(pf, pf, 1);
-    as.SB(pf, offsetof(ThreadState, pf), threadStatePointer());
+    as.SB(pf, offsetof(ThreadState, ctx.pf), threadStatePointer());
     popScratch();
 }
 
@@ -3030,7 +3030,7 @@ biscuit::GPR Recompiler::getFlags() {
     biscuit::GPR zf = flag(X86_REF_ZF);
     biscuit::GPR sf = flag(X86_REF_SF);
     biscuit::GPR of = flag(X86_REF_OF);
-    as.LBU(temp, offsetof(ThreadState, df), threadStatePointer());
+    as.LBU(temp, offsetof(ThreadState, ctx.df), threadStatePointer());
     as.SLLI(temp, temp, 10);
     as.SLLI(reg, of, 11);
     as.OR(reg, reg, temp);
@@ -3066,21 +3066,21 @@ void Recompiler::setFlags(biscuit::GPR flags) {
 
     as.SRLI(temp, flags, 2);
     as.ANDI(temp, temp, 1);
-    as.SB(temp, offsetof(ThreadState, pf), threadStatePointer());
+    as.SB(temp, offsetof(ThreadState, ctx.pf), threadStatePointer());
 
     as.SRLI(zf, flags, 6);
     as.ANDI(zf, zf, 1);
 
     as.SRLI(temp, flags, 4);
     as.ANDI(temp, temp, 1);
-    as.SB(temp, offsetof(ThreadState, af), threadStatePointer());
+    as.SB(temp, offsetof(ThreadState, ctx.af), threadStatePointer());
 
     as.SRLI(sf, flags, 7);
     as.ANDI(sf, sf, 1);
 
     as.SRLI(temp, flags, 10);
     as.ANDI(temp, temp, 1);
-    as.SB(temp, offsetof(ThreadState, df), threadStatePointer());
+    as.SB(temp, offsetof(ThreadState, ctx.df), threadStatePointer());
 
     as.SRLI(of, flags, 11);
     as.ANDI(of, of, 1);
@@ -3118,7 +3118,7 @@ biscuit::FPR Recompiler::getST(int index, bool dirty) {
         as.ANDI(top, top, 0b111);
     }
     as.SH3ADD(address, top, threadStatePointer());
-    as.FLD(x87_reg_cache[index].reg, offsetof(ThreadState, fp), address);
+    as.FLD(x87_reg_cache[index].reg, offsetof(ThreadState, ctx.fp), address);
 
     popScratch();
     popScratch();
@@ -3536,9 +3536,9 @@ void Recompiler::popX87() {
         as.ANDI(top, top, 0b111);
         setTOP(top);
 
-        as.LHU(ftw, offsetof(ThreadState, fpu_tw), threadStatePointer());
+        as.LHU(ftw, offsetof(ThreadState, ctx.fpu_tw), threadStatePointer());
         as.OR(ftw, ftw, mask);
-        as.SH(ftw, offsetof(ThreadState, fpu_tw), threadStatePointer());
+        as.SH(ftw, offsetof(ThreadState, ctx.fpu_tw), threadStatePointer());
 
         popScratch();
         popScratch();

--- a/src/felix86/v2/recompiler.hpp
+++ b/src/felix86/v2/recompiler.hpp
@@ -372,7 +372,7 @@ struct Recompiler {
             // We don't statically allocate MMX registers because they are so rare
             // to justify loading/storing them on every VM enter/exit
             biscuit::GPR address = scratch();
-            as.ADDI(address, threadStatePointer(), offsetof(ThreadState, fp) + index * 8);
+            as.ADDI(address, threadStatePointer(), offsetof(ThreadState, ctx.fp) + index * 8);
             setVectorState(SEW::E64, 1);
             as.VLE64(entry.reg, address);
             popScratch();


### PR DESCRIPTION
Allows us to copy the x86 related stuff easier 