### PR TITLE
Use compressed instructions for jumping to invalidate_caller_thunk

### DIFF
--- a/src/felix86/common/frame.hpp
+++ b/src/felix86/common/frame.hpp
@@ -6,9 +6,8 @@
 
 struct ThreadState;
 
-constexpr static std::array saved_gprs = {biscuit::ra, biscuit::sp, biscuit::tp,
-    biscuit::s0, biscuit::s1, biscuit::s2, biscuit::s3, biscuit::s4, biscuit::s5,
-    biscuit::s6, biscuit::s7, biscuit::s8, biscuit::s9, biscuit::s10, biscuit::s11};
+constexpr static std::array saved_gprs = {biscuit::ra, biscuit::sp, biscuit::tp, biscuit::s0, biscuit::s1, biscuit::s2,  biscuit::s3, biscuit::s4,
+                                          biscuit::s5, biscuit::s6, biscuit::s7, biscuit::s8, biscuit::s9, biscuit::s10, biscuit::s11};
 
 // A frame in the host stack that contains saved host registers
 // This is used to restore the context before entering the dispatcher and to also store multiple contexts
@@ -17,6 +16,7 @@ struct felix86_frame {
     constexpr static u64 expected_magic = 0x6814'8664'0000'FE86;
     u64 magic; // to make sure this is indeed a frame
     ThreadState* state;
+    u64 invalidate_caller_thunk_ptr;
     u64 gprs[saved_gprs.size()];
     // We don't modify the saved FPRs so we don't need to save them
 };

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -161,8 +161,12 @@ Recompiler::~Recompiler() {
 void Recompiler::emitNecessaryStuff() {
     OptimizationGuard guard(as, optimization_guard_counter);
 
-    emitInvalidateCallerThunk();
+    u8* replace_me = emitInvalidateCallerThunk();
     emitDispatcher();
+    u8* ptr = as.GetCursorPointer();
+    as.SetCursorPointer(replace_me);
+    backToDispatcher();
+    as.SetCursorPointer(ptr);
 
     start_of_code_cache = as.GetCursorPointer();
 
@@ -299,7 +303,7 @@ void Recompiler::emitDispatcher() {
     as.JR(ra);
 }
 
-void Recompiler::emitInvalidateCallerThunk() {
+u8* Recompiler::emitInvalidateCallerThunk() {
     invalidate_caller_thunk = (u64)as.GetCursorPointer();
 
     // Call the invalidateAt function which will remove the block from the map
@@ -314,7 +318,13 @@ void Recompiler::emitInvalidateCallerThunk() {
     as.ADDI(a2, a2, -8); // JALR links to instruction right after, go back two
     call((u64)Recompiler::invalidateAt);
     restoreState(); // TODO: instead, make a "backToDispatcherSkipWriteback" function and remove this restore
-    backToDispatcher();
+
+    // Will be replaced with backToDispatcher later
+    u8* replace_me = as.GetCursorPointer();
+    as.NOP();
+    as.NOP();
+    as.NOP();
+    return replace_me;
 }
 
 // Note: This function is important. When we invalidate a block range, our choices are either iterate every block that links

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -306,16 +306,21 @@ void Recompiler::emitDispatcher() {
 u8* Recompiler::emitInvalidateCallerThunk() {
     invalidate_caller_thunk = (u64)as.GetCursorPointer();
 
+    as.ADDI(sp, sp, -16);
+    // All block links set the return address in t5, and we collect it here
+    // The dispatcher itself sets t5 to 0 to signal that the jump comes from there
+    as.SD(sp, 0, t5);
+    // Contains the RISC-V PC of the block that gets invalidated
+    as.SD(sp, 8, ra);
+
     // Call the invalidateAt function which will remove the block from the map
     // when it's called and it will go back to the dispatcher, which will trigger a new compilation
     writebackState();
     as.MV(a0, threadStatePointer());
-    // All block links set the return address in t5, and we collect it here
-    // The dispatcher itself sets t5 to 0 to signal that the jump comes from there
-    as.MV(a1, t5);
-    // Contains the RISC-V PC of the block that gets invalidated
-    as.MV(a2, ra);
-    as.ADDI(a2, a2, -8); // JALR links to instruction right after, go back two
+    as.LD(a1, 0, sp);
+    as.LD(a2, 8, sp);
+    as.ADDI(a2, a2, -4); // JALR links to instruction right after, go back 4 bytes
+    as.ADDI(sp, sp, 16);
     call((u64)Recompiler::invalidateAt);
     restoreState(); // TODO: instead, make a "backToDispatcherSkipWriteback" function and remove this restore
 

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -161,8 +161,8 @@ Recompiler::~Recompiler() {
 void Recompiler::emitNecessaryStuff() {
     OptimizationGuard guard(as, optimization_guard_counter);
 
-    emitDispatcher();
     emitInvalidateCallerThunk();
+    emitDispatcher();
 
     start_of_code_cache = as.GetCursorPointer();
 
@@ -192,6 +192,10 @@ void Recompiler::emitDispatcher() {
     // Also save the magic number
     as.LI(t1, felix86_frame::expected_magic);
     as.SD(t1, offsetof(felix86_frame, magic), sp);
+
+    ASSERT(invalidate_caller_thunk);
+    as.LI(t1, invalidate_caller_thunk);
+    as.SD(t1, offsetof(felix86_frame, invalidate_caller_thunk_ptr), sp);
 
     as.MV(threadStatePointer(), a0);
 
@@ -306,7 +310,7 @@ void Recompiler::emitInvalidateCallerThunk() {
     // The dispatcher itself sets t5 to 0 to signal that the jump comes from there
     as.MV(a1, t5);
     // Contains the RISC-V PC of the block that gets invalidated
-    as.MV(a2, t6);
+    as.MV(a2, ra);
     as.ADDI(a2, a2, -8); // JALR links to instruction right after, go back two
     call((u64)Recompiler::invalidateAt);
     restoreState(); // TODO: instead, make a "backToDispatcherSkipWriteback" function and remove this restore
@@ -504,6 +508,8 @@ u64 Recompiler::compile(ThreadState* state, u64 rip) {
 }
 
 void Recompiler::insertSafepoint() {
+    // This instruction must be 4 bytes, see invalidateBlock for reason
+    OptimizationGuard guard(as, optimization_guard_counter);
     as.SD(x0, -8, Recompiler::threadStatePointer());
 }
 
@@ -3206,18 +3212,23 @@ void Recompiler::invalidateBlock(BlockMetadata* block) {
         return;
     }
 
-    u64* address = (u64*)host_address;
-    const u64 offset = (u64)invalidate_caller_thunk - (u64)address;
-    const auto hi20 = static_cast<int32_t>(((static_cast<uint32_t>(offset) + 0x800) >> 12) & 0xFFFFF);
-    const auto lo12 = static_cast<int32_t>(offset << 20) >> 20;
-    u64 storage;
-    Assembler tas((u8*)&storage, 8);
-    ASSERT(isScratch(t4));
-    tas.AUIPC(t4, hi20);
-    tas.JALR(t6, lo12, t4); // see invalidate_caller_thunk for t6
-    // If the address isn't aligned it can lead into problems with the atomic instruction or
-    // with the fact that the first and second instructions can span multiple cache blocks
-    ASSERT(((u64)address & 0x7) == 0);
+    u32* address = (u32*)host_address;
+    u32 storage;
+    Assembler tas((u8*)&storage, 4);
+    static_assert(isScratch(t4));
+    static_assert(isScratch(ra));
+    // It is important we use two compressed instructions here
+    // Previously we would use two non-compressed instructions
+    // But there's the scenario of one thread being about to run the second instruction
+    // and another thread invalidating the block. In that case only the second instruction would be run
+    // and jump to a bogus place. By being two compressed instructions and ensuring the first instruction
+    // of a block (the safepoint) is a 4-byte instruction, either the first instruction of the block executes
+    // or the two invalidation instructions execute, there's no in-between
+    // We would prefer to load the literal from ThreadState or AUIPC like before, but compressed can't do that
+    // so we use C.LDSP here
+    tas.C_LDSP(t4, offsetof(felix86_frame, invalidate_caller_thunk_ptr));
+    tas.C_JALR(t4); // ra is used in invalidate_caller_thunk
+    ASSERT(((u64)address & 0x4) == 0);
     __atomic_exchange_n(address, storage, __ATOMIC_SEQ_CST);
 }
 

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -309,9 +309,9 @@ u8* Recompiler::emitInvalidateCallerThunk() {
     as.ADDI(sp, sp, -16);
     // All block links set the return address in t5, and we collect it here
     // The dispatcher itself sets t5 to 0 to signal that the jump comes from there
-    as.SD(sp, 0, t5);
+    as.SD(t5, 0, sp);
     // Contains the RISC-V PC of the block that gets invalidated
-    as.SD(sp, 8, ra);
+    as.SD(ra, 8, sp);
 
     // Call the invalidateAt function which will remove the block from the map
     // when it's called and it will go back to the dispatcher, which will trigger a new compilation

--- a/src/felix86/v2/recompiler.hpp
+++ b/src/felix86/v2/recompiler.hpp
@@ -739,7 +739,7 @@ private:
 
     void emitDispatcher();
 
-    void emitInvalidateCallerThunk();
+    [[nodiscard]] u8* emitInvalidateCallerThunk();
 
     void scanAhead(u64 rip);
 


### PR DESCRIPTION
While the previous commit made the crashes rarer, they are still not gone. It is still possible for the second instruction to get changed while getting fetched. In this commit the first instruction of the block (which is guaranteed to be 4 bytes) is replaced with two 2-byte instructions, such that either the 1st 4-byte instruction is ran or the two 2-byte instructions are ran. This should completely fix this issue.

C.LDSP+C.JALR are used, we can't C.LD from ThreadState as ThreadState is at $gp (and it's there for a good reason) so the next best option is loading it from the stack frame.