### PR TITLE
Use multiple CMPXCHG16B locks instead of 1 global lock

### DIFF
--- a/src/felix86/common/config.inc
+++ b/src/felix86/common/config.inc
@@ -70,4 +70,3 @@ X(Performance, bool, auto_compress, false, FELIX86_AUTO_COMPRESS, "Automatically
 X(Performance, bool, scan_ahead_multi, true, FELIX86_SCAN_AHEAD_MULTI, "Scan ahead to multiple blocks when possible, avoiding even more flag calculations")
 X(Performance, bool, no_address_overflow, true, FELIX86_NO_ADDRESS_OVERFLOW, "Assume addresses won't overflow in 32-bit apps, which allows for some optimizations")
 X(Performance, bool, group_loadstore, true, FELIX86_GROUP_LOADSTORE, "Load/store SIMD state in groups of eight, may improve performance")
-X(Performance, bool, cas128_global, false, FELIX86_CAS128_GLOBAL, "Use a global lock for emulating CMPXCHG16B, may improve stability but worsen performance in some games")

--- a/src/felix86/common/config.inc
+++ b/src/felix86/common/config.inc
@@ -70,3 +70,4 @@ X(Performance, bool, auto_compress, false, FELIX86_AUTO_COMPRESS, "Automatically
 X(Performance, bool, scan_ahead_multi, true, FELIX86_SCAN_AHEAD_MULTI, "Scan ahead to multiple blocks when possible, avoiding even more flag calculations")
 X(Performance, bool, no_address_overflow, true, FELIX86_NO_ADDRESS_OVERFLOW, "Assume addresses won't overflow in 32-bit apps, which allows for some optimizations")
 X(Performance, bool, group_loadstore, true, FELIX86_GROUP_LOADSTORE, "Load/store SIMD state in groups of eight, may improve performance")
+X(Performance, bool, cas128_global, false, FELIX86_CAS128_GLOBAL, "Use a global lock for emulating CMPXCHG16B, may improve stability but worsen performance in some games")

--- a/src/felix86/common/global.cpp
+++ b/src/felix86/common/global.cpp
@@ -98,7 +98,7 @@ void ProcessGlobals::initialize() {
 
     perf = std::make_unique<Perf>();
 
-    cas128_lock = 0;
+    memset(cas128_locks, 0, sizeof(cas128_locks));
 
     // HACK: Don't clear as they get shared per mount namespace
     // TODO: proper mount namespacing when we need it

--- a/src/felix86/common/global.hpp
+++ b/src/felix86/common/global.hpp
@@ -49,7 +49,7 @@ struct ProcessGlobals {
     std::unique_ptr<Perf> perf;
 
     // For cmpxchg16b
-    u32 cas128_lock = 0;
+    u32 cas128_locks[256];
 
     // TODO: this isn't per CLONE_VM but per mount namespace
     // But we don't care for now

--- a/src/felix86/v2/handlers.cpp
+++ b/src/felix86/v2/handlers.cpp
@@ -10687,7 +10687,7 @@ FAST_HANDLE(CMPXCHG16B) {
         as.LI(lock_address, (u64)&g_process_globals.cas128_locks);
         // We will pick one of 256 different spinlocks based on a hash created by our address
         // This means that if two cmpxchg16b target the same address they will spin on the same lock
-        // but if they get a different one they will likely get a different one, which should decrease
+        // but if they target a different address they will likely get a different lock, which should decrease
         // lock contention
         constexpr u32 knuth_hash = 2654435761u;
         as.LI(mem1, knuth_hash);

--- a/src/felix86/v2/handlers.cpp
+++ b/src/felix86/v2/handlers.cpp
@@ -10685,22 +10685,18 @@ FAST_HANDLE(CMPXCHG16B) {
         biscuit::GPR lock_address = rec.scratch();
         biscuit::GPR lock = rec.scratch();
         as.LI(lock_address, (u64)&g_process_globals.cas128_locks);
-        if (g_config.cas128_global) {
-            // Do nothing, use the first lock in the array
-        } else {
-            // We will pick one of 256 different spinlocks based on a hash created by our address
-            // This means that if two cmpxchg16b target the same address they will spin on the same lock
-            // but if they get a different one they will likely get a different one, which should decrease
-            // lock contention
-            constexpr u32 knuth_hash = 2654435761u;
-            as.LI(mem1, knuth_hash);
-            as.SRLI(mem0, address, 4); // shift out low bits since they are 0 to get a better hash
-            as.MULW(mem0, mem0, mem1);
-            as.ANDI(mem0, mem0, 0xFF);
-            as.SLLI(mem0, mem0, 2);
-            static_assert(sizeof(g_process_globals.cas128_locks) == 256 * sizeof(u32));
-            as.ADD(lock_address, lock_address, mem0);
-        }
+        // We will pick one of 256 different spinlocks based on a hash created by our address
+        // This means that if two cmpxchg16b target the same address they will spin on the same lock
+        // but if they get a different one they will likely get a different one, which should decrease
+        // lock contention
+        constexpr u32 knuth_hash = 2654435761u;
+        as.LI(mem1, knuth_hash);
+        as.SRLI(mem0, address, 4); // shift out low bits since they are 0 to get a better hash
+        as.MULW(mem0, mem0, mem1);
+        as.ANDI(mem0, mem0, 0xFF);
+        as.SLLI(mem0, mem0, 2);
+        static_assert(sizeof(g_process_globals.cas128_locks) == 256 * sizeof(u32));
+        as.ADD(lock_address, lock_address, mem0);
 
         as.Bind(&spinloop);
         as.LI(lock, 1);

--- a/src/felix86/v2/handlers.cpp
+++ b/src/felix86/v2/handlers.cpp
@@ -10696,7 +10696,9 @@ FAST_HANDLE(CMPXCHG16B) {
             as.LI(mem1, knuth_hash);
             as.SRLI(mem0, address, 4); // shift out low bits since they are 0 to get a better hash
             as.MULW(mem0, mem0, mem1);
-            as.ANDI(mem0, mem0, (sizeof(g_process_globals.cas128_locks) / sizeof(u32)) - 1);
+            as.ANDI(mem0, mem0, 0xFF);
+            as.SLLI(mem0, mem0, 2);
+            static_assert(sizeof(g_process_globals.cas128_locks) == 256 * sizeof(u32));
             as.ADD(lock_address, lock_address, mem0);
         }
 

--- a/src/felix86/v2/handlers.cpp
+++ b/src/felix86/v2/handlers.cpp
@@ -10698,8 +10698,8 @@ FAST_HANDLE(CMPXCHG16B) {
         static_assert(sizeof(g_process_globals.cas128_locks) == 256 * sizeof(u32));
         as.ADD(lock_address, lock_address, mem0);
 
-        as.Bind(&spinloop);
         as.LI(lock, 1);
+        as.Bind(&spinloop);
         as.AMOSWAP_W(Ordering::AQRL, lock, lock, lock_address);
         as.BNEZ(lock, &spinloop);
 

--- a/src/felix86/v2/handlers.cpp
+++ b/src/felix86/v2/handlers.cpp
@@ -10684,7 +10684,21 @@ FAST_HANDLE(CMPXCHG16B) {
         biscuit::Label spinloop, writeloop;
         biscuit::GPR lock_address = rec.scratch();
         biscuit::GPR lock = rec.scratch();
-        as.LI(lock_address, (u64)&g_process_globals.cas128_lock);
+        as.LI(lock_address, (u64)&g_process_globals.cas128_locks);
+        if (g_config.cas128_global) {
+            // Do nothing, use the first lock in the array
+        } else {
+            // We will pick one of 256 different spinlocks based on a hash created by our address
+            // This means that if two cmpxchg16b target the same address they will spin on the same lock
+            // but if they get a different one they will likely get a different one, which should decrease
+            // lock contention
+            constexpr u32 knuth_hash = 2654435761u;
+            as.LI(mem1, knuth_hash);
+            as.SRLI(mem0, address, 4); // shift out low bits since they are 0 to get a better hash
+            as.MULW(mem0, mem0, mem1);
+            as.ANDI(mem0, mem0, (sizeof(g_process_globals.cas128_locks) / sizeof(u32)) - 1);
+            as.ADD(lock_address, lock_address, mem0);
+        }
 
         as.Bind(&spinloop);
         as.LI(lock, 1);

--- a/src/felix86/v2/handlers.cpp
+++ b/src/felix86/v2/handlers.cpp
@@ -10694,9 +10694,8 @@ FAST_HANDLE(CMPXCHG16B) {
         as.SRLI(mem0, address, 4); // shift out low bits since they are 0 to get a better hash
         as.MULW(mem0, mem0, mem1);
         as.ANDI(mem0, mem0, 0xFF);
-        as.SLLI(mem0, mem0, 2);
         static_assert(sizeof(g_process_globals.cas128_locks) == 256 * sizeof(u32));
-        as.ADD(lock_address, lock_address, mem0);
+        as.SH2ADD(lock_address, mem0, lock_address);
 
         as.LI(lock, 1);
         as.Bind(&spinloop);


### PR DESCRIPTION
CMPXCHG16B would previously use a single global lock to provide some (but not perfect) atomicity to the instruction, since we don't have hardware support. This would cause high contention. In some games, the blocks with the lock would take up 80% of the CPU and lag immensely.

This PR implements a fast per-address spinlock. A random spinlock out of 256 is picked based on a hash of the address. This greatly reduces collisions and improves performance in affected games by a lot. If two threads perform CAS on the same address, the same spinlock is picked, providing the same atomicity guarantees as before, assuming all the instructions are aligned.