### PR TITLE
Reduce memory footprint of BlockMetadata

### DIFF
--- a/src/felix86/hle/signals.cpp
+++ b/src/felix86/hle/signals.cpp
@@ -312,20 +312,20 @@ struct x86_rt_sigframe {
     /* fp state follows here */
 };
 
-std::pair<u64, BlockMetadata*> get_block_metadata(ThreadState* state, u64 host_pc) {
+BlockMetadata* get_block_metadata(ThreadState* state, u64 host_pc) {
     auto& map = state->recompiler->getHostPcMap();
     auto it = map.lower_bound(host_pc);
     ASSERT(it != map.end());
-    auto [rip, block] = it->second;
+    BlockMetadata* block = it->second;
     u64 address_end = block->host_address;
     for (auto& sizes : block->translation_sizes) {
         address_end += sizes.riscv_instructions_size;
     }
     if (!(host_pc >= block->host_address && host_pc < address_end)) {
         WARN("PC: %lx not inside range %lx-%lx?", host_pc, block->host_address, address_end);
-        return {0, nullptr};
+        return nullptr;
     }
-    return {rip, block};
+    return block;
 }
 
 u64 get_actual_rip(BlockMetadata& metadata, u64 guest_address, u64 fault_pc) {
@@ -1212,8 +1212,9 @@ bool handle_wild_sigsegv(ThreadState* current_state, siginfo_t* info, ucontext_t
         if (g_config.calltrace) {
             LOG("Current RIP:");
             if (in_jit_code) {
-                auto [block_rip, current_block] = get_block_metadata(current_state, pc);
+                auto current_block = get_block_metadata(current_state, pc);
                 if (current_block) {
+                    u64 block_rip = current_block->guest_address;
                     u64 actual_rip = get_actual_rip(*current_block, block_rip, pc);
                     print_address(actual_rip);
                 } else {
@@ -1266,8 +1267,9 @@ bool handle_wild_sigabrt(ThreadState* current_state, siginfo_t* info, ucontext_t
         if (g_config.calltrace) {
             LOG("Current RIP:");
             if (in_jit_code) {
-                auto [block_rip, current_block] = get_block_metadata(current_state, pc);
+                auto current_block = get_block_metadata(current_state, pc);
                 if (current_block) {
+                    u64 block_rip = current_block->guest_address;
                     u64 actual_rip = get_actual_rip(*current_block, block_rip, pc);
                     print_address(actual_rip);
                 } else {
@@ -1325,9 +1327,9 @@ bool handle_synchronous(ThreadState* current_state, siginfo_t* info, ucontext_t*
         tas2.SLTIU(x0, x0, FELIX86_HINT_GP);
     }
 
-    auto [block_rip, current_block] = get_block_metadata(current_state, pc);
+    BlockMetadata* current_block = get_block_metadata(current_state, pc);
     ASSERT_MSG(current_block, "Failed to get current block during synchronous signal with PC=%lx, RIP=%lx", pc, current_state->ctx.rip);
-    u64 actual_rip = get_actual_rip(*current_block, block_rip, pc);
+    u64 actual_rip = get_actual_rip(*current_block, current_block->guest_address, pc);
 
     int sig;
     if (next_instruction == expected_divzero) {
@@ -1403,8 +1405,9 @@ void signal_handler(int sig, siginfo_t* info, void* ctx) {
     if (info->si_code > 0 && (sig == SIGSEGV || sig == SIGBUS || sig == SIGILL || sig == SIGFPE || sig == SIGTRAP)) {
         // Synchronous signal, handle immediately
         if (is_in_jit_code(state, (u8*)pc)) {
-            auto [block_rip, current_block] = get_block_metadata(state, pc);
+            BlockMetadata* current_block = get_block_metadata(state, pc);
             ASSERT_MSG(current_block, "Failed to get current block during synchronous signal with PC=%lx, RIP=%lx", pc, state->ctx.rip);
+            u64 block_rip = current_block->guest_address;
             u64 actual_rip = get_actual_rip(*current_block, block_rip, pc);
             VERBOSE("Synchronous signal block: %lx, actual rip: %lx", block_rip, actual_rip);
             return prepare_synchronous_signal(state, sig, info, ctx, actual_rip);

--- a/src/felix86/hle/signals.cpp
+++ b/src/felix86/hle/signals.cpp
@@ -312,31 +312,36 @@ struct x86_rt_sigframe {
     /* fp state follows here */
 };
 
-BlockMetadata* get_block_metadata(ThreadState* state, u64 host_pc) {
+std::pair<u64, BlockMetadata*> get_block_metadata(ThreadState* state, u64 host_pc) {
     auto& map = state->recompiler->getHostPcMap();
     auto it = map.lower_bound(host_pc);
     ASSERT(it != map.end());
-    if (!(host_pc >= it->second->address && host_pc <= it->second->address_end)) {
-        WARN("PC: %lx not inside range %lx-%lx?", host_pc, it->second->address, it->second->address_end);
-        return nullptr;
+    auto [rip, block] = it->second;
+    u64 address_end = block->host_address;
+    for (auto& sizes : block->translation_sizes) {
+        address_end += sizes.riscv_instructions_size;
     }
-    return it->second;
+    if (!(host_pc >= block->host_address && host_pc < address_end)) {
+        WARN("PC: %lx not inside range %lx-%lx?", host_pc, block->host_address, address_end);
+        return {0, nullptr};
+    }
+    return {rip, block};
 }
 
-u64 get_actual_rip(BlockMetadata& metadata, u64 host_pc) {
-    u64 ret_value{};
-    for (auto& span : metadata.instruction_spans) {
-        if (host_pc >= span.second) {
-            ret_value = span.first;
-        } else { // if it's smaller it means that instruction isn't reached yet, return previous value
-            ASSERT_MSG(ret_value != 0, "First PC: %lx, Our PC: %lx, Block: %lx-%lx", metadata.instruction_spans[0].second, host_pc, metadata.address,
-                       metadata.address_end);
-            return ret_value;
+u64 get_actual_rip(BlockMetadata& metadata, u64 guest_address, u64 fault_pc) {
+    u64 start_guest_address = guest_address;
+    u64 host_address = metadata.host_address;
+    size_t instruction_count = metadata.translation_sizes.size();
+    for (size_t i = 0; i < instruction_count; i++) {
+        u64 host_address_end = host_address + metadata.translation_sizes[i].riscv_instructions_size;
+        if (fault_pc >= host_address && fault_pc < host_address_end) {
+            return guest_address;
         }
+        guest_address += metadata.translation_sizes[i].x86_instruction_size;
+        host_address = host_address_end;
     }
-
-    ASSERT(ret_value != 0);
-    return ret_value;
+    ERROR("Couldn't find RIP for block of RIP %lx and PC: %lx and fault PC: %lx", start_guest_address, metadata.host_address, fault_pc);
+    return 0;
 }
 
 #ifndef REG_PC
@@ -1207,9 +1212,9 @@ bool handle_wild_sigsegv(ThreadState* current_state, siginfo_t* info, ucontext_t
         if (g_config.calltrace) {
             LOG("Current RIP:");
             if (in_jit_code) {
-                BlockMetadata* current_block = get_block_metadata(current_state, pc);
+                auto [block_rip, current_block] = get_block_metadata(current_state, pc);
                 if (current_block) {
-                    u64 actual_rip = get_actual_rip(*current_block, pc);
+                    u64 actual_rip = get_actual_rip(*current_block, block_rip, pc);
                     print_address(actual_rip);
                 } else {
 #ifdef __riscv
@@ -1261,9 +1266,9 @@ bool handle_wild_sigabrt(ThreadState* current_state, siginfo_t* info, ucontext_t
         if (g_config.calltrace) {
             LOG("Current RIP:");
             if (in_jit_code) {
-                BlockMetadata* current_block = get_block_metadata(current_state, pc);
+                auto [block_rip, current_block] = get_block_metadata(current_state, pc);
                 if (current_block) {
-                    u64 actual_rip = get_actual_rip(*current_block, pc);
+                    u64 actual_rip = get_actual_rip(*current_block, block_rip, pc);
                     print_address(actual_rip);
                 } else {
 #ifdef __riscv
@@ -1320,9 +1325,9 @@ bool handle_synchronous(ThreadState* current_state, siginfo_t* info, ucontext_t*
         tas2.SLTIU(x0, x0, FELIX86_HINT_GP);
     }
 
-    BlockMetadata* current_block = get_block_metadata(current_state, pc);
+    auto [block_rip, current_block] = get_block_metadata(current_state, pc);
     ASSERT_MSG(current_block, "Failed to get current block during synchronous signal with PC=%lx, RIP=%lx", pc, current_state->ctx.rip);
-    u64 actual_rip = get_actual_rip(*current_block, pc);
+    u64 actual_rip = get_actual_rip(*current_block, block_rip, pc);
 
     int sig;
     if (next_instruction == expected_divzero) {
@@ -1398,10 +1403,10 @@ void signal_handler(int sig, siginfo_t* info, void* ctx) {
     if (info->si_code > 0 && (sig == SIGSEGV || sig == SIGBUS || sig == SIGILL || sig == SIGFPE || sig == SIGTRAP)) {
         // Synchronous signal, handle immediately
         if (is_in_jit_code(state, (u8*)pc)) {
-            BlockMetadata* current_block = get_block_metadata(state, pc);
+            auto [block_rip, current_block] = get_block_metadata(state, pc);
             ASSERT_MSG(current_block, "Failed to get current block during synchronous signal with PC=%lx, RIP=%lx", pc, state->ctx.rip);
-            u64 actual_rip = get_actual_rip(*current_block, pc);
-            VERBOSE("Synchronous signal block: %lx, actual rip: %lx", current_block->guest_address, actual_rip);
+            u64 actual_rip = get_actual_rip(*current_block, block_rip, pc);
+            VERBOSE("Synchronous signal block: %lx, actual rip: %lx", block_rip, actual_rip);
             return prepare_synchronous_signal(state, sig, info, ctx, actual_rip);
         } else {
             ERROR("Synchronous signal %s with code %d but not in JIT code during RIP=%lx, PC=%lx", sigdescr_np(sig), info->si_code, state->ctx.rip,

--- a/src/felix86/repl.cpp
+++ b/src/felix86/repl.cpp
@@ -123,9 +123,9 @@ void compile(const std::string& input) {
 
     std::unique_ptr<Recompiler> rec = std::make_unique<Recompiler>(true);
     rec->setFlagMode(flag_mode);
-    auto start = rec->getAssembler().GetCursorPointer();
+    u64 start = (u64)rec->getAssembler().GetCursorPointer();
     rec->compileSequence((u64)output.data());
-    auto end = rec->getAssembler().GetCursorPointer();
+    u64 end = (u64)rec->getAssembler().GetCursorPointer();
 
     BlockMetadata& metadata = rec->getBlockMetadata((u64)output.data());
 
@@ -143,25 +143,25 @@ void compile(const std::string& input) {
     end -= 8;
 
     size_t span_index = 0;
+    u64 address = start;
     for (int i = 0; i < end - start;) {
-        void* address = start + i;
-        i += 4;
-        u32 data = 0;
-        memcpy(&data, address, 4);
-        const char* out = rv64_print(data, (u64)address);
-
-        if (span_index + 1 < metadata.instruction_spans.size() && (u64)address == metadata.instruction_spans[span_index + 1].second) {
-            span_index++;
+        u64 riscv_size = metadata.translation_sizes[span_index].riscv_instructions_size;
+        for (int j = 0; j < riscv_size; j += 4) {
+            u32 data = 0;
+            memcpy(&data, (void*)(address + j), 4);
+            const char* out = rv64_print(data, address + j);
+            if (use_color) {
+                printf("%s", colors[span_index % color_count]);
+            }
+            printf("%s", out);
+            if (use_color) {
+                printf("%s", reset);
+            }
+            printf("\n");
         }
-
-        if (use_color) {
-            printf("%s", colors[span_index % color_count]);
-        }
-        printf("%s", out);
-        if (use_color) {
-            printf("%s", reset);
-        }
-        printf("\n");
+        address += riscv_size;
+        i += riscv_size;
+        span_index++;
     }
 }
 

--- a/src/felix86/v2/handlers.cpp
+++ b/src/felix86/v2/handlers.cpp
@@ -14126,7 +14126,7 @@ FAST_HANDLE(VPMOVSXDQ) {
 void VGATHER(Recompiler& rec, Assembler& as, ZydisDecodedInstruction& instruction, ZydisDecodedOperand* operands, SEW sew, int elements,
              bool sign_extend_index) {
     if (operands[1].mem.base == ZYDIS_REGISTER_NONE) {
-        WARN("VGATHER with base == x0 at %lx", rec.getCurrentMetadata().guest_address);
+        WARN("VGATHER with base == x0");
     }
     ASSERT(operands[1].mem.index != ZYDIS_REGISTER_NONE);
     ASSERT(operands[0].reg.value != operands[1].mem.index);
@@ -14324,7 +14324,7 @@ void VCMP(Recompiler& rec, Assembler& as, ZydisDecodedInstruction& instruction, 
     rec.setVectorState(sew, elements);
     switch (imm & 0b11111) {
     case EQ_OS: {
-        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().address);
+        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().host_address);
         [[fallthrough]];
     }
     case EQ_OQ: {
@@ -14332,7 +14332,7 @@ void VCMP(Recompiler& rec, Assembler& as, ZydisDecodedInstruction& instruction, 
         break;
     }
     case LT_OS: {
-        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().address);
+        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().host_address);
         [[fallthrough]];
     }
     case LT_OQ: {
@@ -14340,7 +14340,7 @@ void VCMP(Recompiler& rec, Assembler& as, ZydisDecodedInstruction& instruction, 
         break;
     }
     case LE_OS: {
-        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().address);
+        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().host_address);
         [[fallthrough]];
     }
     case LE_OQ: {
@@ -14348,7 +14348,7 @@ void VCMP(Recompiler& rec, Assembler& as, ZydisDecodedInstruction& instruction, 
         break;
     }
     case UNORD_S: {
-        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().address);
+        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().host_address);
         [[fallthrough]];
     }
     case UNORD_Q: {
@@ -14359,7 +14359,7 @@ void VCMP(Recompiler& rec, Assembler& as, ZydisDecodedInstruction& instruction, 
         break;
     }
     case NEQ_US: {
-        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().address);
+        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().host_address);
         [[fallthrough]];
     }
     case NEQ_UQ: {
@@ -14371,7 +14371,7 @@ void VCMP(Recompiler& rec, Assembler& as, ZydisDecodedInstruction& instruction, 
         break;
     }
     case NLT_US: {
-        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().address);
+        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().host_address);
         [[fallthrough]];
     }
     case NLT_UQ: {
@@ -14383,7 +14383,7 @@ void VCMP(Recompiler& rec, Assembler& as, ZydisDecodedInstruction& instruction, 
         break;
     }
     case NLE_US: {
-        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().address);
+        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().host_address);
         [[fallthrough]];
     }
     case NLE_UQ: {
@@ -14395,7 +14395,7 @@ void VCMP(Recompiler& rec, Assembler& as, ZydisDecodedInstruction& instruction, 
         break;
     }
     case ORD_S: {
-        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().address);
+        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().host_address);
         [[fallthrough]];
     }
     case ORD_Q: {
@@ -14406,7 +14406,7 @@ void VCMP(Recompiler& rec, Assembler& as, ZydisDecodedInstruction& instruction, 
         break;
     }
     case EQ_US: {
-        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().address);
+        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().host_address);
         [[fallthrough]];
     }
     case EQ_UQ: {
@@ -14418,7 +14418,7 @@ void VCMP(Recompiler& rec, Assembler& as, ZydisDecodedInstruction& instruction, 
         break;
     }
     case NGE_US: {
-        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().address);
+        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().host_address);
         [[fallthrough]];
     }
     case NGE_UQ: {
@@ -14430,7 +14430,7 @@ void VCMP(Recompiler& rec, Assembler& as, ZydisDecodedInstruction& instruction, 
         break;
     }
     case NGT_US: {
-        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().address);
+        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().host_address);
         [[fallthrough]];
     }
     case NGT_UQ: {
@@ -14442,7 +14442,7 @@ void VCMP(Recompiler& rec, Assembler& as, ZydisDecodedInstruction& instruction, 
         break;
     }
     case FALSE_OS: {
-        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().address);
+        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().host_address);
         [[fallthrough]];
     }
     case FALSE_OQ: {
@@ -14450,7 +14450,7 @@ void VCMP(Recompiler& rec, Assembler& as, ZydisDecodedInstruction& instruction, 
         break;
     }
     case NEQ_OS: {
-        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().address);
+        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().host_address);
         [[fallthrough]];
     }
     case NEQ_OQ: {
@@ -14462,7 +14462,7 @@ void VCMP(Recompiler& rec, Assembler& as, ZydisDecodedInstruction& instruction, 
         break;
     }
     case GE_OS: {
-        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().address);
+        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().host_address);
         [[fallthrough]];
     }
     case GE_OQ: {
@@ -14470,7 +14470,7 @@ void VCMP(Recompiler& rec, Assembler& as, ZydisDecodedInstruction& instruction, 
         break;
     }
     case GT_OS: {
-        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().address);
+        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().host_address);
         [[fallthrough]];
     }
     case GT_OQ: {
@@ -14478,7 +14478,7 @@ void VCMP(Recompiler& rec, Assembler& as, ZydisDecodedInstruction& instruction, 
         break;
     }
     case TRUE_US: {
-        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().address);
+        WARN("Signaling comparison at rip=%lx", rec.getCurrentMetadata().host_address);
         [[fallthrough]];
     }
     case TRUE_UQ: {

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -336,7 +336,7 @@ void Recompiler::invalidateAt(ThreadState* state, u8* linked_block) {
         tas.AUIPC(t5, 0);
         ASSERT(instruction == *(u32*)linked_block);
 
-        auto [rip, block] = get_block_metadata(state, (u64)linked_block);
+        BlockMetadata* block = get_block_metadata(state, (u64)linked_block);
         ASSERT_MSG(block, "Failed to get block metadata for address %lx", linked_block);
         // The link location should be an instruction after the AUIPC...
         u8* link_location = linked_block + sizeof(u32);

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -34,7 +34,7 @@ constexpr static u64 code_cache_sizes_count = std::size(code_cache_sizes);
 constexpr static u64 max_code_cache_size = code_cache_sizes[code_cache_sizes_count - 1];
 
 // TODO: move to header file
-std::pair<u64, BlockMetadata*> get_block_metadata(ThreadState* state, u64 host_pc);
+BlockMetadata* get_block_metadata(ThreadState* state, u64 host_pc);
 
 static void incorrect_magic(void* sp) {
     ERROR("Incorrect magic in frame (sp: %lx)", sp);
@@ -438,14 +438,14 @@ u64 Recompiler::compile(ThreadState* state, u64 rip) {
     ASSERT(host_address_end - start >= 8); // At least 2 instructions, so that our unlinking logic works
 
     BlockMetadata& block_meta = getBlockMetadata(rip);
-    host_pc_map[host_address_end - 1] = {start_rip, &block_meta};
+    host_pc_map[host_address_end - 1] = {&block_meta};
 
     {
         auto guard = page_map_lock.lock();
         u64 start_masked = start_rip & ~0xFFFull;
         u64 end_masked = (end_rip - 1) & ~0xFFFull;
         for (u64 page = start_masked; page <= end_masked; page += 0x1000) {
-            page_map[page].push_back({start_rip, &block_meta});
+            page_map[page].push_back(&block_meta);
         }
     }
 
@@ -3272,7 +3272,7 @@ void Recompiler::setTOP(biscuit::GPR new_top) {
     as.SB(new_top, offsetof(ThreadState, ctx.fpu_top), threadStatePointer());
 }
 
-void Recompiler::invalidateBlock(BlockMetadata* block, u64 rip) {
+void Recompiler::invalidateBlock(BlockMetadata* block) {
     if (block->host_address == 0) {
         return;
     }
@@ -3289,8 +3289,8 @@ void Recompiler::invalidateBlock(BlockMetadata* block, u64 rip) {
     __atomic_store(address, &storage, __ATOMIC_SEQ_CST);
 
     if (g_config.address_cache) {
-        AddressCacheEntry& entry = address_cache[rip & ((1 << address_cache_bits) - 1)];
-        entry.guest = ~rip;
+        AddressCacheEntry& entry = address_cache[block->guest_address & ((1 << address_cache_bits) - 1)];
+        entry.guest = ~block->guest_address;
         entry.host = 0;
     }
 
@@ -3306,8 +3306,8 @@ int Recompiler::invalidateRange(u64 start, u64 end) {
     int blocks = 0;
     for (auto it = lower; it != upper; it++) {
         auto& blocks_in_page = it->second;
-        for (auto [rip, block] : blocks_in_page) {
-            invalidateBlock(block, rip);
+        for (BlockMetadata* block : blocks_in_page) {
+            invalidateBlock(block);
             blocks++;
         }
         blocks_in_page.clear();

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -380,7 +380,6 @@ void Recompiler::clearCodeCache(ThreadState* state) {
             block_metadata.clear();
             host_pc_map.clear();
             page_map.clear();
-            pending_links.clear();
             for (size_t i = 0; i < (1 << address_cache_bits); i++) {
                 address_cache[i] = AddressCacheEntry{};
             }
@@ -397,7 +396,6 @@ void Recompiler::clearCodeCache(ThreadState* state) {
         block_metadata.clear();
         host_pc_map.clear();
         page_map.clear();
-        pending_links.clear();
         for (size_t i = 0; i < (1 << address_cache_bits); i++) {
             address_cache[i] = AddressCacheEntry{};
         }
@@ -2632,7 +2630,7 @@ void Recompiler::jumpAndLink(u64 rip) {
         u8* link_me = as.GetCursorPointer();
         backToDispatcher();
 
-        pending_links[rip].push_back(link_me);
+        getBlockMetadata(rip).pending_links.push_back(link_me);
     } else {
         auto& target_meta = getBlockMetadata(rip);
         u64 target = target_meta.host_address;
@@ -2704,7 +2702,7 @@ void Recompiler::expirePendingLinks(u64 rip) {
         return;
     }
 
-    auto& links = pending_links[rip];
+    auto& links = getBlockMetadata(rip).pending_links;
     for (u8* link : links) {
         u8* cursor = as.GetCursorPointer();
         as.SetCursorPointer(link);
@@ -2714,8 +2712,8 @@ void Recompiler::expirePendingLinks(u64 rip) {
 
     flush_icache();
 
-    links.clear();
-    pending_links.erase(rip);
+    // Free the memory as pending_links won't be used after the block is compiled
+    std::vector<u8*>().swap(links);
 }
 
 u64 Recompiler::zextImmediate(u64 imm, ZyanU8 size) {

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -34,7 +34,7 @@ constexpr static u64 code_cache_sizes_count = std::size(code_cache_sizes);
 constexpr static u64 max_code_cache_size = code_cache_sizes[code_cache_sizes_count - 1];
 
 // TODO: move to header file
-BlockMetadata* get_block_metadata(ThreadState* state, u64 host_pc);
+std::pair<u64, BlockMetadata*> get_block_metadata(ThreadState* state, u64 host_pc);
 
 static void incorrect_magic(void* sp) {
     ERROR("Incorrect magic in frame (sp: %lx)", sp);
@@ -336,11 +336,11 @@ void Recompiler::invalidateAt(ThreadState* state, u8* linked_block) {
         tas.AUIPC(t5, 0);
         ASSERT(instruction == *(u32*)linked_block);
 
-        auto linked_metadata = get_block_metadata(state, (u64)linked_block);
-        ASSERT_MSG(linked_metadata, "Failed to get block metadata for address %lx", linked_block);
+        auto [rip, block] = get_block_metadata(state, (u64)linked_block);
+        ASSERT_MSG(block, "Failed to get block metadata for address %lx", linked_block);
         // The link location should be an instruction after the AUIPC...
         u8* link_location = linked_block + sizeof(u32);
-        if (linked_metadata->address != 0) {
+        if (block->host_address != 0) {
             u8* cursor = state->recompiler->as.GetCursorPointer();
             ASSERT_MSG(linked_block >= state->recompiler->start_of_code_cache && linked_block < cursor, "%lx <= %lx < %lx",
                        state->recompiler->start_of_code_cache, linked_block, cursor);
@@ -380,6 +380,7 @@ void Recompiler::clearCodeCache(ThreadState* state) {
             block_metadata.clear();
             host_pc_map.clear();
             page_map.clear();
+            pending_links.clear();
             for (size_t i = 0; i < (1 << address_cache_bits); i++) {
                 address_cache[i] = AddressCacheEntry{};
             }
@@ -396,6 +397,7 @@ void Recompiler::clearCodeCache(ThreadState* state) {
         block_metadata.clear();
         host_pc_map.clear();
         page_map.clear();
+        pending_links.clear();
         for (size_t i = 0; i < (1 << address_cache_bits); i++) {
             address_cache[i] = AddressCacheEntry{};
         }
@@ -426,34 +428,33 @@ u64 Recompiler::compile(ThreadState* state, u64 rip) {
         WARN_ONCE("This program has unaligned atomics that we can't emulate atomically");
     }
 
+    const u64 start_rip = rip;
     u64 start = (u64)as.GetCursorPointer();
 
     // Map it immediately so we can optimize conditional branch to self
-    BlockMetadata& block_meta = getBlockMetadata(rip);
-    block_meta.address = start;
 
     // A sequence of code (ie. basic block). This is so that we can also call it recursively later.
     u64 end_rip = compileSequence(rip);
+    u64 host_address_end = (u64)as.GetCursorPointer();
 
-    u64 end = (u64)as.GetCursorPointer();
+    ASSERT(host_address_end - start >= 8); // At least 2 instructions, so that our unlinking logic works
 
-    ASSERT(end - start >= 8); // At least 2 instructions, so that our unlinking logic works
-
-    host_pc_map[block_meta.address_end - 1] = &block_meta;
+    BlockMetadata& block_meta = getBlockMetadata(rip);
+    host_pc_map[host_address_end - 1] = {start_rip, &block_meta};
 
     {
         auto guard = page_map_lock.lock();
-        u64 start_masked = block_meta.guest_address & ~0xFFFull;
-        u64 end_masked = (block_meta.guest_address_end - 1) & ~0xFFFull;
+        u64 start_masked = start_rip & ~0xFFFull;
+        u64 end_masked = (end_rip - 1) & ~0xFFFull;
         for (u64 page = start_masked; page <= end_masked; page += 0x1000) {
-            page_map[page].push_back(&block_meta);
+            page_map[page].push_back({start_rip, &block_meta});
         }
     }
 
     if (g_config.address_cache) {
-        AddressCacheEntry& entry = address_cache[block_meta.guest_address & ((1 << address_cache_bits) - 1)];
-        entry.host = block_meta.address;
-        entry.guest = block_meta.guest_address;
+        AddressCacheEntry& entry = address_cache[start_rip & ((1 << address_cache_bits) - 1)];
+        entry.host = block_meta.host_address;
+        entry.guest = start_rip;
     }
 
     // If other blocks were waiting for this block to be linked, link them now
@@ -462,9 +463,35 @@ u64 Recompiler::compile(ThreadState* state, u64 rip) {
     // Mark the page as read-only to catch self-modifying code
     markPagesAsReadOnly(rip, end_rip);
 
+    if (g_config.gdb) {
+        size_t inst_count = block_meta.translation_sizes.size();
+        felix86_jit_block_t* gdb_block = GDBJIT::createBlock(inst_count);
+        u64 host_address = block_meta.host_address;
+        u64 guest_address = start_rip;
+        for (size_t i = 0; i < inst_count; i++) {
+            ZydisDisassembledInstruction inst;
+            ZydisDisassembleIntel(decoder.machine_mode, guest_address, (void*)guest_address, 15, &inst);
+            int size = strlen(inst.text);
+            inst.text[size] = '\n';
+            fwrite(inst.text, size + 1, 1, gdb_block->file);
+            gdb_block->lines[i].line = 1 + i;
+            gdb_block->lines[i].pc = host_address;
+            guest_address += inst.info.length;
+            host_address += block_meta.translation_sizes[i].riscv_instructions_size;
+        }
+
+        gdb_block->host_start = block_meta.host_address;
+        gdb_block->host_end = host_address_end;
+        gdb_block->guest_address = start_rip;
+        gdb_block->line_count = inst_count;
+
+        fclose(gdb_block->file);
+        g_gdbjit->fire(gdb_block);
+    }
+
     if (g_config.perf_blocks || g_config.perf_symbols) {
         std::string symbol;
-        size_t size = block_meta.address_end - block_meta.address;
+        size_t size = host_address_end - block_meta.host_address;
         if (g_config.perf_symbols) {
             if (!has_region(rip)) {
                 // Executed region not found, update the symbols
@@ -473,9 +500,9 @@ u64 Recompiler::compile(ThreadState* state, u64 rip) {
 
             symbol = get_perf_symbol(rip);
         } else {
-            symbol = fmt::format("block_0x{:x}", block_meta.guest_address);
+            symbol = fmt::format("block_0x{:x}", start_rip);
         }
-        g_process_globals.perf->addToFile(block_meta.address, size, symbol);
+        g_process_globals.perf->addToFile(block_meta.host_address, size, symbol);
     }
 
     if (g_config.perf_libs) {
@@ -485,8 +512,8 @@ u64 Recompiler::compile(ThreadState* state, u64 rip) {
         }
 
         std::filesystem::path symbol = get_region(rip);
-        size_t size = block_meta.address_end - block_meta.address;
-        g_process_globals.perf->addToFile(block_meta.address, size, "guest " + symbol.filename().string());
+        size_t size = host_address_end - block_meta.host_address;
+        g_process_globals.perf->addToFile(block_meta.host_address, size, "guest " + symbol.filename().string());
     }
 
     return start;
@@ -511,6 +538,7 @@ void Recompiler::markPagesAsReadOnly(u64 start, u64 end) {
 }
 
 u64 Recompiler::compileSequence(u64 rip) {
+    const u64 start_rip = rip;
     compiling = true;
     u8* bytes = (u8*)rip;
     bool all_zeroes = true;
@@ -531,6 +559,8 @@ u64 Recompiler::compileSequence(u64 rip) {
 
     scanAhead(rip);
     BlockMetadata& block_meta = getBlockMetadata(rip);
+    block_meta.host_address = (u64)as.GetCursorPointer();
+    block_meta.translation_sizes.resize(instructions.size());
 
     // TODO: Put all this resetting functionality in a function
     resetX87();
@@ -541,7 +571,6 @@ u64 Recompiler::compileSequence(u64 rip) {
     fsrm_sse = true;                     // dispatcher loads SSE rounding mode as a default
     v0_has_mask = false;
 
-    current_block_metadata->guest_address = rip;
     current_ripreg_value = rip; // may change in a syscall to check for safepoints, or after a set amount of instructions in the future
 
     current_instruction_index = 0;
@@ -555,8 +584,6 @@ u64 Recompiler::compileSequence(u64 rip) {
 
     while (compiling) {
         auto& [instruction, operands] = instructions[current_instruction_index];
-
-        block_meta.instruction_spans.push_back({rip, (u64)as.GetCursorPointer()});
 
         bool is_mmx = (operands[0].type == ZYDIS_OPERAND_TYPE_REGISTER && operands[0].reg.value >= ZYDIS_REGISTER_MM0 &&
                        operands[0].reg.value <= ZYDIS_REGISTER_MM7) ||
@@ -583,6 +610,8 @@ u64 Recompiler::compileSequence(u64 rip) {
         if (instruction.mnemonic == ZYDIS_MNEMONIC_EMMS) {
             ran_mmx_once = false; // if we run another mmx instruction, set tag to valid again
         }
+
+        u64 start_pc = (u64)as.GetCursorPointer();
 
         if (is_mmx) {
             if (!ran_mmx_once) {
@@ -654,6 +683,13 @@ u64 Recompiler::compileSequence(u64 rip) {
             stopCompiling();
         }
 
+        u64 end_pc = (u64)as.GetCursorPointer();
+        u64 size = end_pc - start_pc;
+        ASSERT(instruction.length <= 15);
+        block_meta.translation_sizes[current_instruction_index].x86_instruction_size = instruction.length;
+        ASSERT(size < 1 << 12);
+        block_meta.translation_sizes[current_instruction_index].riscv_instructions_size = size;
+
         current_instruction_index += 1;
 
         if (skip_next) {
@@ -668,7 +704,7 @@ u64 Recompiler::compileSequence(u64 rip) {
     }
 
     if (current_block_big) {
-        VERBOSE("Block at %lx exceeded max instruction count", current_block_metadata->guest_address);
+        VERBOSE("Block at %lx exceeded max instruction count", start_rip);
         resetScratch();
         flushX87();
         biscuit::GPR ripreg = allocatedGPR(X86_REF_RIP);
@@ -677,36 +713,6 @@ u64 Recompiler::compileSequence(u64 rip) {
     }
 
     resetScratch();
-
-    current_block_metadata->guest_address_end = rip;
-    current_block_metadata->address_end = (u64)as.GetCursorPointer();
-
-    if (g_config.gdb) {
-        size_t inst_count = current_block_metadata->instruction_spans.size();
-        felix86_jit_block_t* gdb_block = GDBJIT::createBlock(inst_count);
-        gdb_block->host_start = (u64)as.GetCursorPointer();
-
-        for (size_t i = 0; i < inst_count; i++) {
-            u64 guest_address = current_block_metadata->instruction_spans[i].first;
-            u64 host_address = current_block_metadata->instruction_spans[i].second;
-            ZydisDisassembledInstruction inst;
-            ZydisDisassembleIntel(decoder.machine_mode, guest_address, (void*)guest_address, 15, &inst);
-            int size = strlen(inst.text);
-            inst.text[size] = '\n';
-            fwrite(inst.text, size + 1, 1, gdb_block->file);
-            gdb_block->lines[i].line = 1 + i;
-            gdb_block->lines[i].pc = host_address;
-        }
-
-        gdb_block->host_start = current_block_metadata->address;
-        gdb_block->host_end = current_block_metadata->address_end;
-        gdb_block->guest_address = current_block_metadata->guest_address;
-        gdb_block->line_count = inst_count;
-
-        fclose(gdb_block->file);
-        g_gdbjit->fire(gdb_block);
-    }
-
     flush_icache();
 
     current_block_metadata = nullptr;
@@ -2626,10 +2632,10 @@ void Recompiler::jumpAndLink(u64 rip) {
         u8* link_me = as.GetCursorPointer();
         backToDispatcher();
 
-        getBlockMetadata(rip).pending_links.push_back(link_me);
+        pending_links[rip].push_back(link_me);
     } else {
         auto& target_meta = getBlockMetadata(rip);
-        u64 target = target_meta.address;
+        u64 target = target_meta.host_address;
 
         u64 offset = target - (u64)as.GetCursorPointer();
         if (IsValidJTypeImm(offset - 4)) {
@@ -2698,9 +2704,8 @@ void Recompiler::expirePendingLinks(u64 rip) {
         return;
     }
 
-    auto& block_meta = getBlockMetadata(rip);
-    auto& pending_links = block_meta.pending_links;
-    for (u8* link : pending_links) {
+    auto& links = pending_links[rip];
+    for (u8* link : links) {
         u8* cursor = as.GetCursorPointer();
         as.SetCursorPointer(link);
         jumpAndLink(rip);
@@ -2709,7 +2714,8 @@ void Recompiler::expirePendingLinks(u64 rip) {
 
     flush_icache();
 
-    block_meta.pending_links.clear();
+    links.clear();
+    pending_links.erase(rip);
 }
 
 u64 Recompiler::zextImmediate(u64 imm, ZyanU8 size) {
@@ -3037,7 +3043,7 @@ void Recompiler::sext(biscuit::GPR dst, biscuit::GPR src, x86_size_e size) {
 }
 
 bool Recompiler::blockExists(u64 rip) {
-    return getBlockMetadata(rip).address != 0;
+    return getBlockMetadata(rip).host_address != 0;
 }
 
 biscuit::GPR Recompiler::getFlags() {
@@ -3268,12 +3274,12 @@ void Recompiler::setTOP(biscuit::GPR new_top) {
     as.SB(new_top, offsetof(ThreadState, ctx.fpu_top), threadStatePointer());
 }
 
-void Recompiler::invalidateBlock(BlockMetadata* block) {
-    if (block->address == 0) {
+void Recompiler::invalidateBlock(BlockMetadata* block, u64 rip) {
+    if (block->host_address == 0) {
         return;
     }
 
-    u64* address = (u64*)block->address;
+    u64* address = (u64*)block->host_address;
     const u64 offset = (u64)invalidate_caller_thunk - (u64)address;
     const auto hi20 = static_cast<int32_t>(((static_cast<uint32_t>(offset) + 0x800) >> 12) & 0xFFFFF);
     const auto lo12 = static_cast<int32_t>(offset << 20) >> 20;
@@ -3285,12 +3291,12 @@ void Recompiler::invalidateBlock(BlockMetadata* block) {
     __atomic_store(address, &storage, __ATOMIC_SEQ_CST);
 
     if (g_config.address_cache) {
-        AddressCacheEntry& entry = address_cache[block->guest_address & ((1 << address_cache_bits) - 1)];
-        entry.guest = ~block->guest_address;
+        AddressCacheEntry& entry = address_cache[rip & ((1 << address_cache_bits) - 1)];
+        entry.guest = ~rip;
         entry.host = 0;
     }
 
-    block->address = 0;
+    block->host_address = 0;
     std::atomic_thread_fence(std::memory_order_seq_cst);
 }
 
@@ -3302,8 +3308,8 @@ int Recompiler::invalidateRange(u64 start, u64 end) {
     int blocks = 0;
     for (auto it = lower; it != upper; it++) {
         auto& blocks_in_page = it->second;
-        for (BlockMetadata* block : blocks_in_page) {
-            invalidateBlock(block);
+        for (auto [rip, block] : blocks_in_page) {
+            invalidateBlock(block, rip);
             blocks++;
         }
         blocks_in_page.clear();

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -558,6 +558,7 @@ u64 Recompiler::compileSequence(u64 rip) {
     scanAhead(rip);
     BlockMetadata& block_meta = getBlockMetadata(rip);
     block_meta.host_address = (u64)as.GetCursorPointer();
+    block_meta.guest_address = start_rip;
     block_meta.translation_sizes.resize(instructions.size());
 
     // TODO: Put all this resetting functionality in a function

--- a/src/felix86/v2/recompiler.hpp
+++ b/src/felix86/v2/recompiler.hpp
@@ -50,13 +50,17 @@ struct RegisterAccess {
     bool valid;  // true if loaded and potentially modified, false if written back to memory and allocated register holds garbage
 };
 
+struct TranslationSize {
+    u16 x86_instruction_size : 4;
+    u16 riscv_instructions_size : 12;
+};
+static_assert(sizeof(TranslationSize) == sizeof(u16));
+
 struct BlockMetadata {
-    u64 address{};
-    u64 address_end{};
-    u64 guest_address{};
-    u64 guest_address_end{};
-    std::vector<u8*> pending_links{};
-    std::vector<std::pair<u64, u64>> instruction_spans{};
+    u64 host_address{};
+    // This gives us a count of x86 instructions per block, the size of each instruction
+    // and the size of the risc-v instructions used to translate it
+    std::vector<TranslationSize> translation_sizes{};
 };
 
 // WARN: don't allocate this struct on the stack as it's quite big due to address_cache and can lead to stack overflow
@@ -193,7 +197,7 @@ struct Recompiler {
 
     void jumpAndLinkConditional(biscuit::GPR condition, u64 rip_true, u64 rip_false);
 
-    void invalidateBlock(BlockMetadata* block);
+    void invalidateBlock(BlockMetadata* block, u64 rip);
 
     void insertSafepoint();
 
@@ -461,7 +465,7 @@ struct Recompiler {
             if (entry.guest == rip) {
                 return entry.host;
             } else if (blockExists(rip)) {
-                u64 host = getBlockMetadata(rip).address;
+                u64 host = getBlockMetadata(rip).host_address;
                 entry.guest = rip;
                 entry.host = host;
                 return host;
@@ -470,7 +474,7 @@ struct Recompiler {
             }
         } else {
             if (blockExists(rip)) {
-                return getBlockMetadata(rip).address;
+                return getBlockMetadata(rip).host_address;
             } else {
                 return compile(state, rip);
             }
@@ -751,13 +755,14 @@ private:
     void* start_of_code_cache{};
 
     std::unordered_map<u64, BlockMetadata> block_metadata{};
+    std::unordered_map<u64, std::vector<u8*>> pending_links{};
 
     Semaphore page_map_lock;
-    std::map<u64, std::vector<BlockMetadata*>> page_map{};
+    std::map<u64, std::vector<std::pair<u64, BlockMetadata*>>> page_map{};
 
     // For fast host pc -> block metadata lookup (binary search vs looking up one by one)
     // on signal handlers
-    std::map<u64, BlockMetadata*> host_pc_map{};
+    std::map<u64, std::pair<u64, BlockMetadata*>> host_pc_map{};
 
     bool compiling{};
 

--- a/src/felix86/v2/recompiler.hpp
+++ b/src/felix86/v2/recompiler.hpp
@@ -58,6 +58,7 @@ static_assert(sizeof(TranslationSize) == sizeof(u16));
 
 struct BlockMetadata {
     u64 host_address{};
+    u64 guest_address{};
     // This gives us a count of x86 instructions per block, the size of each instruction
     // and the size of the risc-v instructions used to translate it
     std::vector<TranslationSize> translation_sizes{};
@@ -198,7 +199,7 @@ struct Recompiler {
 
     void jumpAndLinkConditional(biscuit::GPR condition, u64 rip_true, u64 rip_false);
 
-    void invalidateBlock(BlockMetadata* block, u64 rip);
+    void invalidateBlock(BlockMetadata* block);
 
     void insertSafepoint();
 
@@ -758,11 +759,11 @@ private:
     std::unordered_map<u64, BlockMetadata> block_metadata{};
 
     Semaphore page_map_lock;
-    std::map<u64, std::vector<std::pair<u64, BlockMetadata*>>> page_map{};
+    std::map<u64, std::vector<BlockMetadata*>> page_map{};
 
     // For fast host pc -> block metadata lookup (binary search vs looking up one by one)
     // on signal handlers
-    std::map<u64, std::pair<u64, BlockMetadata*>> host_pc_map{};
+    std::map<u64, BlockMetadata*> host_pc_map{};
 
     bool compiling{};
 

--- a/src/felix86/v2/recompiler.hpp
+++ b/src/felix86/v2/recompiler.hpp
@@ -61,6 +61,7 @@ struct BlockMetadata {
     // This gives us a count of x86 instructions per block, the size of each instruction
     // and the size of the risc-v instructions used to translate it
     std::vector<TranslationSize> translation_sizes{};
+    std::vector<u8*> pending_links{};
 };
 
 // WARN: don't allocate this struct on the stack as it's quite big due to address_cache and can lead to stack overflow
@@ -755,7 +756,6 @@ private:
     void* start_of_code_cache{};
 
     std::unordered_map<u64, BlockMetadata> block_metadata{};
-    std::unordered_map<u64, std::vector<u8*>> pending_links{};
 
     Semaphore page_map_lock;
     std::map<u64, std::vector<std::pair<u64, BlockMetadata*>>> page_map{};


### PR DESCRIPTION
Reduces size of BlockMetadata struct from 80 to 64 bytes, and size per instruction from 16 bytes to 2 bytes. But page_map and host_pc_map add 8 bytes per block.

| Process | Before | After | Reduction | % Reduced |
|---|---|---|---|---|
| Cuphead | 795.5 MB | 685.7 MB | 109.8 MB | −13.8% | 
| Celeste | 599.8 MB | 550.5 MB | 49.3 MB | −8.2% |
| steam | 607 MB | 503 MB | 104 MB | −17.1% |
| steamwebhelper | 851 MB | 745 MB | 106 MB | −12.5% |
| Witcher 3 | 2337.2 MB | 2243.2 | 94 MB | -4% |