### PR TITLE
Don't allow rootfs escapes via fd after chrooting

### DIFF
--- a/src/felix86/common/global.cpp
+++ b/src/felix86/common/global.cpp
@@ -53,6 +53,7 @@ bool g_testing = false;
 // g_output_fd should be replaced upon connecting to the server, however if an error occurs before then we should at least log it
 int g_output_fd = STDERR_FILENO;
 int g_rootfs_fd = 0;
+int g_original_rootfs_fd = -1;
 
 u64 g_interpreter_start{};
 u64 g_interpreter_end{};
@@ -348,16 +349,8 @@ void initialize_globals() {
 
     std::filesystem::path original_rootfs = g_config.rootfs_path;
     if (!g_config.no_rootfs) {
-        const char* guest_rootfs = getenv("__FELIX86_ROOTFS");
-        if (guest_rootfs) {
-            g_config.rootfs_path = guest_rootfs;
-        } else {
-            ASSERT(!g_execve_process);
-            ASSERT_MSG(!g_config.rootfs_path.empty(), "Empty rootfs path, please set using felix86 -s <PATH>");
-        }
-
         if (!std::filesystem::exists(g_config.rootfs_path)) {
-            ERROR("Rootfs path does <%s> not exist", g_config.rootfs_path.c_str());
+            ERROR("Rootfs path %s does not exist", g_config.rootfs_path.c_str());
         }
 
         std::string srootfs_path = g_config.rootfs_path.string();
@@ -370,6 +363,22 @@ void initialize_globals() {
         ASSERT_MSG(g_rootfs_fd > 0, "Failed to open rootfs directory");
         g_rootfs_fd = FD::moveToHighNumber(g_rootfs_fd);
         FD::protect(g_rootfs_fd);
+        g_original_rootfs_fd = dup(g_rootfs_fd);
+        ASSERT_MSG(g_original_rootfs_fd > 0, "Failed to dup g_rootfs_fd");
+        g_original_rootfs_fd = FD::moveToHighNumber(g_original_rootfs_fd);
+        FD::protect(g_original_rootfs_fd);
+
+        const char* guest_rootfs = getenv("__FELIX86_ROOTFS");
+        if (guest_rootfs) {
+            std::string rootfs = guest_rootfs;
+            if (rootfs != g_config.rootfs_path) {
+                g_config.rootfs_path = rootfs;
+                g_rootfs_fd = open(g_config.rootfs_path.c_str(), O_PATH | O_DIRECTORY);
+                ASSERT_MSG(g_rootfs_fd > 0, "Failed to open chrooted rootfs directory");
+                g_rootfs_fd = FD::moveToHighNumber(g_rootfs_fd);
+                FD::protect(g_rootfs_fd);
+            }
+        }
 
         ASSERT_MSG(g_config.rootfs_path.string().back() != '/', "Rootfs path should not end in '/'");
         ASSERT_MSG(Filesystem::FakeMount("/dev", original_rootfs / "dev"), "Failed to fake-mount /dev");

--- a/src/felix86/common/global.hpp
+++ b/src/felix86/common/global.hpp
@@ -74,7 +74,8 @@ extern u64 g_dispatcher_exit_count;
 extern u64 g_program_end;
 extern int g_output_fd;
 extern std::string g_emulator_path;
-extern int g_rootfs_fd;
+extern int g_rootfs_fd;          // rootfs with chroots
+extern int g_original_rootfs_fd; // rootfs without chroots
 extern u64 g_interpreter_start, g_interpreter_end;
 extern u64 g_executable_start, g_executable_end;
 extern const char* g_git_hash;

--- a/src/felix86/hle/filesystem.cpp
+++ b/src/felix86/hle/filesystem.cpp
@@ -39,7 +39,7 @@ void remove_if_found(std::string& path, const std::filesystem::path& rootfs) {
 bool statx_inode_same(const struct statx* a, const struct statx* b) {
     return (a && a->stx_mask != 0) && (b && b->stx_mask != 0) && FLAGS_SET(a->stx_mask, STATX_TYPE | STATX_INO) &&
            FLAGS_SET(b->stx_mask, STATX_TYPE | STATX_INO) && ((a->stx_mode ^ b->stx_mode) & S_IFMT) == 0 && a->stx_dev_major == b->stx_dev_major &&
-           a->stx_dev_minor == b->stx_dev_minor && a->stx_ino == b->stx_ino;
+           a->stx_dev_minor == b->stx_dev_minor && a->stx_ino == b->stx_ino && a->stx_mnt_id == b->stx_mnt_id;
 }
 
 int generate_memfd(const char* path, int flags) {
@@ -942,6 +942,11 @@ FdPath Filesystem::resolveImpl(int fd, const char* path, bool resolve_final) {
     int result = statx(g_rootfs_fd, "", AT_EMPTY_PATH, STATX_TYPE | STATX_INO | STATX_MNT_ID, &root_statx);
     ASSERT(result == 0);
 
+    struct statx original_root_statx;
+    result = statx(g_original_rootfs_fd, "", AT_EMPTY_PATH, STATX_TYPE | STATX_INO | STATX_MNT_ID, &original_root_statx);
+    ASSERT(result == 0);
+    bool is_chroot = !statx_inode_same(&root_statx, &original_root_statx);
+
     int total_symlinks_resolved = 0; // goes up to 40 as per the kernel
     while (!components.empty()) {
         std::string current_component = components.front();
@@ -981,6 +986,14 @@ FdPath Filesystem::resolveImpl(int fd, const char* path, bool resolve_final) {
 
                 // Skip this component and point to rootfs
                 current_fd = g_rootfs_fd;
+                // Also clear this since we are starting resolution from rootfs now
+                current_relative_path = ".";
+                continue;
+            } else if (is_chroot && statx_inode_same(&original_root_statx, &current_statx)) {
+                // If a file descriptor is held open after chrooting, it can be used with ".." to go behind the unchrooted rootfs
+                // So we need to ensure that a file descriptor can't be used to escape the original rootfs before chrooting
+                // Skip this component and point to original rootfs
+                current_fd = g_original_rootfs_fd;
                 // Also clear this since we are starting resolution from rootfs now
                 current_relative_path = ".";
                 continue;


### PR DESCRIPTION
resolveImpl would check for rootfs escapes by comparing with the current rootfs fd. But if the rootfs fd changes due to a chroot an open file descriptor can be still used to escape the original rootfs

Reported-by: Spiros Thanasoulas (Radically Open Security)