### PR TITLE
Don't register 'C' flag in binfmt_misc by default

### DIFF
--- a/src/felix86/common/binfmt.cpp
+++ b/src/felix86/common/binfmt.cpp
@@ -111,7 +111,7 @@ bool detect_binfmt_misc() {
     }
 }
 
-void binfmt_misc(bool is_register) {
+void binfmt_misc(bool is_register, bool is_credentials) {
     if (geteuid() != 0) {
         printf("I need root permissions to register felix86 in binfmt_misc, please re-run with root permissions as `sudo -E felix86 -b`\n");
         exit(1);
@@ -133,11 +133,11 @@ void binfmt_misc(bool is_register) {
     exe_path[len] = '\0';
 
     std::string registration_string_x64 = fmt::format(
-        R"!(:felix86-x86_64:M:0:\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x3e\x00:\xff\xff\xff\xff\xff\xfe\xfe\x00\x00\x00\x00\xff\xff\xff\xff\xff\xfe\xff\xff\xff:{}:OCF)!",
-        exe_path);
+        R"!(:felix86-x86_64:M:0:\x7fELF\x02\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x3e\x00:\xff\xff\xff\xff\xff\xfe\xfe\x00\x00\x00\x00\xff\xff\xff\xff\xff\xfe\xff\xff\xff:{}:O{}F)!",
+        exe_path, is_credentials ? "C" : "");
     std::string registration_string_i386 = fmt::format(
-        R"!(:felix86-i386:M:0:\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x03\x00:\xff\xff\xff\xff\xff\xfe\xfe\x00\x00\x00\x00\xff\xff\xff\xff\xff\xfe\xff\xff\xff:{}:OCF)!",
-        exe_path);
+        R"!(:felix86-i386:M:0:\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x03\x00:\xff\xff\xff\xff\xff\xfe\xfe\x00\x00\x00\x00\xff\xff\xff\xff\xff\xfe\xff\xff\xff:{}:O{}F)!",
+        exe_path, is_credentials ? "C" : "");
 
     if (!is_register) {
         if (unregister_binfmt_misc("felix86-x86_64")) {

--- a/src/felix86/common/binfmt.hpp
+++ b/src/felix86/common/binfmt.hpp
@@ -2,5 +2,5 @@
 #include <string>
 
 bool detect_binfmt_misc();
-void binfmt_misc(bool is_register);
+void binfmt_misc(bool is_register, bool is_credentials);
 bool unregister_binfmt_misc(const std::string& path);

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -56,6 +56,10 @@ static struct argp_option options[] = {
     {"get-rootfs", 'g', 0, 0, "Get the rootfs path from config.toml"},
     {"set-thunks", 'S', "DIR", 0, "Set the thunks path in config.toml"},
     {"binfmt-misc", 'b', 0, 0, "Register the emulator in binfmt_misc so that x86-64 executables can run without prepending the emulator path"},
+    {"binfmt-misc-setuid", 'B', 0, 0,
+     "Register the emulator in binfmt_misc so that x86-64 executables can run without prepending the emulator path. Also enables the credentials "
+     "flag, which allows for running privileged executables with the emulator. This may have security implications, read: "
+     "https://felix86.com/docs/users/troubleshooting#privileged-executables-dont-work"},
     {"detect-binfmt-misc", 'd', 0, 0, "Check if we are correctly registered in binfmt_misc, returns 0 if ok"},
     {"unregister-binfmt-misc", 'u', 0, 0, "Unregister the emulator from binfmt_misc"},
     {"log-server", 'l', 0, 0, "Start just the log server in the background"},
@@ -361,7 +365,12 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
         break;
     }
     case 'b': {
-        binfmt_misc(true);
+        binfmt_misc(true, false);
+        exit(0);
+        break;
+    }
+    case 'B': {
+        binfmt_misc(true, true);
         exit(0);
         break;
     }
@@ -372,7 +381,7 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
         break;
     }
     case 'u': {
-        binfmt_misc(false);
+        binfmt_misc(false, false);
         exit(0);
         break;
     }


### PR DESCRIPTION
A new option, `--binfmt-misc-setuid`, can be used to run privileged executables. The old option `--binfmt-misc` that the installer script uses will not enable this flag. This is to ensure that privilege escalation attacks using setuid executables and potential current or future bugs in felix86 won't be possible by default.