### PR TITLE
Pick higher addresses for PIC 32-bit executables

### DIFF
--- a/src/felix86/common/elf.cpp
+++ b/src/felix86/common/elf.cpp
@@ -458,6 +458,7 @@ void Elf::Load(const std::filesystem::path& path) {
             base_ptr = (u8*)g_mapper->map((u8*)base_hint, highest_vaddr, 0, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0);
         } else {
             u64 hint = 0;
+            int flags = MAP_PRIVATE | MAP_ANONYMOUS;
             if (g_mode32) {
                 // We don't want to load the executable in the low memory area, because if a non-relocatable executable wants to be loaded
                 // there, it won't be able to. Example is wine + an older 32-bit game with no relocation tables
@@ -471,8 +472,13 @@ void Elf::Load(const std::filesystem::path& path) {
                 } else {
                     hint = 0x9000'0000;
                 }
+                flags |= MAP_FIXED_NOREPLACE;
             }
-            base_ptr = (u8*)g_mapper->map((void*)hint, highest_vaddr, 0, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+            base_ptr = (u8*)g_mapper->map((void*)hint, highest_vaddr, 0, flags, -1, 0);
+            if (base_ptr == MAP_FAILED) {
+                WARN("Failed to allocate ELF at %lx", hint);
+                base_ptr = (u8*)g_mapper->map(nullptr, highest_vaddr, 0, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+            }
         }
 
         unmap_me.push_back({base_ptr, highest_vaddr});

--- a/src/felix86/common/elf.cpp
+++ b/src/felix86/common/elf.cpp
@@ -457,7 +457,22 @@ void Elf::Load(const std::filesystem::path& path) {
         if (base_hint) {
             base_ptr = (u8*)g_mapper->map((u8*)base_hint, highest_vaddr, 0, MAP_PRIVATE | MAP_ANONYMOUS | MAP_FIXED_NOREPLACE, -1, 0);
         } else {
-            base_ptr = (u8*)g_mapper->map(nullptr, highest_vaddr, 0, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+            u64 hint = 0;
+            if (g_mode32) {
+                // We don't want to load the executable in the low memory area, because if a non-relocatable executable wants to be loaded
+                // there, it won't be able to. Example is wine + an older 32-bit game with no relocation tables
+                if (is_interpreter) {
+                    if (g_executable_end) {
+                        hint = g_executable_end;
+                    } else {
+                        WARN("Interpreter loaded after executable?");
+                        hint = 0xA000'0000;
+                    }
+                } else {
+                    hint = 0x9000'0000;
+                }
+            }
+            base_ptr = (u8*)g_mapper->map((void*)hint, highest_vaddr, 0, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
         }
 
         unmap_me.push_back({base_ptr, highest_vaddr});


### PR DESCRIPTION
Our 32-bit allocator would choose the lowest available which is fine until you try to load an exe with wine that wants a fixed low address and wine can't load it because the wine/ld.so executables are there. 

Fixes Hitman Blood Money (without wine-preloader, with it works anyway) and probably a bunch of other 32-bit games.