### PR TITLE
Turn error to warning

### DIFF
--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -526,7 +526,7 @@ u64 Recompiler::compileSequence(u64 rip) {
     }
 
     if (all_zeroes) {
-        ERROR("Jumped to address %lx which has a sequence of zeroes -- probably a bad jump?", rip);
+        WARN("Jumped to address %lx which has a sequence of zeroes -- probably a bad jump?", rip);
     }
 
     scanAhead(rip);


### PR DESCRIPTION
This is getting hit in Ubisoft Game Launcher consistently and it looks like it eventually does something normal, so it's intended.