### PR TITLE
Use our custom glibc, if present, to change the flags in pthread_create

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -95,7 +95,7 @@ jobs:
           cd $RUNNER_TEMP/tests
           FELIX86_GLIBC_LINK="https://github.com/felix86-emu/glibc/releases/download/2.4.3-felix86/glibc-felix86.zip"
           curl -fsSL "$FELIX86_GLIBC_LINK" -o "$RUNNER_TEMP/tests/glibc.zip"
-          unzip -o -d "$RUNNER_TEMP/tests "$RUNNER_TEMP/tests/glibc.zip"
+          unzip -o -d "$RUNNER_TEMP/tests" "$RUNNER_TEMP/tests/glibc.zip"
           patchelf --set-interpreter "$RUNNER_TEMP/tests/lib/riscv64-linux-gnu/ld-linux-riscv64-lp64d.so.1" --add-rpath "$RUNNER_TEMP/tests/lib/riscv64-linux-gnu" "$FELIX86PATH"
           bash ./install-tests.sh $HOME/felix86_test_binaries
           bash ./run-tests.sh $FELIX86PATH $HOME/felix86_test_binaries

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -93,6 +93,10 @@ jobs:
           ROOTFSPATH=$($FELIX86PATH -g)
           git clone https://github.com/felix86-emu/binary_tests $RUNNER_TEMP/tests
           cd $RUNNER_TEMP/tests
+          FELIX86_GLIBC_LINK="https://github.com/felix86-emu/glibc/releases/download/2.4.3-felix86/glibc-felix86.zip"
+          curl -fsSL "$FELIX86_GLIBC_LINK" -o "$RUNNER_TEMP/tests/glibc.zip"
+          unzip -o -d "$RUNNER_TEMP/tests "$RUNNER_TEMP/tests/glibc.zip"
+          patchelf --set-interpreter "$RUNNER_TEMP/tests/lib/riscv64-linux-gnu/ld-linux-riscv64-lp64d.so.1" --add-rpath "$RUNNER_TEMP/tests/lib/riscv64-linux-gnu" "$FELIX86PATH"
           bash ./install-tests.sh $HOME/felix86_test_binaries
           bash ./run-tests.sh $FELIX86PATH $HOME/felix86_test_binaries
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,24 @@ add_executable(felix86)
 target_sources(felix86 PRIVATE src/felix86/main.cpp)
 target_link_libraries(felix86 PRIVATE felix86_core)
 
+# If custom glibc is installed you can use these environment variables to patch the executable
+# This is helpful for developers to automatically patch felix86 after building
+if (FELIX86_LDSO AND FELIX86_RUNPATH)
+    find_program(PATCHELF_EXECUTABLE patchelf)
+
+    if (NOT PATCHELF_EXECUTABLE)
+        message(FATAL_ERROR "patchelf not found but FELIX86_LDSO/FELIX86_RUNPATH were supplied. "
+            "Install patchelf or unset these options.")
+    endif()
+
+    message(STATUS "patchelf found: ${PATCHELF_EXECUTABLE}")
+
+    add_custom_command(TARGET felix86 POST_BUILD
+        COMMAND ${PATCHELF_EXECUTABLE} --set-interpreter "${FELIX86_LDSO}" --set-rpath "${FELIX86_RUNPATH}" $<TARGET_FILE:felix86>
+        COMMENT "Patching felix86 with patchelf"
+    )
+endif()
+
 if (BUILD_REPL)
     find_package(PkgConfig REQUIRED)
     pkg_check_modules(READLINE REQUIRED readline)

