### PR TITLE
Allow ptrace commands on host stops

### DIFF
--- a/src/felix86/hle/ptrace.cpp
+++ b/src/felix86/hle/ptrace.cpp
@@ -1190,8 +1190,6 @@ i64 sys_ptrace(felix86_ptrace_request op, pid_t pid, void* addr, void* data) {
 
         remote_state->ptrace_data.stop_info.signal = sig;
         remote_state->ptrace_data.injected.cont_type = PTRACE_CONT;
-        if (!remote_state->ptrace_data.stop_info.stopped) {
-        }
         remote_state.commit();
         // Skip the host signal from raise_stop
         int result = __ptrace(PTRACE_CONT, pid, 0, 0);

--- a/src/felix86/hle/ptrace.cpp
+++ b/src/felix86/hle/ptrace.cpp
@@ -719,7 +719,7 @@ i64 sys_ptrace(felix86_ptrace_request op, pid_t pid, void* addr, void* data) {
     default: {
         remote_state = get_remote_state(pid);
         if (!remote_state) {
-            HOSTPTRACELOG("Tried to run ptrace operation %s on %d, but it is not stopped", guest_op_to_string(op), pid);
+            HOSTPTRACELOG("Tried to run ptrace operation %s on %d, but it is not stopped or not traced by us", guest_op_to_string(op), pid);
             return -ESRCH;
         }
 

--- a/src/felix86/hle/ptrace.cpp
+++ b/src/felix86/hle/ptrace.cpp
@@ -727,7 +727,6 @@ i64 sys_ptrace(felix86_ptrace_request op, pid_t pid, void* addr, void* data) {
             // Not in an official stop, so return ESRCH and warn
             // This may happen if a different thread than the tracer was already run a waitpid on the tracee
             // We want to try to run the operation anyway, but this may be a host-side stop
-            // If this is a host signal-delivery-stop then we need to not raise the next guest signal-delivery-stop...
             WARN("Tried to run ptrace operation %s on %d, but it is not guest stopped", guest_op_to_string(op), pid);
         }
 
@@ -1170,6 +1169,7 @@ i64 sys_ptrace(felix86_ptrace_request op, pid_t pid, void* addr, void* data) {
         }
 
         if (sig > 0 && !remote_state->ptrace_data.stop_info.stopped) {
+            // If this is a host signal-delivery-stop then we need to not raise the next guest signal-delivery-stop...
             // TODO: handle this properly
             WARN("Tracee is not guest stopped but continued with signal, this will cause a second signal-delivery-stop");
         }

--- a/src/felix86/hle/ptrace.cpp
+++ b/src/felix86/hle/ptrace.cpp
@@ -725,11 +725,10 @@ i64 sys_ptrace(felix86_ptrace_request op, pid_t pid, void* addr, void* data) {
 
         if (!remote_state->ptrace_data.stop_info.stopped) {
             // Not in an official stop, so return ESRCH and warn
-            // This may be the case if the tracer doesn't properly waitpid, which should not happen in legit
-            // applications. It may be the case we are actually in a "stop", but only due to host effects
-            // and we don't want to run ptrace operations that require stopping at that time
-            HOSTPTRACELOG("Tried to run ptrace operation %d on %d, but it is not guest stopped", op, pid);
-            return -ESRCH;
+            // This may happen if a different thread than the tracer was already run a waitpid on the tracee
+            // We want to try to run the operation anyway, but this may be a host-side stop
+            // If this is a host signal-delivery-stop then we need to not raise the next guest signal-delivery-stop...
+            WARN("Tried to run ptrace operation %s on %d, but it is not guest stopped", guest_op_to_string(op), pid);
         }
 
         if (remote_state->ptrace_data.constants.tracer_pid != gettid()) {
@@ -1170,6 +1169,11 @@ i64 sys_ptrace(felix86_ptrace_request op, pid_t pid, void* addr, void* data) {
             return -EIO;
         }
 
+        if (sig > 0 && !remote_state->ptrace_data.stop_info.stopped) {
+            // TODO: handle this properly
+            WARN("Tracee is not guest stopped but continued with signal, this will cause a second signal-delivery-stop");
+        }
+
         if (sig != remote_state->ptrace_data.stop_info.signal && !remote_state->ptrace_data.injected.siginfo_changed) {
             // When the signal is changed and the siginfo isn't changed via PTRACE_SETSIGINFO
             // the siginfo value is changed as seen in signal.c SEND_SIG_NOINFO
@@ -1186,6 +1190,8 @@ i64 sys_ptrace(felix86_ptrace_request op, pid_t pid, void* addr, void* data) {
 
         remote_state->ptrace_data.stop_info.signal = sig;
         remote_state->ptrace_data.injected.cont_type = PTRACE_CONT;
+        if (!remote_state->ptrace_data.stop_info.stopped) {
+        }
         remote_state.commit();
         // Skip the host signal from raise_stop
         int result = __ptrace(PTRACE_CONT, pid, 0, 0);


### PR DESCRIPTION
It is possible that a unit test or a real program tries to run a ptrace command without verifying it was stopped via waitpid (and instead waiting with sleep) so we should warn and run the command