### PR TITLE
Correctly use AT_SECURE in auxv and fix some codeql issues

### DIFF
--- a/src/felix86/common/binfmt.cpp
+++ b/src/felix86/common/binfmt.cpp
@@ -156,7 +156,12 @@ void binfmt_misc(bool is_register) {
         unregister_binfmt_misc("felix86-x86_64");
         unregister_binfmt_misc("felix86-i386");
 
-        FILE* fp = fopen("/proc/sys/fs/binfmt_misc/register", "w");
+        int fd = open("/proc/sys/fs/binfmt_misc/register", O_WRONLY);
+        if (fd < 0) {
+            perror("open");
+            exit(1);
+        }
+        FILE* fp = fdopen(fd, "w");
 
         if (!fp) {
             ERROR("Failed to open /proc/sys/fs/binfmt_misc/register");
@@ -169,7 +174,12 @@ void binfmt_misc(bool is_register) {
 
         fclose(fp);
 
-        fp = fopen("/proc/sys/fs/binfmt_misc/register", "w");
+        fd = open("/proc/sys/fs/binfmt_misc/register", O_WRONLY);
+        if (fd < 0) {
+            perror("open");
+            exit(1);
+        }
+        fp = fdopen(fd, "w");
 
         if (fwrite(registration_string_i386.c_str(), 1, registration_string_i386.size(), fp) != registration_string_i386.size()) {
             fclose(fp);

--- a/src/felix86/common/elf.cpp
+++ b/src/felix86/common/elf.cpp
@@ -400,12 +400,12 @@ void Elf::Load(const std::filesystem::path& path) {
     // Avoiding heap allocations for when I must do that in the future
     Elf_Phdr* phdrtable = (Elf_Phdr*)alloca(ehdr.phnum() * sizeof(Elf_Phdr));
     fseek(file, ehdr.phoff(), SEEK_SET);
-    for (Elf64_Half i = 0; i < ehdr.phnum(); i++) {
+    for (u64 i = 0; i < ehdr.phnum(); i++) {
         // Placement new to run the constructor
         new (&phdrtable[i]) Elf_Phdr(mode32, file);
     }
 
-    for (Elf64_Half i = 0; i < ehdr.phnum(); i++) {
+    for (u64 i = 0; i < ehdr.phnum(); i++) {
         Elf_Phdr& phdr = phdrtable[i];
         switch (phdr.type()) {
         case PT_INTERP: {
@@ -492,7 +492,7 @@ void Elf::Load(const std::filesystem::path& path) {
 
     VERBOSE("Allocated memory at %p-%p", base_ptr, base_ptr + highest_vaddr);
 
-    for (Elf64_Half i = 0; i < ehdr.phnum(); i += 1) {
+    for (u64 i = 0; i < ehdr.phnum(); i += 1) {
         Elf_Phdr& phdr = phdrtable[i];
         switch (phdr.type()) {
         case PT_LOAD: {

--- a/src/felix86/common/log.cpp
+++ b/src/felix86/common/log.cpp
@@ -28,11 +28,11 @@ void Logger::startServer(bool detach) {
     int fd = mkstemps(log_path.data(), 4);
     ASSERT(fd != -1);
 
-    int ok = mkfifo(g_pipe_name.c_str(), 0666);
+    int ok = mkfifo(g_pipe_name.c_str(), 0600);
     ASSERT(ok == 0);
 
     // mkfifo uses umask to set the permissions, override them
-    ok = chmod(g_pipe_name.c_str(), 0666);
+    ok = chmod(g_pipe_name.c_str(), 0600);
     ASSERT(ok == 0);
 
     if (detach) {

--- a/src/felix86/common/perf.hpp
+++ b/src/felix86/common/perf.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string>
+#include <fcntl.h>
 #include <sys/syscall.h>
 #include "felix86/common/log.hpp"
 #include "felix86/hle/fd.hpp"
@@ -10,17 +11,15 @@ struct Perf {
     Perf() {
         if (g_config.perf_blocks || g_config.perf_libs || g_config.perf_global) {
             std::string path = "/tmp/perf-" + std::to_string(getpid()) + ".map";
-            f = fopen(path.c_str(), "a");
-            if (f) {
-                fd = fileno(f);
-                ASSERT(fd > 0);
-                // fd = FD::moveToHighNumber(fd); -- TODO: doing this isn't safe probably with FILE*, rewrite to use syscalls instead of FILE*
-                FD::protect(fd);
-            } else {
-                // TODO: for some reason, running a setuid app through binfmt_misc after being forked
-                // loves failing the fopen and idk why, but game processes aren't setuid so we can perf them fine
+            fd = open(path.c_str(), O_WRONLY | O_CREAT | O_APPEND, 0600);
+            if (fd < 0) {
                 WARN("Failed to open perf map file for process %d", getpid());
+                return;
             }
+            fd = FD::moveToHighNumber(fd);
+            FD::protect(fd);
+            f = fdopen(fd, "a");
+            ASSERT(f);
         }
     }
 

--- a/src/felix86/common/utility.cpp
+++ b/src/felix86/common/utility.cpp
@@ -552,7 +552,7 @@ void dump_states() {
     auto& states = g_process_globals.states;
     int i = 0;
     for (auto& state : states) {
-        dprintf(g_output_fd, ANSI_COLOR_RED "State %d (%ld):" ANSI_COLOR_RESET "\n", i, gettid());
+        dprintf(g_output_fd, ANSI_COLOR_RED "State %d (%d):" ANSI_COLOR_RESET "\n", i, gettid());
 
         if (g_config.calltrace) {
             auto it = state->recompiler->getCalltrace().rbegin();

--- a/src/felix86/emulator.cpp
+++ b/src/felix86/emulator.cpp
@@ -97,7 +97,8 @@ static void setupMainStack(ThreadState* state) {
     }
 
     size_t envc = g_params.envp.size();
-    u64* envp_addresses = (u64*)alloca(envc * sizeof(u64));
+    std::vector<u64> envp_addresses;
+    envp_addresses.resize(envc);
 
     for (size_t i = 0; i < envc; i++) {
         const char* env = g_params.envp[i].c_str();
@@ -123,16 +124,16 @@ static void setupMainStack(ThreadState* state) {
     std::vector<std::pair<u64, u64>> auxv_entries = {
         {AT_PAGESZ, {4096}},
         {AT_EXECFN, {(u64)program_name}},
-        {AT_CLKTCK, {100}},
+        {AT_CLKTCK, {getauxval(AT_CLKTCK)}},
         {AT_ENTRY, {elf->GetEntrypoint()}},
         {AT_PLATFORM, {(u64)platform_name}},
         {AT_BASE, {(u64)elf->GetProgramBase()}},
         {AT_FLAGS, {0}},
-        {AT_UID, {1000}},
-        {AT_EUID, {1000}},
-        {AT_GID, {1000}},
-        {AT_EGID, {1000}},
-        {AT_SECURE, {0}},
+        {AT_UID, {getauxval(AT_UID)}},
+        {AT_EUID, {getauxval(AT_EUID)}},
+        {AT_GID, {getauxval(AT_GID)}},
+        {AT_EGID, {getauxval(AT_EGID)}},
+        {AT_SECURE, {getauxval(AT_SECURE)}},
         {AT_PHDR, {(u64)elf->GetPhdr()}},
         {AT_PHENT, {elf->GetPhent()}},
         {AT_PHNUM, {elf->GetPhnum()}},

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -1282,58 +1282,6 @@ biscuit::Vec Recompiler::getVec(const ZydisDecodedOperand* operand) {
     }
 }
 
-biscuit::GPR Recompiler::getElementGPR(ZydisDecodedOperand* operand, x86_size_e size, int element, bool sext) {
-    biscuit::GPR address;
-    int offset;
-    if (operand->type == ZYDIS_OPERAND_TYPE_REGISTER) {
-        ASSERT(operand->reg.value >= ZYDIS_REGISTER_XMM0 && operand->reg.value <= ZYDIS_REGISTER_XMM15);
-        x86_ref_e ref = zydisToRef(operand->reg.value);
-        offset = offsetof(ThreadState, ctx.xmm) + (ref - X86_REF_XMM0) * sizeof(XmmReg) + (getBitSize(size) / 8) * element;
-        address = threadStatePointer();
-    } else if (operand->type == ZYDIS_OPERAND_TYPE_MEMORY) {
-        address = lea(operand, false);
-        offset = (getBitSize(size) / 8) * element;
-    } else {
-        UNREACHABLE();
-    }
-
-    biscuit::GPR temp = scratch();
-    switch (size) {
-    case X86_SIZE_BYTE: {
-        if (!sext) {
-            as.LBU(temp, offset, address);
-        } else {
-            as.LB(temp, offset, address);
-        }
-        break;
-    }
-    case X86_SIZE_WORD: {
-        if (!sext) {
-            as.LHU(temp, offset, address);
-        } else {
-            as.LH(temp, offset, address);
-        }
-        break;
-    }
-    case X86_SIZE_DWORD: {
-        if (!sext) {
-            as.LWU(temp, offset, address);
-        } else {
-            as.LW(temp, offset, address);
-        }
-        break;
-    }
-    case X86_SIZE_QWORD: {
-        as.LD(temp, offset, address);
-        break;
-    }
-    default: {
-        UNREACHABLE();
-    }
-    }
-    return temp;
-}
-
 biscuit::FPR Recompiler::getElementFPR(ZydisDecodedOperand* operand, x86_size_e size, int element) {
     biscuit::GPR address;
     int offset;
@@ -1364,74 +1312,6 @@ biscuit::FPR Recompiler::getElementFPR(ZydisDecodedOperand* operand, x86_size_e 
     }
     }
     return temp;
-}
-
-void Recompiler::setElementGPR(ZydisDecodedOperand* operand, x86_size_e size, int element, biscuit::GPR src) {
-    biscuit::GPR address;
-    int offset;
-    if (operand->type == ZYDIS_OPERAND_TYPE_REGISTER) {
-        ASSERT(operand->reg.value >= ZYDIS_REGISTER_XMM0 && operand->reg.value <= ZYDIS_REGISTER_XMM15);
-        x86_ref_e ref = zydisToRef(operand->reg.value);
-        offset = offsetof(ThreadState, ctx.xmm) + (ref - X86_REF_XMM0) * sizeof(XmmReg) + (getBitSize(size) / 8) * element;
-        address = threadStatePointer();
-    } else if (operand->type == ZYDIS_OPERAND_TYPE_MEMORY) {
-        address = lea(operand, false);
-        offset = (getBitSize(size) / 8) * element;
-    } else {
-        UNREACHABLE();
-    }
-
-    switch (size) {
-    case X86_SIZE_BYTE: {
-        as.SB(src, offset, address);
-        break;
-    }
-    case X86_SIZE_WORD: {
-        as.SH(src, offset, address);
-        break;
-    }
-    case X86_SIZE_DWORD: {
-        as.SW(src, offset, address);
-        break;
-    }
-    case X86_SIZE_QWORD: {
-        as.SD(src, offset, address);
-        break;
-    }
-    default: {
-        UNREACHABLE();
-    }
-    }
-}
-
-void Recompiler::setElementFPR(ZydisDecodedOperand* operand, x86_size_e size, int element, biscuit::FPR src) {
-    biscuit::GPR address;
-    int offset;
-    if (operand->type == ZYDIS_OPERAND_TYPE_REGISTER) {
-        ASSERT(operand->reg.value >= ZYDIS_REGISTER_XMM0 && operand->reg.value <= ZYDIS_REGISTER_XMM15);
-        x86_ref_e ref = zydisToRef(operand->reg.value);
-        offset = offsetof(ThreadState, ctx.xmm) + (ref - X86_REF_XMM0) * sizeof(XmmReg) + (getBitSize(size) / 8) * element;
-        address = threadStatePointer();
-    } else if (operand->type == ZYDIS_OPERAND_TYPE_MEMORY) {
-        address = lea(operand, false);
-        offset = (getBitSize(size) / 8) * element;
-    } else {
-        UNREACHABLE();
-    }
-
-    switch (size) {
-    case X86_SIZE_DWORD: {
-        as.FSW(src, offset, address);
-        break;
-    }
-    case X86_SIZE_QWORD: {
-        as.FSD(src, offset, address);
-        break;
-    }
-    default: {
-        UNREACHABLE();
-    }
-    }
 }
 
 u64 Recompiler::getImmediate(ZydisDecodedOperand* operand) {

--- a/src/felix86/v2/recompiler.hpp
+++ b/src/felix86/v2/recompiler.hpp
@@ -142,14 +142,7 @@ struct Recompiler {
     biscuit::Vec getVec(ZydisRegister reg);
 
     biscuit::Vec getVec(x86_ref_e ref);
-
-    biscuit::GPR getElementGPR(ZydisDecodedOperand* operand, x86_size_e size, int element, bool sext = false);
-
     biscuit::FPR getElementFPR(ZydisDecodedOperand* operand, x86_size_e size, int element);
-
-    void setElementGPR(ZydisDecodedOperand* operand, x86_size_e size, int element, biscuit::GPR src);
-
-    void setElementFPR(ZydisDecodedOperand* operand, x86_size_e size, int element, biscuit::FPR src);
 
     void setGPR(const ZydisDecodedOperand* operand, biscuit::GPR reg);
 


### PR DESCRIPTION
AT_SECURE wasn't being set correctly in auxv which could allow LD_PRELOAD on setuid binaries
Also fix some codeql warnings.

Reported-by: Spiros Thanasoulas (Radically Open Security)