### PR TITLE
Move {{ github.ref }} to environment variable

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,8 +29,6 @@ jobs:
           sudo cp -r /usr/include/KHR /usr/local/include/KHR
           sudo cp -r /usr/include/vk_video /usr/local/include/vk_video
       - name: Configure
-        env:
-          GITHUB_REF: ${{ github.ref }}
         run: |
           EXTRA_FLAGS=""
           if [[ "$GITHUB_REF" == refs/tags/* ]]; then

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,9 +29,11 @@ jobs:
           sudo cp -r /usr/include/KHR /usr/local/include/KHR
           sudo cp -r /usr/include/vk_video /usr/local/include/vk_video
       - name: Configure
+        env:
+          GITHUB_REF: ${{ github.ref }}
         run: |
           EXTRA_FLAGS=""
-          if [[ "${{ github.ref }}" == refs/tags/* ]]; then
+          if [[ "$GITHUB_REF" == refs/tags/* ]]; then
             EXTRA_FLAGS="-DFELIX86_MONTHLY_RELEASE=1"
           fi
           cmake -B ${{ github.workspace }}/build -DBUILD_TESTS=1 -DCMAKE_TOOLCHAIN_FILE=riscv.cmake -DFELIX86_BUILD_THUNKING=1 -DCMAKE_C_COMPILER_LAUNCHER=ccache -DCMAKE_CXX_COMPILER_LAUNCHER=ccache -DCMAKE_BUILD_TYPE=Release $EXTRA_FLAGS


### PR DESCRIPTION
While actions won't trigger without explicit approval, it's good to patch this user exploitable variable

Reported-by: Spiros Thanasoulas (Radically Open Security)