### PR TITLE
added syscall header manually

### DIFF
--- a/src/felix86/hle/cpuid.cpp
+++ b/src/felix86/hle/cpuid.cpp
@@ -1,6 +1,7 @@
 #include <array>
 #include <span>
 #include <fcntl.h>
+#include <sys/syscall.h>
 #include "felix86/common/config.hpp"
 #include "felix86/common/feature.hpp"
 #include "felix86/common/global.hpp"


### PR DESCRIPTION
this fixes a failed compile on my local device by manually including the `sys/syscall.h` implicitly included on other devices.