### PR TITLE
Allow optionally passing program to `--shell`

### DIFF
--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -282,11 +282,13 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
             ps1 = "PS1=felix86 > ";
         }
 
-        char* const argv[4] = {
-            self.data(),
-            path_string.data(),
-            norc.empty() ? nullptr : norc.data(),
-            nullptr,
+        std::string program;
+        if (arg && arg[0] != 0) {
+            program = "-c " + std::string(arg);
+        }
+
+        char* const argv[5] = {
+            self.data(), path_string.data(), norc.empty() ? nullptr : norc.data(), program.empty() ? nullptr : program.data(), nullptr,
         };
 
         std::string quiet = "FELIX86_QUIET=1";

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -93,7 +93,7 @@ int print_system_info() {
     std::vector<const char*> args = {"fastfetch", "--structure", "cpu:gpu:host:distro:kernel:wm:memory", "--logo", "none", nullptr};
     pid_t pid;
     int status;
-    int ok = posix_spawnp(&pid, "neofetch", nullptr, nullptr, (char**)args.data(), environ);
+    int ok = posix_spawnp(&pid, "fastfetch", nullptr, nullptr, (char**)args.data(), environ);
     if (ok != 0) {
         printf("Please install fastfetch for more information\n");
         return ok;

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -43,8 +43,8 @@ static char doc[] = "felix86 - a userspace x86 and x86_64 emulator for RISC-V";
 static char args_doc[] = "TARGET_BINARY [TARGET_ARGS...]";
 
 static struct argp_option options[] = {
-    {"shell", 5, 0, 0, "Enter the rootfs through a shell"},
-    {"shell-debug", 6, 0, 0, "Enter the rootfs through a shell, enable logging"},
+    {"shell", 5, "PROGRAM", OPTION_ARG_OPTIONAL, "Enter the rootfs through a shell"},
+    {"shell-debug", 6, "PROGRAM", OPTION_ARG_OPTIONAL, "Enter the rootfs through a shell, enable logging"},
     {"info", 'i', 0, 0, "Print system info"},
     {"configs", 'c', 0, 0, "Print the emulator configurations"},
     {"kill-all", 'k', 0, 0, "Kill all open emulator instances"},
@@ -284,7 +284,7 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
 
         std::string program;
         if (arg && arg[0] != 0) {
-            program = "-c " + std::string(arg);
+            program = "-c \"" + std::string(arg) + "\"";
         }
 
         char* const argv[5] = {

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -282,13 +282,19 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
             ps1 = "PS1=felix86 > ";
         }
 
+        std::string c = "-c";
         std::string program;
         if (arg && arg[0] != 0) {
-            program = "-c \"" + std::string(arg) + "\"";
+            program = arg;
         }
 
-        char* const argv[5] = {
-            self.data(), path_string.data(), norc.empty() ? nullptr : norc.data(), program.empty() ? nullptr : program.data(), nullptr,
+        char* const argv[6] = {
+            self.data(),
+            path_string.data(),
+            norc.empty() ? nullptr : norc.data(),
+            program.empty() ? nullptr : c.data(),
+            program.empty() ? nullptr : program.data(),
+            nullptr,
         };
 
         std::string quiet = "FELIX86_QUIET=1";

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -283,19 +283,17 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
         }
 
         std::string c = "-c";
-        std::string program;
-        if (arg && arg[0] != 0) {
-            program = arg;
+        std::vector<char*> argv;
+        argv.push_back(self.data());
+        argv.push_back(path_string.data());
+        if (!norc.empty()) {
+            argv.push_back(norc.data());
         }
-
-        char* const argv[6] = {
-            self.data(),
-            path_string.data(),
-            norc.empty() ? nullptr : norc.data(),
-            program.empty() ? nullptr : c.data(),
-            program.empty() ? nullptr : program.data(),
-            nullptr,
-        };
+        if (arg && arg[0] != 0) {
+            argv.push_back(c.data());
+            argv.push_back(arg);
+        }
+        argv.push_back(nullptr);
 
         std::string quiet = "FELIX86_QUIET=1";
         std::vector<char*> envp;
@@ -314,7 +312,7 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
         }
         envp.push_back(nullptr);
 
-        (void)execve(self.c_str(), argv, envp.data());
+        (void)execve(self.c_str(), argv.data(), envp.data());
         printf("Failed to start %s, error: %s\n", path_string.c_str(), strerror(errno));
         exit(1);
         break;


### PR DESCRIPTION
Can run a program from inside the felix86 rootfs using e.g. `felix86 --shell="steam -no-cef-sandbox"`. 

Also fix bug where posix_spawnp would use neofetch instead of fastfetch