--- a/src/felix86/hle/thread.cpp
+++ b/src/felix86/hle/thread.cpp
@@ -231,6 +231,7 @@ long NewCloneMe(CloneArgs& host_clone_args) {
     if (host_clone_args.guest_flags == pthread_create_flags) {
         // Great, just passthrough to host
     } else {
+        // Try to use our custom glibc function to manipulate the pthread_create clone flags
         pthread_attr_setsysflags_t pthread_attr_setsysflags = felix86_get_pthread_attr_setsysflags_ptr();
         if (!pthread_attr_setsysflags) {
             // Not using the custom glibc, use the old method
@@ -238,6 +239,8 @@ long NewCloneMe(CloneArgs& host_clone_args) {
             return CloneMe(host_clone_args);
         }
 
+        std::string sflags = flags_to_string(host_clone_args.guest_flags);
+        WARN("Using pthread_attr_setsysflags for clone with flags: %s", sflags.c_str());
         u64 host_flags = host_clone_args.guest_flags | CLONE_SETTLS; // Always set a new host-side TLS
         pthread_attr_setsysflags(&attr, host_flags);
     }

--- a/src/felix86/hle/thread.cpp
+++ b/src/felix86/hle/thread.cpp
@@ -216,12 +216,11 @@ pthread_attr_setsysflags_t felix86_get_pthread_attr_setsysflags_ptr() {
 }
 
 long NewCloneMe(CloneArgs& host_clone_args) {
-    // We use a custom pthread_attr_t in our custom libc. However, it makes use of a `void* unused` field
+    // We use a custom pthread_attr_t in our custom libc. It makes use of a `void* unused` field in pthread_attr_t
     // so as to not disturb the size. This way the usage of pthread_attr_t here allocates enough stack space.
-    // CloneMe creates two processes to create a TLS and also set the correct flags
-    // NewCloneMe uses a custom felix86 glibc fork to change the clone flags
-    // This should be more accurate in some rare cases, such as ptrace detecting our processes
-    // or CLONE_VM without CLONE_THREAD and checking that tgid == tid
+    // This way we can use the TLS created by the libc via pthread_create and also modify the flags to be accurate on the guest side.
+    // The custom libc is installed by default via the installation script, but if not present the code will fallback to the old
+    // method using CloneMe and work as before
     ASSERT(host_clone_args.guest_flags & CLONE_VM);
     u64 pthread_create_flags =
         CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SYSVSEM | CLONE_SIGHAND | CLONE_THREAD | CLONE_SETTLS | CLONE_PARENT_SETTID | CLONE_CHILD_CLEARTID;

--- a/src/felix86/hle/thread.cpp
+++ b/src/felix86/hle/thread.cpp
@@ -1,5 +1,6 @@
 #include <atomic>
 #include <csignal>
+#include <dlfcn.h>
 #include <fcntl.h>
 #include <linux/futex.h>
 #include <sys/mman.h>
@@ -203,6 +204,44 @@ long CloneMe(CloneArgs& host_clone_args) {
     return result;
 }
 
+using pthread_attr_setsysflags_t = int (*)(pthread_attr_t*, size_t);
+
+pthread_attr_setsysflags_t felix86_get_pthread_attr_setsysflags_ptr() {
+    static void* pthread_attr_setsysflags_p = dlsym(RTLD_DEFAULT, "pthread_attr_setsysflags");
+    if (!pthread_attr_setsysflags_p) {
+        WARN_ONCE("pthread_attr_setsysflags not found, custom libc not present, using legacy clone implementation");
+        return NULL;
+    }
+    return (pthread_attr_setsysflags_t)pthread_attr_setsysflags_p;
+}
+
+long NewCloneMe(CloneArgs& host_clone_args) {
+    // CloneMe creates two processes to create a TLS
+    // NewCloneMe uses a custom felix86 glibc fork to change the clone flags
+    // This should be more accurate in some rare cases, such as ptrace detecting our processes
+    // or CLONE_VM without CLONE_THREAD and checking that tgid == tid
+    ASSERT(host_clone_args.guest_flags & CLONE_VM);
+    pthread_attr_setsysflags_t pthread_attr_setsysflags = felix86_get_pthread_attr_setsysflags_ptr();
+    pthread_attr_t attr;
+    pthread_attr_init(&attr);
+
+    // Always set a new host-side TLS
+    u64 host_flags = host_clone_args.guest_flags | CLONE_SETTLS;
+    pthread_attr_setsysflags(&attr, host_flags);
+
+    pthread_t thread;
+    pthread_create(&thread, &attr, pthread_handler, &host_clone_args);
+    pthread_detach(thread);
+
+    pthread_attr_destroy(&attr);
+
+    // Wait for the pthread_handler to finish initialization and set this flag
+    while (!__atomic_load_n(&host_clone_args.new_tid, __ATOMIC_SEQ_CST))
+        ;
+
+    return host_clone_args.new_tid;
+}
+
 long ForkMe(CloneArgs& host_clone_args) {
     // If the child_stack argument is NULL, we need to handle it specially. The `clone` function can't take a null child_stack, we have to use
     // the syscall. Per the clone man page: Another difference for sys_clone is that the child_stack argument may be zero, in which case
@@ -356,7 +395,11 @@ long Threads::Clone(ThreadState* current_state, CloneArgs* args) {
     } else if (args->new_rsp == 0 || !(args->guest_flags & CLONE_VM)) {
         result = ForkMe(*args);
     } else {
-        result = CloneMe(*args);
+        if (felix86_get_pthread_attr_setsysflags_ptr()) {
+            result = NewCloneMe(*args);
+        } else {
+            result = CloneMe(*args);
+        }
     }
 
     return result;

--- a/src/felix86/hle/thread.cpp
+++ b/src/felix86/hle/thread.cpp
@@ -216,18 +216,31 @@ pthread_attr_setsysflags_t felix86_get_pthread_attr_setsysflags_ptr() {
 }
 
 long NewCloneMe(CloneArgs& host_clone_args) {
-    // CloneMe creates two processes to create a TLS
+    // We use a custom pthread_attr_t in our custom libc. However, it makes use of a `void* unused` field
+    // so as to not disturb the size. This way the usage of pthread_attr_t here allocates enough stack space.
+    // CloneMe creates two processes to create a TLS and also set the correct flags
     // NewCloneMe uses a custom felix86 glibc fork to change the clone flags
     // This should be more accurate in some rare cases, such as ptrace detecting our processes
     // or CLONE_VM without CLONE_THREAD and checking that tgid == tid
     ASSERT(host_clone_args.guest_flags & CLONE_VM);
-    pthread_attr_setsysflags_t pthread_attr_setsysflags = felix86_get_pthread_attr_setsysflags_ptr();
+    u64 pthread_create_flags =
+        CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SYSVSEM | CLONE_SIGHAND | CLONE_THREAD | CLONE_SETTLS | CLONE_PARENT_SETTID | CLONE_CHILD_CLEARTID;
+
     pthread_attr_t attr;
     pthread_attr_init(&attr);
+    if (host_clone_args.guest_flags == pthread_create_flags) {
+        // Great, just passthrough to host
+    } else {
+        pthread_attr_setsysflags_t pthread_attr_setsysflags = felix86_get_pthread_attr_setsysflags_ptr();
+        if (!pthread_attr_setsysflags) {
+            // Not using the custom glibc, use the old method
+            pthread_attr_destroy(&attr);
+            return CloneMe(host_clone_args);
+        }
 
-    // Always set a new host-side TLS
-    u64 host_flags = host_clone_args.guest_flags | CLONE_SETTLS;
-    pthread_attr_setsysflags(&attr, host_flags);
+        u64 host_flags = host_clone_args.guest_flags | CLONE_SETTLS; // Always set a new host-side TLS
+        pthread_attr_setsysflags(&attr, host_flags);
+    }
 
     pthread_t thread;
     pthread_create(&thread, &attr, pthread_handler, &host_clone_args);
@@ -395,11 +408,7 @@ long Threads::Clone(ThreadState* current_state, CloneArgs* args) {
     } else if (args->new_rsp == 0 || !(args->guest_flags & CLONE_VM)) {
         result = ForkMe(*args);
     } else {
-        if (felix86_get_pthread_attr_setsysflags_ptr()) {
-            result = NewCloneMe(*args);
-        } else {
-            result = CloneMe(*args);
-        }
+        result = NewCloneMe(*args);
     }
 
     return result;


### PR DESCRIPTION
If the [custom glibc fork](https://github.com/felix86-emu/glibc) function `pthread_attr_setsysflags` is present, use it to change the flags in the internal clone called by `pthread_create`. Previously we would run clone and run pthread_create inside the clone. The first clone would serve to pass the guest flags to the host process, and the pthread_create would serve to create the TLS. By modifying the flags of the pthread_create clone directly we don't need to call a clone first.

Another change in this PR is calling pthread_create directly when the guest flags are the same as pthread_create. Which is 99% of cases that CLONE_VM is used.

The cases where this is needed are rare. You'd need a clone with CLONE_VM that doesn't have the exact pthread/std::thread clone flags, and without CLONE_VFORK as that's handled in a separate path.
