### PR TITLE
Implement CS-switching jumps

### DIFF
--- a/src/felix86/common/state.hpp
+++ b/src/felix86/common/state.hpp
@@ -232,6 +232,17 @@ struct UserContext {
             return false;
         }
     }
+
+    void SetFlags(u64 flags) {
+        cf = flags & 1;
+        pf = (flags >> 2) & 1;
+        af = (flags >> 4) & 1;
+        zf = (flags >> 6) & 1;
+        sf = (flags >> 7) & 1;
+        tf = (flags >> 8) & 1;
+        df = (flags >> 10) & 1;
+        of = (flags >> 11) & 1;
+    }
 };
 
 // TODO: Please make me standard layout type? offsetof warnings...

--- a/src/felix86/common/utility.cpp
+++ b/src/felix86/common/utility.cpp
@@ -1287,7 +1287,7 @@ void felix86_set_segment(ThreadState* state, u64 value, int segment) {
         bool new_mode32 = state->ctx.Mode32();
         if (old_mode32 != new_mode32) {
             WARN("Mode32 switched during %lx", state->ctx.rip);
-            state->recompiler->clearCodeCache(state);
+            // state->recompiler->clearCodeCache(state);
         }
         break;
     }

--- a/src/felix86/common/utility.cpp
+++ b/src/felix86/common/utility.cpp
@@ -1287,6 +1287,11 @@ void felix86_set_segment(ThreadState* state, u64 value, int segment) {
         bool new_mode32 = state->ctx.Mode32();
         if (old_mode32 != new_mode32) {
             WARN("Mode32 switched during %lx", state->ctx.rip);
+            // Technically there could be a code segment that runs on both 32-bit and 64-bit
+            // and we'd need to clear the code cache on switch or have separate 32-bit and 64-bit
+            // code caches to emulate it correctly. There's no known programs that do this
+            // as of this moment so we don't care about it, the warning above will help
+            // us find such a case if it ever comes up
             // state->recompiler->clearCodeCache(state);
         }
         break;

--- a/src/felix86/common/utility.cpp
+++ b/src/felix86/common/utility.cpp
@@ -305,32 +305,24 @@ int clear_breakpoints() {
     return count;
 }
 
-void felix86_iret(struct ThreadState* state) {
-    int size = state->ctx.Mode32() ? 4 : 8;
+void felix86_iret(struct ThreadState* state, bool iretq) {
+    int size = !iretq ? 4 : 8;
     u64 rsp = state->ctx.gprs[X86_REF_RSP];
     u8* rsp_ptr = (u8*)rsp;
     u64 rip = 0, rflags = 0, cs = 0, ss = 0, new_rsp = 0;
     memcpy(&rip, rsp_ptr, size);
     memcpy(&cs, rsp_ptr + (size * 1), size);
     memcpy(&rflags, rsp_ptr + (size * 2), size);
-
-    if (!state->ctx.Mode32()) {
-        memcpy(&new_rsp, rsp_ptr + (size * 3), size);
-        memcpy(&ss, rsp_ptr + (size * 4), size);
-        state->SetGpr(X86_REF_RSP, new_rsp);
-        // TODO: what are we supposed to do with ss?
-    }
-
+    memcpy(&new_rsp, rsp_ptr + (size * 3), size);
+    memcpy(&ss, rsp_ptr + (size * 4), size);
+    state->SetGpr(X86_REF_RSP, new_rsp);
+    felix86_set_segment(state, ss, ZYDIS_REGISTER_SS);
     u64 mask = 0x3F7BD7;
     rflags &= mask;
-    // TODO: actually set rflags
-
+    rflags |= 0b10;
+    state->ctx.SetFlags(rflags);
     state->SetRip(rip);
-
-    if (state->ctx.Mode32()) {
-        felix86_set_segment(state, cs, ZYDIS_REGISTER_CS);
-        state->SetGpr(X86_REF_RSP, rsp + 3 * 4); // 3 values popped
-    }
+    felix86_set_segment(state, cs, ZYDIS_REGISTER_CS);
 }
 
 void felix86_fstenv_16(ThreadState* state, u64 address) {

--- a/src/felix86/common/utility.cpp
+++ b/src/felix86/common/utility.cpp
@@ -313,10 +313,15 @@ void felix86_iret(struct ThreadState* state, bool iretq) {
     memcpy(&rip, rsp_ptr, size);
     memcpy(&cs, rsp_ptr + (size * 1), size);
     memcpy(&rflags, rsp_ptr + (size * 2), size);
-    memcpy(&new_rsp, rsp_ptr + (size * 3), size);
-    memcpy(&ss, rsp_ptr + (size * 4), size);
-    state->SetGpr(X86_REF_RSP, new_rsp);
-    felix86_set_segment(state, ss, ZYDIS_REGISTER_SS);
+
+    if (state->ctx.Mode32()) {
+        state->SetGpr(X86_REF_RSP, rsp + 3 * sizeof(u32));
+    } else {
+        memcpy(&new_rsp, rsp_ptr + (size * 3), size);
+        memcpy(&ss, rsp_ptr + (size * 4), size);
+        state->SetGpr(X86_REF_RSP, new_rsp);
+        felix86_set_segment(state, ss, ZYDIS_REGISTER_SS);
+    }
     u64 mask = 0x3F7BD7;
     rflags &= mask;
     rflags |= 0b10;

--- a/src/felix86/common/utility.cpp
+++ b/src/felix86/common/utility.cpp
@@ -320,13 +320,16 @@ void felix86_iret(struct ThreadState* state, bool iretq) {
         memcpy(&new_rsp, rsp_ptr + (size * 3), size);
         memcpy(&ss, rsp_ptr + (size * 4), size);
         state->SetGpr(X86_REF_RSP, new_rsp);
+        ss &= 0xFFFF;
         felix86_set_segment(state, ss, ZYDIS_REGISTER_SS);
     }
+
     u64 mask = 0x3F7BD7;
     rflags &= mask;
     rflags |= 0b10;
     state->ctx.SetFlags(rflags);
     state->SetRip(rip);
+    cs &= 0xFFFF;
     felix86_set_segment(state, cs, ZYDIS_REGISTER_CS);
 }
 

--- a/src/felix86/common/utility.hpp
+++ b/src/felix86/common/utility.hpp
@@ -26,7 +26,7 @@
 void felix86_div128(struct ThreadState* state, u64 divisor);
 void felix86_divu128(struct ThreadState* state, u64 divisor);
 
-void felix86_iret(struct ThreadState* state);
+void felix86_iret(struct ThreadState* state, bool iretq);
 
 u64 sext(u64 value, u8 size);
 u64 sext_if_64(u64 value, u8 size_e);

--- a/src/felix86/v2/handlers.cpp
+++ b/src/felix86/v2/handlers.cpp
@@ -2613,6 +2613,27 @@ FAST_HANDLE(MOVD) {
 }
 
 FAST_HANDLE(JMP) {
+    if (operands[0].type == ZYDIS_OPERAND_TYPE_MEMORY) {
+        if (operands[0].size == 64 + 16 || operands[0].size == 32 + 16) {
+            WARN("Far jump detected at %lx", rip);
+            bool bit32 = operands[0].size == 32 + 16;
+            biscuit::GPR ripreg = rec.allocatedGPR(X86_REF_RIP);
+            biscuit::GPR address = rec.lea(&operands[0]);
+            biscuit::GPR cs = rec.scratch();
+            rec.readMemory(ripreg, address, 0, bit32 ? X86_SIZE_DWORD : X86_SIZE_QWORD);
+            rec.readMemory(cs, address, bit32 ? 4 : 8, X86_SIZE_WORD);
+            rec.writebackState();
+            as.MV(a1, cs);
+            as.LI(a2, ZYDIS_REGISTER_CS);
+            as.MV(a0, rec.threadStatePointer());
+            rec.callPointer(offsetof(ThreadState, felix86_set_segment));
+            rec.restoreState();
+            rec.backToDispatcher();
+            rec.stopCompiling();
+            return;
+        }
+    }
+
     switch (operands[0].type) {
     case ZYDIS_OPERAND_TYPE_REGISTER:
     case ZYDIS_OPERAND_TYPE_MEMORY: {

--- a/src/felix86/v2/handlers.cpp
+++ b/src/felix86/v2/handlers.cpp
@@ -9489,7 +9489,6 @@ FAST_HANDLE(XRSTOR64) {
 }
 
 FAST_HANDLE(WRFSBASE) {
-    WARN("WRFSBASE");
     biscuit::GPR reg = rec.getGPR(&operands[0]);
 
     if (instruction.operand_width == 32) {

--- a/src/felix86/v2/handlers.cpp
+++ b/src/felix86/v2/handlers.cpp
@@ -544,13 +544,30 @@ FAST_HANDLE(MOV) {
             ASSERT(operands[0].reg.value != ZYDIS_REGISTER_CS);
             biscuit::GPR src = rec.getGPR(&operands[1]);
             rec.writebackState();
-            as.MV(a0, rec.threadStatePointer());
             as.MV(a1, src);
             as.LI(a2, operands[0].reg.value);
+            as.MV(a0, rec.threadStatePointer());
             rec.callPointer(offsetof(ThreadState, felix86_set_segment));
             rec.restoreState();
         } else {
-            WARN("Setting segment register %d in 64-bit mode, ignoring", operands[0].reg.value);
+            switch (operands[0].reg.value) {
+            case ZYDIS_REGISTER_FS:
+            case ZYDIS_REGISTER_GS: {
+                WARN("Setting segment register %d in 64-bit mode", operands[0].reg.value);
+                biscuit::GPR src = rec.getGPR(&operands[1]);
+                rec.writebackState();
+                as.MV(a1, src);
+                as.LI(a2, operands[0].reg.value);
+                as.MV(a0, rec.threadStatePointer());
+                rec.callPointer(offsetof(ThreadState, felix86_set_segment));
+                rec.restoreState();
+                break;
+            }
+            default: {
+                WARN("Setting segment register %d in 64-bit mode, ignoring", operands[0].reg.value);
+                break;
+            }
+            }
         }
     } else if (is_segment(operands[1])) {
         biscuit::GPR seg = rec.scratch();
@@ -1808,6 +1825,7 @@ FAST_HANDLE(IRETD) {
     ASSERT(MODE32);
     rec.writebackState();
     as.MV(a0, rec.threadStatePointer());
+    as.LI(a1, 0);
     rec.callPointer(offsetof(ThreadState, felix86_iret));
     rec.restoreState();
     rec.backToDispatcher();
@@ -1818,6 +1836,7 @@ FAST_HANDLE(IRETQ) {
     ASSERT(!MODE32);
     rec.writebackState();
     as.MV(a0, rec.threadStatePointer());
+    as.LI(a1, 1);
     rec.callPointer(offsetof(ThreadState, felix86_iret));
     rec.restoreState();
     rec.backToDispatcher();
@@ -9449,6 +9468,7 @@ FAST_HANDLE(XRSTOR64) {
 }
 
 FAST_HANDLE(WRFSBASE) {
+    WARN("WRFSBASE");
     biscuit::GPR reg = rec.getGPR(&operands[0]);
 
     if (instruction.operand_width == 32) {


### PR DESCRIPTION
These are used in newer WoW64 versions of Wine to switch from 32-bit to 64-bit and back by changing the CS segment