### PR TITLE
Fix invalidateBlock rare tearing

### DIFF
--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -542,28 +542,6 @@ u64 Recompiler::compileSequence(bool mode32, u64 rip) {
         WARN("Jumped to address %lx which has a sequence of zeroes -- probably a bad jump?", rip);
     }
 
-    current_mode32 = mode32;
-    current_decoder_initialized = false; // TODO: don't invalidate if same mode32 as before
-    scanAhead(rip);
-    BlockMetadata& block_meta = getBlockMetadata(rip);
-    block_meta.host_address = (u64)as.GetCursorPointer();
-    block_meta.guest_address = start_rip;
-    block_meta.translation_sizes.resize(instructions.size());
-
-    // TODO: Put all this resetting functionality in a function
-    resetX87();
-    pushed_this_block = 0;
-    current_block_metadata = &block_meta;
-    resetVectorState();
-    local_x87_state = x87State::Unknown; // we don't know what ThreadState::x87_state is at runtime
-    fsrm_sse = true;                     // dispatcher loads SSE rounding mode as a default
-    v0_has_mask = false;
-
-    current_ripreg_value = rip; // may change in a syscall to check for safepoints, or after a set amount of instructions in the future
-    current_instruction_index = 0;
-
-    bool ran_mmx_once = false;
-
     // When invalidating from other threads we need to do it in a single atomic instruction, thus block starts
     // need to be aligned to 8 bytes as we exchange two instructions
     switch ((u64)as.GetCursorPointer() & 0x7) {
@@ -586,6 +564,28 @@ u64 Recompiler::compileSequence(bool mode32, u64 rip) {
     }
 
     ASSERT(((u64)as.GetCursorPointer() & 0x7) == 0);
+
+    current_mode32 = mode32;
+    current_decoder_initialized = false; // TODO: don't invalidate if same mode32 as before
+    scanAhead(rip);
+    BlockMetadata& block_meta = getBlockMetadata(rip);
+    block_meta.host_address = (u64)as.GetCursorPointer();
+    block_meta.guest_address = start_rip;
+    block_meta.translation_sizes.resize(instructions.size());
+
+    // TODO: Put all this resetting functionality in a function
+    resetX87();
+    pushed_this_block = 0;
+    current_block_metadata = &block_meta;
+    resetVectorState();
+    local_x87_state = x87State::Unknown; // we don't know what ThreadState::x87_state is at runtime
+    fsrm_sse = true;                     // dispatcher loads SSE rounding mode as a default
+    v0_has_mask = false;
+
+    current_ripreg_value = rip; // may change in a syscall to check for safepoints, or after a set amount of instructions in the future
+    current_instruction_index = 0;
+
+    bool ran_mmx_once = false;
 
     // Insert a safepoint at the start of the block, as it's easier than doing it at the end of the block
     // Also, this means that when a signal returns it will find a compiled block instead of needing to compile a new one

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -564,6 +564,29 @@ u64 Recompiler::compileSequence(bool mode32, u64 rip) {
 
     bool ran_mmx_once = false;
 
+    // When invalidating from other threads we need to do it in a single atomic instruction, thus block starts
+    // need to be aligned to 8 bytes as we exchange two instructions
+    switch ((u64)as.GetCursorPointer() & 0x7) {
+    case 0: {
+        break;
+    }
+    case 4: {
+        as.NOP();
+        break;
+    }
+    case 2: {
+        as.C_NOP();
+        as.NOP();
+        break;
+    }
+    case 6: {
+        as.C_NOP();
+        break;
+    }
+    }
+
+    ASSERT(((u64)as.GetCursorPointer() & 0x7) == 0);
+
     // Insert a safepoint at the start of the block, as it's easier than doing it at the end of the block
     // Also, this means that when a signal returns it will find a compiled block instead of needing to compile a new one
     // TODO: insert safepoints within the block every N instructions, needs to flushx87 too
@@ -3192,7 +3215,10 @@ void Recompiler::invalidateBlock(BlockMetadata* block) {
     ASSERT(isScratch(t4));
     tas.AUIPC(t4, hi20);
     tas.JALR(t6, lo12, t4); // see invalidate_caller_thunk for t6
-    __atomic_store(address, &storage, __ATOMIC_SEQ_CST);
+    // If the address isn't aligned it can lead into problems with the atomic instruction or
+    // with the fact that the first and second instructions can span multiple cache blocks
+    ASSERT(((u64)address & 0x7) == 0);
+    __atomic_exchange_n(address, storage, __ATOMIC_SEQ_CST);
 }
 
 int Recompiler::invalidateRange(u64 start, u64 end) {


### PR DESCRIPTION
This bug is noticed in Java but occasionally happens in other recompilers too like in steamwebhelper where a bogus address appears. This happens when the first two instructions of the block are on different cache lines. Our __atomic_store wouldn't actually do an atomic store in those cases and if unlucky enough over many runs (e.g. java would crash at a 0.4% rate in the helloworld.jar) only the second instruction will run.

By ensuring blocks start aligned to 8, the store should happen atomically, and we make this even tighter by using amoswap instead.

Here's an example crash, notice how the second instruction which got replaced is on a different cache line and that the offset to t4 is the faulting PC.
```
(gdb) frame 7
#7  0x000000000000079c in ?? ()
(gdb) p/x $s11
$1 = 0x3f5460013b
(gdb) p/x ((ThreadState*)$gp)->recompiler->address_cache[$1 & 0xFFFF]
$2 = {host = 0x3f71218b3c, guest = 0x3f5460013b}
(gdb) x/10i 0x3f71218b3c
   0x3f71218b3c:        auipc   t4,0xffb55
   0x3f71218b40:        jalr    t6,1948(t4)
```
