### PR TITLE
Use UserContext for fsave/frstor functions

### DIFF
--- a/src/felix86/common/state.hpp
+++ b/src/felix86/common/state.hpp
@@ -204,6 +204,8 @@ struct UserContext {
     // This is important so that we know whether the current values in the fp array are MMX registers or x87 registers
     // Because if they are x87 registers we need to f64_to_f80 them when saving using fsave or when reading from signal handlers
     x87State x87_state = x87State::MMX;
+    biscuit::RMode rmode_sse{biscuit::RMode::RNE};
+    biscuit::RMode rmode_x87{biscuit::RMode::RNE};
 
     u64 GetFlags() {
         u64 flags = 0;
@@ -221,8 +223,6 @@ struct UserContext {
 // TODO: Please make me standard layout type? offsetof warnings...
 struct ThreadState {
     UserContext ctx{};
-    biscuit::RMode rmode_sse{biscuit::RMode::RNE};
-    biscuit::RMode rmode_x87{biscuit::RMode::RNE};
 
     pid_t* clear_tid_address = nullptr;
     pthread_t thread{}; // The pthread this state belongs to

--- a/src/felix86/common/state.hpp
+++ b/src/felix86/common/state.hpp
@@ -199,6 +199,11 @@ struct UserContext {
     u16 fpu_cw{};
     u16 fpu_tw{};
     u16 fpu_sw{};
+    u8 fpu_top{};
+
+    // This is important so that we know whether the current values in the fp array are MMX registers or x87 registers
+    // Because if they are x87 registers we need to f64_to_f80 them when saving using fsave or when reading from signal handlers
+    x87State x87_state = x87State::MMX;
 
     u64 GetFlags() {
         u64 flags = 0;
@@ -218,11 +223,6 @@ struct ThreadState {
     UserContext ctx{};
     biscuit::RMode rmode_sse{biscuit::RMode::RNE};
     biscuit::RMode rmode_x87{biscuit::RMode::RNE};
-    u8 fpu_top{};
-
-    // This is important so that we know whether the current values in the fp array are MMX registers or x87 registers
-    // Because if they are x87 registers we need to f64_to_f80 them when saving using fsave or when reading from signal handlers
-    x87State x87_state = x87State::MMX;
 
     pid_t* clear_tid_address = nullptr;
     pthread_t thread{}; // The pthread this state belongs to

--- a/src/felix86/common/utility.cpp
+++ b/src/felix86/common/utility.cpp
@@ -353,7 +353,7 @@ void felix86_fldenv_16(struct ThreadState* state, u64 address) {
     state->ctx.fpu_tw = env->tw;
     state->ctx.fpu_sw = env->sw;
     state->ctx.fpu_top = (env->sw >> 11) & 0b111;
-    state->rmode_x87 = rounding_mode(x86RoundingMode((state->ctx.fpu_cw >> 10) & 0b11));
+    state->ctx.rmode_x87 = rounding_mode(x86RoundingMode((state->ctx.fpu_cw >> 10) & 0b11));
 }
 
 void felix86_fldenv_32(struct ThreadState* state, u64 address) {
@@ -362,7 +362,7 @@ void felix86_fldenv_32(struct ThreadState* state, u64 address) {
     state->ctx.fpu_tw = env->tw;
     state->ctx.fpu_sw = env->sw;
     state->ctx.fpu_top = (env->sw >> 11) & 0b111;
-    state->rmode_x87 = rounding_mode(x86RoundingMode((state->ctx.fpu_cw >> 10) & 0b11));
+    state->ctx.rmode_x87 = rounding_mode(x86RoundingMode((state->ctx.fpu_cw >> 10) & 0b11));
 }
 
 void felix86_pmaddwd(i16* dst, i16* src) {

--- a/src/felix86/common/utility.cpp
+++ b/src/felix86/common/utility.cpp
@@ -19,7 +19,7 @@
 #include <sys/cachectl.h>
 #endif
 
-#define TOP(x) ((state->fpu_top + x) & 0b111)
+#define TOP(x) ((state->ctx.fpu_top + x) & 0b111)
 
 struct fenv_data_16 {
     u16 cw;
@@ -337,14 +337,14 @@ void felix86_fstenv_16(ThreadState* state, u64 address) {
     fenv_data_16* env = (fenv_data_16*)address;
     env->cw = state->ctx.fpu_cw;
     env->tw = state->ctx.fpu_tw;
-    env->sw = (state->fpu_top << 11) | (state->ctx.fpu_sw & ~(0b111 << 11));
+    env->sw = (state->ctx.fpu_top << 11) | (state->ctx.fpu_sw & ~(0b111 << 11));
 }
 
 void felix86_fstenv_32(ThreadState* state, u64 address) {
     fenv_data_32* env = (fenv_data_32*)address;
     env->cw = state->ctx.fpu_cw;
     env->tw = state->ctx.fpu_tw;
-    env->sw = (state->fpu_top << 11) | (state->ctx.fpu_sw & ~(0b111 << 11));
+    env->sw = (state->ctx.fpu_top << 11) | (state->ctx.fpu_sw & ~(0b111 << 11));
 }
 
 void felix86_fldenv_16(struct ThreadState* state, u64 address) {
@@ -352,7 +352,7 @@ void felix86_fldenv_16(struct ThreadState* state, u64 address) {
     state->ctx.fpu_cw = env->cw;
     state->ctx.fpu_tw = env->tw;
     state->ctx.fpu_sw = env->sw;
-    state->fpu_top = (env->sw >> 11) & 0b111;
+    state->ctx.fpu_top = (env->sw >> 11) & 0b111;
     state->rmode_x87 = rounding_mode(x86RoundingMode((state->ctx.fpu_cw >> 10) & 0b11));
 }
 
@@ -361,7 +361,7 @@ void felix86_fldenv_32(struct ThreadState* state, u64 address) {
     state->ctx.fpu_cw = env->cw;
     state->ctx.fpu_tw = env->tw;
     state->ctx.fpu_sw = env->sw;
-    state->fpu_top = (env->sw >> 11) & 0b111;
+    state->ctx.fpu_top = (env->sw >> 11) & 0b111;
     state->rmode_x87 = rounding_mode(x86RoundingMode((state->ctx.fpu_cw >> 10) & 0b11));
 }
 
@@ -937,8 +937,8 @@ void felix86_fcos(ThreadState* state) {
 void felix86_fsincos(ThreadState* state) {
     double boop;
     memcpy(&boop, &state->ctx.fp[TOP(0)], sizeof(double));
-    state->fpu_top -= 1;
-    state->ctx.fpu_tw &= ~(0b11 << (state->fpu_top * 2));
+    state->ctx.fpu_top -= 1;
+    state->ctx.fpu_tw &= ~(0b11 << (state->ctx.fpu_top * 2));
     sincos(boop, (double*)&state->ctx.fp[TOP(1)], (double*)&state->ctx.fp[TOP(0)]);
     state->ctx.fpu_sw &= ~C2_BIT;
 }
@@ -1350,7 +1350,7 @@ void felix86_fxam(ThreadState* state) {
     double st0d;
     memcpy(&st0d, &st0, 8);
 
-    u16 mask = 0b11 << state->fpu_top;
+    u16 mask = 0b11 << state->ctx.fpu_top;
 
     u8 c3c2c0;
     if ((state->ctx.fpu_tw & mask) == mask) {

--- a/src/felix86/common/xsave.cpp
+++ b/src/felix86/common/xsave.cpp
@@ -2,23 +2,23 @@
 #include "felix86/common/state.hpp"
 #include "felix86/common/xsave.hpp"
 
-void felix86_fsave_16(ThreadState* state, void* address) {
-    bool is_mmx = (x87State)state->ctx.x87_state == x87State::MMX;
+void felix86_fsave_16(const UserContext& ctx, void* address) {
+    bool is_mmx = (x87State)ctx.x87_state == x87State::MMX;
     fsave_frame_16* data = (fsave_frame_16*)address;
     for (int i = 0; i < 8; i++) {
         if (is_mmx) {
             u16 ones = 0xFFFF;
-            memcpy(&data->st[i], &state->ctx.fp[i], sizeof(double));
+            memcpy(&data->st[i], &ctx.fp[i], sizeof(double));
             memcpy(&data->st[i].exponent, &ones, sizeof(u16));
         } else {
-            Float80 f80 = f64_to_80(state->ctx.fp[i]);
+            Float80 f80 = f64_to_80(ctx.fp[i]);
             memcpy(&data->st[i], &f80, sizeof(Float80));
         }
     }
 
-    data->cw = state->ctx.fpu_cw;
-    data->tw = state->ctx.fpu_tw;
-    data->sw = (state->ctx.fpu_top << 11) | (state->ctx.fpu_sw & ~(0b111 << 11));
+    data->cw = ctx.fpu_cw;
+    data->tw = ctx.fpu_tw;
+    data->sw = (ctx.fpu_top << 11) | (ctx.fpu_sw & ~(0b111 << 11));
 
     // We use this reserved bit in FCW to signify we stored the registers as MMX and thus
     // will not need f80->f64 conversion if loaded with frstor
@@ -27,23 +27,23 @@ void felix86_fsave_16(ThreadState* state, void* address) {
     }
 }
 
-void felix86_fsave_32(ThreadState* state, void* address) {
-    bool is_mmx = (x87State)state->ctx.x87_state == x87State::MMX;
+void felix86_fsave_32(const UserContext& ctx, void* address) {
+    bool is_mmx = (x87State)ctx.x87_state == x87State::MMX;
     fsave_frame_32* data = (fsave_frame_32*)address;
     for (int i = 0; i < 8; i++) {
         if (is_mmx) {
             u16 ones = 0xFFFF;
-            memcpy(&data->st[i], &state->ctx.fp[i], sizeof(double));
+            memcpy(&data->st[i], &ctx.fp[i], sizeof(double));
             memcpy(&data->st[i].exponent, &ones, sizeof(u16));
         } else {
-            Float80 f80 = f64_to_80(state->ctx.fp[i]);
+            Float80 f80 = f64_to_80(ctx.fp[i]);
             memcpy(&data->st[i], &f80, sizeof(Float80));
         }
     }
 
-    data->cw = state->ctx.fpu_cw;
-    data->tw = state->ctx.fpu_tw;
-    data->sw = (state->ctx.fpu_top << 11) | (state->ctx.fpu_sw & ~(0b111 << 11));
+    data->cw = ctx.fpu_cw;
+    data->tw = ctx.fpu_tw;
+    data->sw = (ctx.fpu_top << 11) | (ctx.fpu_sw & ~(0b111 << 11));
 
     // We use this reserved bit in FCW to signify we stored the registers as MMX and thus
     // will not need f80->f64 conversion if loaded with frstor
@@ -52,45 +52,45 @@ void felix86_fsave_32(ThreadState* state, void* address) {
     }
 }
 
-void felix86_frstor_16(ThreadState* state, void* address) {
+void felix86_frstor_16(UserContext& ctx, void* address) {
     fsave_frame_16* data = (fsave_frame_16*)address;
 
-    state->ctx.fpu_top = (data->sw >> 11) & 0b111;
-    state->ctx.fpu_cw = data->cw;
-    state->ctx.fpu_tw = data->tw;
-    state->ctx.fpu_sw = data->sw;
-    state->rmode_x87 = rounding_mode(x86RoundingMode((state->ctx.fpu_cw >> 10) & 0b11));
+    ctx.fpu_top = (data->sw >> 11) & 0b111;
+    ctx.fpu_cw = data->cw;
+    ctx.fpu_tw = data->tw;
+    ctx.fpu_sw = data->sw;
+    ctx.rmode_x87 = rounding_mode(x86RoundingMode((ctx.fpu_cw >> 10) & 0b11));
 
     for (int i = 0; i < 8; i++) {
-        if (state->ctx.fpu_cw & 0x8000) {
-            memcpy(&state->ctx.fp[i], &data->st[i], sizeof(double));
+        if (ctx.fpu_cw & 0x8000) {
+            memcpy(&ctx.fp[i], &data->st[i], sizeof(double));
         } else {
             double f64 = f80_to_64(&data->st[i]);
-            memcpy(&state->ctx.fp[i], &f64, sizeof(double));
+            memcpy(&ctx.fp[i], &f64, sizeof(double));
         }
     }
 }
 
-void felix86_frstor_32(ThreadState* state, void* address) {
+void felix86_frstor_32(UserContext& ctx, void* address) {
     fsave_frame_32* data = (fsave_frame_32*)address;
 
-    state->ctx.fpu_top = (data->sw >> 11) & 0b111;
-    state->ctx.fpu_cw = data->cw;
-    state->ctx.fpu_tw = data->tw;
-    state->ctx.fpu_sw = data->sw;
-    state->rmode_x87 = rounding_mode(x86RoundingMode((state->ctx.fpu_cw >> 10) & 0b11));
+    ctx.fpu_top = (data->sw >> 11) & 0b111;
+    ctx.fpu_cw = data->cw;
+    ctx.fpu_tw = data->tw;
+    ctx.fpu_sw = data->sw;
+    ctx.rmode_x87 = rounding_mode(x86RoundingMode((ctx.fpu_cw >> 10) & 0b11));
 
     for (int i = 0; i < 8; i++) {
-        if (state->ctx.fpu_cw & 0x8000) {
-            memcpy(&state->ctx.fp[i], &data->st[i], sizeof(double));
+        if (ctx.fpu_cw & 0x8000) {
+            memcpy(&ctx.fp[i], &data->st[i], sizeof(double));
         } else {
             double f64 = f80_to_64(&data->st[i]);
-            memcpy(&state->ctx.fp[i], &f64, sizeof(double));
+            memcpy(&ctx.fp[i], &f64, sizeof(double));
         }
     }
 }
 
-void felix86_fxsave(UserContext& ctx, void* address, bool save_x87, bool save_xmm, bool save_mxcsr) {
+void felix86_fxsave(const UserContext& ctx, void* address, bool save_x87, bool save_xmm, bool save_mxcsr) {
     bool is_mmx = (x87State)ctx.x87_state == x87State::MMX;
     bool is_x87 = (x87State)ctx.x87_state == x87State::x87;
     fxsave_frame* data = (fxsave_frame*)address;
@@ -141,43 +141,43 @@ void felix86_fxsave(UserContext& ctx, void* address, bool save_x87, bool save_xm
     }
 }
 
-void felix86_fxrstor(ThreadState* state, void* address, bool restore_x87, bool restore_xmm, bool restore_mxcsr) {
+void felix86_fxrstor(UserContext& ctx, void* address, bool restore_x87, bool restore_xmm, bool restore_mxcsr) {
     fxsave_frame* data = (fxsave_frame*)address;
 
     if (restore_xmm) {
         for (int i = 0; i < (g_mode32 ? 8 : 16); i++) {
-            state->ctx.xmm[i].data[0] = data->xmms[i].val[0];
-            state->ctx.xmm[i].data[1] = data->xmms[i].val[1];
+            ctx.xmm[i].data[0] = data->xmms[i].val[0];
+            ctx.xmm[i].data[1] = data->xmms[i].val[1];
         }
     }
 
     if (restore_x87) {
-        state->ctx.fpu_tw = 0;
+        ctx.fpu_tw = 0;
         for (int i = 0; i < 8; i++) {
             if (!((data->ftw >> i) & 0b1)) {
-                state->ctx.fpu_tw |= 0b11 << (i * 2);
+                ctx.fpu_tw |= 0b11 << (i * 2);
             }
         }
 
-        state->ctx.fpu_cw = data->fcw;
-        state->ctx.fpu_sw = data->fsw;
-        state->ctx.fpu_top = (data->fsw >> 11) & 7;
+        ctx.fpu_cw = data->fcw;
+        ctx.fpu_sw = data->fsw;
+        ctx.fpu_top = (data->fsw >> 11) & 7;
 
         for (int i = 0; i < 8; i++) {
-            if (state->ctx.fpu_cw & 0x8000) {
-                memcpy(&state->ctx.fp[i], &data->st[i].st[0], sizeof(double));
+            if (ctx.fpu_cw & 0x8000) {
+                memcpy(&ctx.fp[i], &data->st[i].st[0], sizeof(double));
             } else {
                 double f64 = f80_to_64((Float80*)&data->st[i].st[0]);
-                memcpy(&state->ctx.fp[i], &f64, sizeof(double));
+                memcpy(&ctx.fp[i], &f64, sizeof(double));
             }
         }
 
-        state->rmode_x87 = rounding_mode(x86RoundingMode((state->ctx.fpu_cw >> 10) & 0b11));
+        ctx.rmode_x87 = rounding_mode(x86RoundingMode((ctx.fpu_cw >> 10) & 0b11));
     }
 
     if (restore_mxcsr) {
-        state->ctx.mxcsr = data->mxcsr;
-        state->rmode_sse = rounding_mode(x86RoundingMode((state->ctx.mxcsr >> 13) & 0b11));
+        ctx.mxcsr = data->mxcsr;
+        ctx.rmode_sse = rounding_mode(x86RoundingMode((ctx.mxcsr >> 13) & 0b11));
     }
 }
 
@@ -185,7 +185,7 @@ bool felix86_xsave_contains_ymms() {
     return is_feature_enabled(x86_feature::AVX) && is_feature_enabled(x86_feature::OSXSAVE);
 }
 
-void felix86_xsave(UserContext& ctx, void* address, bool save_all) {
+void felix86_xsave(const UserContext& ctx, void* address, bool save_all) {
     u64 rfbm = (u64)(u32)ctx.gprs[X86_REF_RDX] << 32 | (u32)ctx.gprs[X86_REF_RAX];
     bool save_x87 = (rfbm & 0b001) || save_all;
     bool save_xmm = (rfbm & 0b010) || save_all;
@@ -203,17 +203,17 @@ void felix86_xsave(UserContext& ctx, void* address, bool save_all) {
     }
 }
 
-void felix86_xrstor(ThreadState* state, void* address, bool restore_all) {
-    u64 rfbm = (u64)(u32)state->ctx.gprs[X86_REF_RDX] << 32 | (u32)state->ctx.gprs[X86_REF_RAX];
+void felix86_xrstor(UserContext& ctx, void* address, bool restore_all) {
+    u64 rfbm = (u64)(u32)ctx.gprs[X86_REF_RDX] << 32 | (u32)ctx.gprs[X86_REF_RAX];
     bool restore_x87 = (rfbm & 0b001) || restore_all;
     bool restore_xmm = (rfbm & 0b010) || restore_all;
     bool restore_avx = (rfbm & 0b100) || restore_all;
     bool restore_mxcsr = restore_xmm || restore_avx;
-    felix86_fxrstor(state, address, restore_x87, restore_xmm, restore_mxcsr);
+    felix86_fxrstor(ctx, address, restore_x87, restore_xmm, restore_mxcsr);
     if (felix86_xsave_contains_ymms() && restore_avx) {
         ymm_hi* ymm_storage = (ymm_hi*)((u8*)address + sizeof(fxsave_frame) + sizeof(xsave_header));
         for (int i = 0; i < 16; i++) {
-            memcpy(&state->ctx.xmm[i].data[2], (u8*)ymm_storage->data + 16 * i, sizeof(u64) * 2);
+            memcpy(&ctx.xmm[i].data[2], (u8*)ymm_storage->data + 16 * i, sizeof(u64) * 2);
         }
     }
 }

--- a/src/felix86/common/xsave.cpp
+++ b/src/felix86/common/xsave.cpp
@@ -3,7 +3,7 @@
 #include "felix86/common/xsave.hpp"
 
 void felix86_fsave_16(ThreadState* state, void* address) {
-    bool is_mmx = (x87State)state->x87_state == x87State::MMX;
+    bool is_mmx = (x87State)state->ctx.x87_state == x87State::MMX;
     fsave_frame_16* data = (fsave_frame_16*)address;
     for (int i = 0; i < 8; i++) {
         if (is_mmx) {
@@ -18,7 +18,7 @@ void felix86_fsave_16(ThreadState* state, void* address) {
 
     data->cw = state->ctx.fpu_cw;
     data->tw = state->ctx.fpu_tw;
-    data->sw = (state->fpu_top << 11) | (state->ctx.fpu_sw & ~(0b111 << 11));
+    data->sw = (state->ctx.fpu_top << 11) | (state->ctx.fpu_sw & ~(0b111 << 11));
 
     // We use this reserved bit in FCW to signify we stored the registers as MMX and thus
     // will not need f80->f64 conversion if loaded with frstor
@@ -28,7 +28,7 @@ void felix86_fsave_16(ThreadState* state, void* address) {
 }
 
 void felix86_fsave_32(ThreadState* state, void* address) {
-    bool is_mmx = (x87State)state->x87_state == x87State::MMX;
+    bool is_mmx = (x87State)state->ctx.x87_state == x87State::MMX;
     fsave_frame_32* data = (fsave_frame_32*)address;
     for (int i = 0; i < 8; i++) {
         if (is_mmx) {
@@ -43,7 +43,7 @@ void felix86_fsave_32(ThreadState* state, void* address) {
 
     data->cw = state->ctx.fpu_cw;
     data->tw = state->ctx.fpu_tw;
-    data->sw = (state->fpu_top << 11) | (state->ctx.fpu_sw & ~(0b111 << 11));
+    data->sw = (state->ctx.fpu_top << 11) | (state->ctx.fpu_sw & ~(0b111 << 11));
 
     // We use this reserved bit in FCW to signify we stored the registers as MMX and thus
     // will not need f80->f64 conversion if loaded with frstor
@@ -55,7 +55,7 @@ void felix86_fsave_32(ThreadState* state, void* address) {
 void felix86_frstor_16(ThreadState* state, void* address) {
     fsave_frame_16* data = (fsave_frame_16*)address;
 
-    state->fpu_top = (data->sw >> 11) & 0b111;
+    state->ctx.fpu_top = (data->sw >> 11) & 0b111;
     state->ctx.fpu_cw = data->cw;
     state->ctx.fpu_tw = data->tw;
     state->ctx.fpu_sw = data->sw;
@@ -74,7 +74,7 @@ void felix86_frstor_16(ThreadState* state, void* address) {
 void felix86_frstor_32(ThreadState* state, void* address) {
     fsave_frame_32* data = (fsave_frame_32*)address;
 
-    state->fpu_top = (data->sw >> 11) & 0b111;
+    state->ctx.fpu_top = (data->sw >> 11) & 0b111;
     state->ctx.fpu_cw = data->cw;
     state->ctx.fpu_tw = data->tw;
     state->ctx.fpu_sw = data->sw;
@@ -90,28 +90,28 @@ void felix86_frstor_32(ThreadState* state, void* address) {
     }
 }
 
-void felix86_fxsave(ThreadState* state, void* address, bool save_x87, bool save_xmm, bool save_mxcsr) {
-    bool is_mmx = (x87State)state->x87_state == x87State::MMX;
-    bool is_x87 = (x87State)state->x87_state == x87State::x87;
+void felix86_fxsave(UserContext& ctx, void* address, bool save_x87, bool save_xmm, bool save_mxcsr) {
+    bool is_mmx = (x87State)ctx.x87_state == x87State::MMX;
+    bool is_x87 = (x87State)ctx.x87_state == x87State::x87;
     fxsave_frame* data = (fxsave_frame*)address;
 
     if (save_xmm) {
         for (int i = 0; i < (g_mode32 ? 8 : 16); i++) {
-            data->xmms[i] = state->GetXmm(x86_ref_e(X86_REF_XMM0 + i));
+            data->xmms[i] = ctx.xmm[i];
         }
     }
 
     if (save_x87) {
         for (int i = 0; i < 8; i++) {
             if (is_x87) {
-                Float80 f80 = f64_to_80(state->ctx.fp[i]);
+                Float80 f80 = f64_to_80(ctx.fp[i]);
                 memcpy(&data->st[i].st[0], &f80, sizeof(Float80));
             } else {
                 if (!is_mmx) {
                     WARN("Unknown x87 state during fxsave");
                 }
                 u16 ones = 0xFFFF;
-                memcpy(&data->st[i].st[0], &state->ctx.fp[i], sizeof(double));
+                memcpy(&data->st[i].st[0], &ctx.fp[i], sizeof(double));
                 memcpy(&data->st[i].st[8], &ones, sizeof(u16));
             }
         }
@@ -120,14 +120,14 @@ void felix86_fxsave(ThreadState* state, void* address, bool save_x87, bool save_
         data->ftw = 0;
         for (int i = 0; i < 8; i++) {
             u16 mask = 0b11 << (i * 2);
-            bool empty = (mask & state->ctx.fpu_tw) == mask;
+            bool empty = (mask & ctx.fpu_tw) == mask;
             if (!empty) {
                 data->ftw |= 1 << i;
             }
         }
 
-        data->fcw = state->ctx.fpu_cw;
-        data->fsw = (state->fpu_top << 11) | (state->ctx.fpu_sw & ~(0b111 << 11));
+        data->fcw = ctx.fpu_cw;
+        data->fsw = (ctx.fpu_top << 11) | (ctx.fpu_sw & ~(0b111 << 11));
 
         // We use this reserved bit in FCW to signify we stored the registers as MMX and thus
         // will not need f80->f64 conversion if loaded with fxrstor
@@ -137,7 +137,7 @@ void felix86_fxsave(ThreadState* state, void* address, bool save_x87, bool save_
     }
 
     if (save_mxcsr) {
-        data->mxcsr = state->ctx.mxcsr;
+        data->mxcsr = ctx.mxcsr;
     }
 }
 
@@ -161,7 +161,7 @@ void felix86_fxrstor(ThreadState* state, void* address, bool restore_x87, bool r
 
         state->ctx.fpu_cw = data->fcw;
         state->ctx.fpu_sw = data->fsw;
-        state->fpu_top = (data->fsw >> 11) & 7;
+        state->ctx.fpu_top = (data->fsw >> 11) & 7;
 
         for (int i = 0; i < 8; i++) {
             if (state->ctx.fpu_cw & 0x8000) {
@@ -185,20 +185,20 @@ bool felix86_xsave_contains_ymms() {
     return is_feature_enabled(x86_feature::AVX) && is_feature_enabled(x86_feature::OSXSAVE);
 }
 
-void felix86_xsave(ThreadState* state, void* address, bool save_all) {
-    u64 rfbm = (u64)(u32)state->ctx.gprs[X86_REF_RDX] << 32 | (u32)state->ctx.gprs[X86_REF_RAX];
+void felix86_xsave(UserContext& ctx, void* address, bool save_all) {
+    u64 rfbm = (u64)(u32)ctx.gprs[X86_REF_RDX] << 32 | (u32)ctx.gprs[X86_REF_RAX];
     bool save_x87 = (rfbm & 0b001) || save_all;
     bool save_xmm = (rfbm & 0b010) || save_all;
     bool save_avx = (rfbm & 0b100) || save_all;
     bool save_mxcsr = save_xmm || save_avx;
-    felix86_fxsave(state, address, save_x87, save_xmm, save_mxcsr);
+    felix86_fxsave(ctx, address, save_x87, save_xmm, save_mxcsr);
     if (felix86_xsave_contains_ymms() && save_avx) {
         xsave_header* header = (xsave_header*)((u8*)address + sizeof(fxsave_frame));
         header->xstate_bv = get_xfeature_enabled_mask();
         header->xcomp_bv = 0; // use standard form
         ymm_hi* ymm_storage = (ymm_hi*)((u8*)address + sizeof(fxsave_frame) + sizeof(xsave_header));
         for (int i = 0; i < 16; i++) {
-            memcpy((u8*)ymm_storage->data + 16 * i, &state->ctx.xmm[i].data[2], sizeof(u64) * 2);
+            memcpy((u8*)ymm_storage->data + 16 * i, &ctx.xmm[i].data[2], sizeof(u64) * 2);
         }
     }
 }

--- a/src/felix86/common/xsave.hpp
+++ b/src/felix86/common/xsave.hpp
@@ -96,20 +96,20 @@ struct ymm_hi {
     u64 data[2 * 16];
 };
 
-void felix86_fsave_16(ThreadState* state, void* address);
+void felix86_fsave_16(const UserContext& ctx, void* address);
 
-void felix86_fsave_32(ThreadState* state, void* address);
+void felix86_fsave_32(const UserContext& ctx, void* address);
 
-void felix86_fxsave(UserContext& ctx, void* address, bool save_x87 = true, bool save_xmm = true, bool save_mxcsr = true);
+void felix86_fxsave(const UserContext& ctx, void* address, bool save_x87 = true, bool save_xmm = true, bool save_mxcsr = true);
 
-void felix86_xsave(UserContext& ctx, void* address, bool save_all);
+void felix86_xsave(const UserContext& ctx, void* address, bool save_all);
 
-void felix86_frstor_16(ThreadState* state, void* address);
+void felix86_frstor_16(UserContext& ctx, void* address);
 
-void felix86_frstor_32(ThreadState* state, void* address);
+void felix86_frstor_32(UserContext& ctx, void* address);
 
-void felix86_fxrstor(ThreadState* state, void* address, bool restore_x87 = true, bool restore_xmm = true, bool restore_mxcsr = true);
+void felix86_fxrstor(UserContext& ctx, void* address, bool restore_x87 = true, bool restore_xmm = true, bool restore_mxcsr = true);
 
-void felix86_xrstor(ThreadState* state, void* address, bool restore_all);
+void felix86_xrstor(UserContext& ctx, void* address, bool restore_all);
 
 bool felix86_xsave_contains_ymms();

--- a/src/felix86/common/xsave.hpp
+++ b/src/felix86/common/xsave.hpp
@@ -2,7 +2,6 @@
 
 #include "felix86/common/types.hpp"
 
-struct ThreadState;
 struct UserContext;
 
 struct XmmReg {

--- a/src/felix86/common/xsave.hpp
+++ b/src/felix86/common/xsave.hpp
@@ -3,6 +3,7 @@
 #include "felix86/common/types.hpp"
 
 struct ThreadState;
+struct UserContext;
 
 struct XmmReg {
     u64 data[4] = {0, 0, 0, 0};
@@ -99,9 +100,9 @@ void felix86_fsave_16(ThreadState* state, void* address);
 
 void felix86_fsave_32(ThreadState* state, void* address);
 
-void felix86_fxsave(ThreadState* state, void* address, bool save_x87 = true, bool save_xmm = true, bool save_mxcsr = true);
+void felix86_fxsave(UserContext& ctx, void* address, bool save_x87 = true, bool save_xmm = true, bool save_mxcsr = true);
 
-void felix86_xsave(ThreadState* state, void* address, bool save_all);
+void felix86_xsave(UserContext& ctx, void* address, bool save_all);
 
 void felix86_frstor_16(ThreadState* state, void* address);
 

--- a/src/felix86/hle/signals.cpp
+++ b/src/felix86/hle/signals.cpp
@@ -514,7 +514,7 @@ void setupFrame_x86_rt(RegisteredSignal& signal, int sig, ThreadState* state, si
     x86_fpstate* fpstate = (x86_fpstate*)rsp;
     ASSERT((u64)fpstate < UINT32_MAX);
 
-    felix86_fsave_32(state, &fpstate->fsave);
+    felix86_fsave_32(state->ctx, &fpstate->fsave);
 
     fpstate->magic = 0; // extended state
 
@@ -670,7 +670,7 @@ void setupFrame_x86(RegisteredSignal& signal, int sig, ThreadState* state, sigin
     }
     frame->sig = sig;
     frame->extramask = old_mask.__val[1];
-    felix86_fsave_32(state, &fpstate->fsave);
+    felix86_fsave_32(state->ctx, &fpstate->fsave);
     frame->fpstate_unused.magic = 0; // extended state
     felix86_xsave(state->ctx, &fpstate->fxsave, true);
     frame->sc.fpstate = (u32)(u64)fpstate;
@@ -756,7 +756,7 @@ void Signals::sigreturn(ThreadState* state, bool rt) {
             ctx = &legacy_frame->sc;
         }
         restore_sigcontext_32(state, ctx);
-        felix86_xrstor(state, &((x86_fpstate*)(u64)ctx->fpstate)->fxsave, true);
+        felix86_xrstor(state->ctx, &((x86_fpstate*)(u64)ctx->fpstate)->fxsave, true);
 
         // Restore signal mask to what it was supposed to be outside of signal handler
         sigset_t new_set;
@@ -812,7 +812,7 @@ void Signals::sigreturn(ThreadState* state, bool rt) {
         state->SetFlag(X86_REF_OF, of);
         state->SetFlag(X86_REF_DF, df);
 
-        felix86_xrstor(state, &frame->uc.uc_mcontext.fpregs->fxsave, true);
+        felix86_xrstor(state->ctx, &frame->uc.uc_mcontext.fpregs->fxsave, true);
 
         // Restore signal mask to what it was supposed to be outside of signal handler
         Signals::sigprocmask(state, SIG_SETMASK, &frame->uc.uc_sigmask, nullptr);

--- a/src/felix86/hle/signals.cpp
+++ b/src/felix86/hle/signals.cpp
@@ -449,7 +449,7 @@ void setupFrame_x64(RegisteredSignal& signal, int sig, ThreadState* state, sigin
     frame->uc.uc_mcontext.gregs[REG_OLDMASK] = 0;
     frame->uc.uc_mcontext.gregs[REG_CR2] = 0;
 
-    felix86_xsave(state, &frame->uc.uc_mcontext.fpregs->fxsave, true);
+    felix86_xsave(state->ctx, &frame->uc.uc_mcontext.fpregs->fxsave, true);
 
     state->SetGpr(X86_REF_RSP, (u64)frame);        // set the new stack pointer
     state->SetGpr(X86_REF_RDI, sig);               // set the signal
@@ -518,7 +518,7 @@ void setupFrame_x86_rt(RegisteredSignal& signal, int sig, ThreadState* state, si
 
     fpstate->magic = 0; // extended state
 
-    felix86_xsave(state, &fpstate->fxsave, true);
+    felix86_xsave(state->ctx, &fpstate->fxsave, true);
 
     rsp -= sizeof(x86_rt_sigframe);
 
@@ -672,7 +672,7 @@ void setupFrame_x86(RegisteredSignal& signal, int sig, ThreadState* state, sigin
     frame->extramask = old_mask.__val[1];
     felix86_fsave_32(state, &fpstate->fsave);
     frame->fpstate_unused.magic = 0; // extended state
-    felix86_xsave(state, &fpstate->fxsave, true);
+    felix86_xsave(state->ctx, &fpstate->fxsave, true);
     frame->sc.fpstate = (u32)(u64)fpstate;
 
     state->SetGpr(X86_REF_RSP, (u64)frame); // set the new stack pointer

--- a/src/felix86/v2/handlers.cpp
+++ b/src/felix86/v2/handlers.cpp
@@ -9131,6 +9131,7 @@ FAST_HANDLE(FXRSTOR) {
     rec.writebackState();
     as.MV(a1, address);
     as.MV(a0, rec.threadStatePointer());
+    static_assert(offsetof(ThreadState, ctx) == 0);
     as.LI(a2, 1);
     as.LI(a3, 1);
     as.LI(a4, 1);
@@ -9143,6 +9144,7 @@ FAST_HANDLE(FXRSTOR64) {
     rec.writebackState();
     as.MV(a1, address);
     as.MV(a0, rec.threadStatePointer());
+    static_assert(offsetof(ThreadState, ctx) == 0);
     as.LI(a2, 1);
     as.LI(a3, 1);
     as.LI(a4, 1);
@@ -9156,6 +9158,7 @@ FAST_HANDLE(XSAVE) {
     rec.writebackState();
     as.MV(a1, address);
     as.MV(a0, rec.threadStatePointer());
+    static_assert(offsetof(ThreadState, ctx) == 0);
     as.LI(a2, 0); // don't save all, use rfbm
     rec.callPointer(offsetof(ThreadState, felix86_xsave));
     rec.restoreState();
@@ -9167,6 +9170,7 @@ FAST_HANDLE(XSAVE64) {
     rec.writebackState();
     as.MV(a1, address);
     as.MV(a0, rec.threadStatePointer());
+    static_assert(offsetof(ThreadState, ctx) == 0);
     as.LI(a2, 0); // don't save all, use rfbm
     rec.callPointer(offsetof(ThreadState, felix86_xsave));
     rec.restoreState();
@@ -9178,6 +9182,7 @@ FAST_HANDLE(XRSTOR) {
     rec.writebackState();
     as.MV(a1, address);
     as.MV(a0, rec.threadStatePointer());
+    static_assert(offsetof(ThreadState, ctx) == 0);
     as.LI(a2, 0); // don't restore all, use rfbm
     rec.callPointer(offsetof(ThreadState, felix86_xrstor));
     rec.restoreState();
@@ -9189,6 +9194,7 @@ FAST_HANDLE(XRSTOR64) {
     rec.writebackState();
     as.MV(a1, address);
     as.MV(a0, rec.threadStatePointer());
+    static_assert(offsetof(ThreadState, ctx) == 0);
     as.LI(a2, 0); // don't restore all, use rfbm
     rec.callPointer(offsetof(ThreadState, felix86_xrstor));
     rec.restoreState();
@@ -10138,7 +10144,7 @@ FAST_HANDLE(LDMXCSR) {
     // Also save the converted rounding mode for quick access
     as.ANDI(masked, src, 0xFFC0); // ignore low bits
     as.SW(masked, offsetof(ThreadState, ctx.mxcsr), rec.threadStatePointer());
-    as.SB(temp, offsetof(ThreadState, rmode_sse), rec.threadStatePointer());
+    as.SB(temp, offsetof(ThreadState, ctx.rmode_sse), rec.threadStatePointer());
 
     rec.setFsrmSSE(true);
 }
@@ -11442,7 +11448,7 @@ FAST_HANDLE(FLDCW) {
     as.ANDI(temp, temp, 0b11);
     as.FSRM(x0, temp);
 
-    as.SB(temp, offsetof(ThreadState, rmode_x87), rec.threadStatePointer());
+    as.SB(temp, offsetof(ThreadState, ctx.rmode_x87), rec.threadStatePointer());
 
     rec.setFsrmSSE(false);
 }
@@ -11529,6 +11535,7 @@ FAST_HANDLE(FNSAVE) {
     rec.writebackState();
     as.MV(a1, address);
     as.MV(a0, rec.threadStatePointer());
+    static_assert(offsetof(ThreadState, ctx) == 0);
     if (instruction.attributes & ZYDIS_ATTRIB_HAS_OPERANDSIZE) {
         rec.callPointer(offsetof(ThreadState, felix86_fsave_16));
     } else {
@@ -11542,6 +11549,7 @@ FAST_HANDLE(FRSTOR) {
     rec.writebackState();
     as.MV(a1, address);
     as.MV(a0, rec.threadStatePointer());
+    static_assert(offsetof(ThreadState, ctx) == 0);
     if (instruction.attributes & ZYDIS_ATTRIB_HAS_OPERANDSIZE) {
         rec.callPointer(offsetof(ThreadState, felix86_frstor_16));
     } else {

--- a/src/felix86/v2/handlers.cpp
+++ b/src/felix86/v2/handlers.cpp
@@ -9105,6 +9105,7 @@ FAST_HANDLE(FXSAVE) {
     rec.writebackState();
     as.MV(a1, address);
     as.MV(a0, rec.threadStatePointer());
+    static_assert(offsetof(ThreadState, ctx) == 0);
     as.LI(a2, 1);
     as.LI(a3, 1);
     as.LI(a4, 1);
@@ -9117,6 +9118,7 @@ FAST_HANDLE(FXSAVE64) {
     rec.writebackState();
     as.MV(a1, address);
     as.MV(a0, rec.threadStatePointer());
+    static_assert(offsetof(ThreadState, ctx) == 0);
     as.LI(a2, 1);
     as.LI(a3, 1);
     as.LI(a4, 1);
@@ -11453,7 +11455,7 @@ FAST_HANDLE(FNINIT) {
     as.LI(temp, -1);
     as.SH(temp, offsetof(ThreadState, ctx.fpu_tw), Recompiler::threadStatePointer());
 
-    as.SB(x0, offsetof(ThreadState, fpu_top), Recompiler::threadStatePointer());
+    as.SB(x0, offsetof(ThreadState, ctx.fpu_top), Recompiler::threadStatePointer());
 
     // FINIT sets it to nearest neighbor which happens to be 0 in both x86 and RISC-V
     as.FSRM(x0);

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -765,7 +765,7 @@ void Recompiler::flushX87() {
         ASSERT(top_got);
         as.ADDI(top, top, -pushed_this_block);
         as.ANDI(top, top, 0b111);
-        as.SB(top, offsetof(ThreadState, fpu_top), threadStatePointer());
+        as.SB(top, offsetof(ThreadState, ctx.fpu_top), threadStatePointer());
     }
 
     for (int i = 0; i < 8; i++) {
@@ -3107,7 +3107,7 @@ void Recompiler::setFlags(biscuit::GPR flags) {
 
 biscuit::GPR Recompiler::getTOP() {
     biscuit::GPR top = scratch();
-    as.LBU(top, offsetof(ThreadState, fpu_top), threadStatePointer());
+    as.LBU(top, offsetof(ThreadState, ctx.fpu_top), threadStatePointer());
     return top;
 }
 
@@ -3256,7 +3256,7 @@ void Recompiler::setST(ZydisDecodedOperand* operand, biscuit::FPR value) {
 }
 
 void Recompiler::setTOP(biscuit::GPR new_top) {
-    as.SB(new_top, offsetof(ThreadState, fpu_top), threadStatePointer());
+    as.SB(new_top, offsetof(ThreadState, ctx.fpu_top), threadStatePointer());
 }
 
 void Recompiler::invalidateBlock(BlockMetadata* block) {
@@ -3577,7 +3577,7 @@ void Recompiler::switchToMMX() {
 
     biscuit::GPR val = scratch();
     as.LI(val, (int)x87State::MMX);
-    as.SB(val, offsetof(ThreadState, x87_state), threadStatePointer());
+    as.SB(val, offsetof(ThreadState, ctx.x87_state), threadStatePointer());
     popScratch();
 
     local_x87_state = x87State::MMX;
@@ -3586,7 +3586,7 @@ void Recompiler::switchToMMX() {
 void Recompiler::switchToX87() {
     biscuit::GPR val = scratch();
     as.LI(val, (int)x87State::x87);
-    as.SB(val, offsetof(ThreadState, x87_state), threadStatePointer());
+    as.SB(val, offsetof(ThreadState, ctx.x87_state), threadStatePointer());
     popScratch();
 
     local_x87_state = x87State::x87;

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -613,13 +613,13 @@ u64 Recompiler::compileSequence(u64 rip) {
         if (is_x87 && isFsrmSSE()) {
             // An x87 instruction, load the x87 rounding mode
             biscuit::GPR rm = scratch();
-            as.LBU(rm, offsetof(ThreadState, rmode_x87), threadStatePointer());
+            as.LBU(rm, offsetof(ThreadState, ctx.rmode_x87), threadStatePointer());
             as.FSRM(x0, rm);
             popScratch();
             setFsrmSSE(false);
         } else if (is_sse && !isFsrmSSE()) {
             biscuit::GPR rm = scratch();
-            as.LBU(rm, offsetof(ThreadState, rmode_sse), threadStatePointer());
+            as.LBU(rm, offsetof(ThreadState, ctx.rmode_sse), threadStatePointer());
             as.FSRM(x0, rm);
             popScratch();
             setFsrmSSE(true);
@@ -2030,12 +2030,12 @@ void Recompiler::restoreState() {
     // Restore the rounding mode
     if (fsrm_sse) {
         biscuit::GPR rm = scratch();
-        as.LBU(rm, offsetof(ThreadState, rmode_sse), threadStatePointer());
+        as.LBU(rm, offsetof(ThreadState, ctx.rmode_sse), threadStatePointer());
         as.FSRM(x0, rm);
         popScratch();
     } else {
         biscuit::GPR rm = scratch();
-        as.LBU(rm, offsetof(ThreadState, rmode_x87), threadStatePointer());
+        as.LBU(rm, offsetof(ThreadState, ctx.rmode_x87), threadStatePointer());
         as.FSRM(x0, rm);
         popScratch();
     }


### PR DESCRIPTION
This will be helpful for getting/setting remote contexts without copying the entire ThreadState