### PR TITLE
Make libvulkan pull X11

### DIFF
--- a/src/felix86/hle/guest_libs/CMakeLists.txt
+++ b/src/felix86/hle/guest_libs/CMakeLists.txt
@@ -42,6 +42,7 @@ set_target_properties(vulkan PROPERTIES
     OUTPUT_NAME "vulkan"
     SOVERSION 1
 )
+target_link_libraries(vulkan PRIVATE X11)
  
 add_library(GLX-asm OBJECT libGLX.asm)
 add_library(GLX SHARED libGLX.c $<TARGET_OBJECTS:GLX-asm>)


### PR DESCRIPTION
In the future we should load these X11 pointers at runtime, but for now make it pull X11