### PR TITLE
Implement `--set-config` and `--get-config`

### DIFF
--- a/src/felix86/common/config.cpp
+++ b/src/felix86/common/config.cpp
@@ -354,18 +354,18 @@ bool loadFromToml(const toml_result_t& toml, const char* group, const char* name
 }
 
 template <typename Type>
-bool setFromString(Config& config, Type& value, const char* env) {
+bool setFromString(Config& config, Type& value, const char* str) {
     if constexpr (std::is_same_v<Type, bool>) {
-        value = is_truthy(env);
+        value = is_truthy(str);
         return true;
     } else if constexpr (std::is_same_v<Type, u64>) {
-        value = get_int(env);
+        value = get_int(str);
         return true;
     } else if constexpr (std::is_same_v<Type, std::filesystem::path>) {
-        value = env;
+        value = str;
         return true;
     } else if constexpr (std::is_same_v<Type, std::string>) {
-        value = env;
+        value = str;
         return true;
     } else {
         static_assert(false);

--- a/src/felix86/common/config.cpp
+++ b/src/felix86/common/config.cpp
@@ -1,5 +1,6 @@
 #include <algorithm>
 #include <filesystem>
+#include <optional>
 #include <system_error>
 #include <pwd.h>
 #include <sys/types.h>
@@ -244,7 +245,7 @@ bool Config::initialize(bool ignore_envs) {
         }
     }
 
-    // g_config can be changed, c_initial_config won't be changed
+    // g_config can be changed, g_initial_config won't be changed
     g_initial_config = g_config;
 
 #define X(group, type, name, default_value, env_name, description)                                                                                   \
@@ -353,7 +354,7 @@ bool loadFromToml(const toml_result_t& toml, const char* group, const char* name
 }
 
 template <typename Type>
-bool loadFromEnv(Config& config, Type& value, const char* env) {
+bool setFromString(Config& config, Type& value, const char* env) {
     if constexpr (std::is_same_v<Type, bool>) {
         value = is_truthy(env);
         return true;
@@ -407,7 +408,7 @@ void Config::initializeChild() {
 #define X(group, type, name, default_value, env_name, description)                                                                                   \
     {                                                                                                                                                \
         bool loaded = false;                                                                                                                         \
-        loaded = loadFromEnv<type>(config, config.name, env_map.at(#env_name).c_str());                                                              \
+        loaded = setFromString<type>(config, config.name, env_map.at(#env_name).c_str());                                                            \
         if (!loaded) {                                                                                                                               \
             ERROR("Failed to load option " #env_name);                                                                                               \
         }                                                                                                                                            \
@@ -440,7 +441,7 @@ Config Config::load(const std::filesystem::path& path, bool ignore_envs) {
         [[maybe_unused]] bool loaded = false;                                                                                                        \
         const char* env = getenv(#env_name);                                                                                                         \
         if (env && !ignore_envs) {                                                                                                                   \
-            loaded = loadFromEnv<type>(config, config.name, env);                                                                                    \
+            loaded = setFromString<type>(config, config.name, env);                                                                                  \
         } else if (!no_config_path) {                                                                                                                \
             loaded = loadFromToml<type>(result, #group, #name, config.name);                                                                         \
         }                                                                                                                                            \
@@ -524,4 +525,42 @@ void Config::save(const std::filesystem::path& path, const Config& config, bool 
     ofs << "# You may change any values here, or their respective environment variable\n";
     ofs << "# The environment variables override the values here\n\n";
     ofs << toml;
+}
+
+static std::string lowercase(const char* str) {
+    std::string s(str);
+    for_each(s.begin(), s.end(), [](char& c) {
+        c = tolower(c);
+    });
+    return s;
+}
+
+std::optional<std::string> Config::getConfigString(const char* group, const char* field) {
+    // cmp_group and cmp_name are marked 'static' to avoid initializing more than once (first call of function). This is thread safe.
+#define X(group_, type_, name_, ...)                                                                                                                 \
+    {                                                                                                                                                \
+        static const std::string cmp_group = lowercase(#group_);                                                                                     \
+        static const std::string cmp_name = lowercase(#name_);                                                                                       \
+        if (strcmp(group, cmp_group.c_str()) == 0 && strcmp(field, cmp_name.c_str()) == 0) {                                                         \
+            return std::optional{stringify<type_>(this->name_)};                                                                                     \
+        }                                                                                                                                            \
+    }
+#include "config.inc"
+#undef X
+    return std::optional<std::string>{};
+}
+
+bool Config::setConfigString(const char* group, const char* field, const char* value) {
+    // cmp_group and cmp_name are marked 'static' to avoid initializing more than once (first call of function). This is thread safe.
+#define X(group_, type_, name_, ...)                                                                                                                 \
+    {                                                                                                                                                \
+        static const std::string cmp_group = lowercase(#group_);                                                                                     \
+        static const std::string cmp_name = lowercase(#name_);                                                                                       \
+        if (strcmp(group, cmp_group.c_str()) == 0 && strcmp(field, cmp_name.c_str()) == 0) {                                                         \
+            return setFromString<type_>(*this, this->name_, value);                                                                                  \
+        }                                                                                                                                            \
+    }
+#include "config.inc"
+#undef X
+    return false;
 }

--- a/src/felix86/common/config.cpp
+++ b/src/felix86/common/config.cpp
@@ -473,28 +473,28 @@ bool Config::loadProfile(Config& config, const std::filesystem::path& profile) {
 }
 
 template <typename T>
-std::string stringify(const T& value) {
+std::string stringify_toml(const T& value) {
     static_assert(false);
     return "";
 }
 
 template <>
-std::string stringify<std::string>(const std::string& value) {
+std::string stringify_toml<std::string>(const std::string& value) {
     return '\"' + value + '\"';
 }
 
 template <>
-std::string stringify<std::filesystem::path>(const std::filesystem::path& value) {
+std::string stringify_toml<std::filesystem::path>(const std::filesystem::path& value) {
     return '\"' + value.string() + '\"';
 }
 
 template <>
-std::string stringify<bool>(const bool& value) {
+std::string stringify_toml<bool>(const bool& value) {
     return value ? "true" : "false";
 }
 
 template <>
-std::string stringify<u64>(const u64& value) {
+std::string stringify_toml<u64>(const u64& value) {
     return fmt::format("{:#x}", value);
 }
 
@@ -511,7 +511,7 @@ void Config::save(const std::filesystem::path& path, const Config& config, bool 
         toml += "# " #name " (" #type ")\n";                                                                                                         \
         toml += "# Description: " description "\n";                                                                                                  \
         toml += "# Environment variable: " #env_name "\n";                                                                                           \
-        toml += #name " = " + stringify<type>(config.name) + "\n\n";                                                                                 \
+        toml += #name " = " + stringify_toml<type>(config.name) + "\n\n";                                                                            \
     }
 #include "config.inc"
 #undef X
@@ -535,6 +535,32 @@ static std::string lowercase(const char* str) {
     return s;
 }
 
+template <typename T>
+std::string stringify_shell(const T& value) {
+    static_assert(false);
+    return "";
+}
+
+template <>
+std::string stringify_shell<std::string>(const std::string& value) {
+    return value;
+}
+
+template <>
+std::string stringify_shell<std::filesystem::path>(const std::filesystem::path& value) {
+    return value;
+}
+
+template <>
+std::string stringify_shell<bool>(const bool& value) {
+    return value ? "true" : "false";
+}
+
+template <>
+std::string stringify_shell<u64>(const u64& value) {
+    return fmt::format("{:#x}", value);
+}
+
 std::optional<std::string> Config::getConfigString(const char* group, const char* field) {
     // cmp_group and cmp_name are marked 'static' to avoid initializing more than once (first call of function). This is thread safe.
 #define X(group_, type_, name_, ...)                                                                                                                 \
@@ -542,7 +568,7 @@ std::optional<std::string> Config::getConfigString(const char* group, const char
         static const std::string cmp_group = lowercase(#group_);                                                                                     \
         static const std::string cmp_name = lowercase(#name_);                                                                                       \
         if (strcmp(group, cmp_group.c_str()) == 0 && strcmp(field, cmp_name.c_str()) == 0) {                                                         \
-            return std::optional{stringify<type_>(this->name_)};                                                                                     \
+            return std::optional{stringify_shell<type_>(this->name_)};                                                                               \
         }                                                                                                                                            \
     }
 #include "config.inc"

--- a/src/felix86/common/config.hpp
+++ b/src/felix86/common/config.hpp
@@ -6,6 +6,7 @@
 #pragma once
 
 #include <filesystem>
+#include <optional>
 #include "felix86/common/types.hpp"
 
 struct Config {
@@ -23,6 +24,10 @@ struct Config {
     std::filesystem::path path() const {
         return config_path;
     }
+
+    std::optional<std::string> getConfigString(const char* group, const char* field);
+    /// Returns 'true' if a config value was updated, otherwise return `false`.
+    bool setConfigString(const char* group, const char* field, const char* value);
 
     [[nodiscard]] static Config load(const std::filesystem::path& path, bool ignore_envs = false);
     static bool loadProfile(Config& config, const std::filesystem::path& profile);

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -22,7 +22,6 @@
 #include "felix86/emulator.hpp"
 #include "felix86/hle/signals.hpp"
 #include "felix86/hle/thunks.hpp"
-#include "tomlc17.h"
 
 #if !defined(__riscv)
 #pragma message("You are compiling for x86-64, felix86 should only be compiled for RISC-V, are you sure you want to do this?")
@@ -46,10 +45,10 @@ static char doc[] = "felix86 - a userspace x86 and x86_64 emulator for RISC-V";
 static char args_doc[] = "TARGET_BINARY [TARGET_ARGS...]";
 
 static struct argp_option options[] = {
-    {"shell", 0, "PROGRAM", OPTION_ARG_OPTIONAL, "Enter the rootfs through a shell"},
-    {"shell-debug", -1, "PROGRAM", OPTION_ARG_OPTIONAL, "Enter the rootfs through a shell, enable logging"},
-    {"get-config", -2, "<GROUP.CONFIG>", 0, "Get a config value from the local felix configuration file. Format is '<group.config>'"},
-    {"set-config", -3, "<GROUP.CONFIG>=<VALUE>", 0, "Set a config value and store it into the local felix configuration. Format is '<group.config> <value>'"},
+    {"shell", -1, "PROGRAM", OPTION_ARG_OPTIONAL, "Enter the rootfs through a shell"},
+    {"shell-debug", -2, "PROGRAM", OPTION_ARG_OPTIONAL, "Enter the rootfs through a shell, enable logging"},
+    {"get-config", -3, "<GROUP.CONFIG>", 0, "Get a config value from the local felix configuration file. Format is '<group.config>'"},
+    {"set-config", -4, "<GROUP.CONFIG>=<VALUE>", 0, "Set a config value and store it into the local felix configuration. Format is '<group.config>=<value>'"},
     {"info", 'i', 0, 0, "Print system info"},
     {"configs", 'c', 0, 0, "Print the emulator configurations"},
     {"kill-all", 'k', 0, 0, "Kill all open emulator instances"},
@@ -191,11 +190,11 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
     bool shell_logging = false;
 
     switch (key) {
-    case 0: {
+    case -1: {
         shell_logging = true;
         [[fallthrough]];
     }
-    case -1: {
+    case -2: {
         std::error_code ec;
         Config::initialize();
         if (!g_config.no_rootfs) {
@@ -322,7 +321,7 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
         exit(1);
         break;
     }
-    case -2: {
+    case -3: {
         // get-config
         ASSERT(Config::initialize(true));
         std::string group{};
@@ -346,14 +345,14 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
         std::optional<std::string> get = g_config.getConfigString(group.c_str(), field.c_str());
         if (get.has_value()) {
             printf("%s\n", get.value().c_str());
-            exit(1);
+            exit(0);
         } else {
             ERROR("%s.%s is not a valid config tuple\n", group.c_str(), field.c_str());
         }
 
         break;
     }
-    case -3: {
+    case -4: {
         // set-config
         ASSERT(Config::initialize(true));
         std::string group{};
@@ -365,14 +364,14 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
             group.push_back(c); 
         }
         if (c != '.' || group.empty()) {
-            ERROR("expected argument to get-config to be in the format of '<GROUP.CONFIG>=<VALUE>'");
+            ERROR("expected argument to set-config to be in the format of '<GROUP.CONFIG>=<VALUE>'");
         }
 
         while(arg != NULL && (c = *arg++) && c != '=') {
             field.push_back(c); 
         }
         if (c != '=' || field.empty()) {
-            ERROR("expected argument to get-config to be in the format of '<GROUP.CONFIG>=<VALUE>'");
+            ERROR("expected argument to set-config to be in the format of '<GROUP.CONFIG>=<VALUE>'");
         }
 
         while(arg != NULL && (c = *arg++)) {
@@ -382,7 +381,7 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
 
         if (g_config.setConfigString(group.c_str(), field.c_str(), value.c_str())) {
             Config::save(g_config.path(), g_config);
-            exit(1);
+            exit(0);
         } else {
             ERROR("%s.%s is not a valid config tuple, or %s is not a valid value for the configuration\n", group.c_str(), field.c_str(), value.c_str());
         }

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -1,3 +1,5 @@
+#include <cstddef>
+#include <cstdio>
 #include <fstream>
 #include <argp.h>
 #include <dirent.h>
@@ -20,6 +22,7 @@
 #include "felix86/emulator.hpp"
 #include "felix86/hle/signals.hpp"
 #include "felix86/hle/thunks.hpp"
+#include "tomlc17.h"
 
 #if !defined(__riscv)
 #pragma message("You are compiling for x86-64, felix86 should only be compiled for RISC-V, are you sure you want to do this?")
@@ -43,8 +46,10 @@ static char doc[] = "felix86 - a userspace x86 and x86_64 emulator for RISC-V";
 static char args_doc[] = "TARGET_BINARY [TARGET_ARGS...]";
 
 static struct argp_option options[] = {
-    {"shell", 5, "PROGRAM", OPTION_ARG_OPTIONAL, "Enter the rootfs through a shell"},
-    {"shell-debug", 6, "PROGRAM", OPTION_ARG_OPTIONAL, "Enter the rootfs through a shell, enable logging"},
+    {"shell", 0, "PROGRAM", OPTION_ARG_OPTIONAL, "Enter the rootfs through a shell"},
+    {"shell-debug", -1, "PROGRAM", OPTION_ARG_OPTIONAL, "Enter the rootfs through a shell, enable logging"},
+    {"get-config", -2, "<GROUP.CONFIG>", 0, "Get a config value from the local felix configuration file. Format is '<group.config>'"},
+    {"set-config", -3, "<GROUP.CONFIG>=<VALUE>", 0, "Set a config value and store it into the local felix configuration. Format is '<group.config> <value>'"},
     {"info", 'i', 0, 0, "Print system info"},
     {"configs", 'c', 0, 0, "Print the emulator configurations"},
     {"kill-all", 'k', 0, 0, "Kill all open emulator instances"},
@@ -186,11 +191,11 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
     bool shell_logging = false;
 
     switch (key) {
-    case 6: {
+    case 0: {
         shell_logging = true;
         [[fallthrough]];
     }
-    case 5: {
+    case -1: {
         std::error_code ec;
         Config::initialize();
         if (!g_config.no_rootfs) {
@@ -315,6 +320,73 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
         (void)execve(self.c_str(), argv.data(), envp.data());
         printf("Failed to start %s, error: %s\n", path_string.c_str(), strerror(errno));
         exit(1);
+        break;
+    }
+    case -2: {
+        // get-config
+        ASSERT(Config::initialize(true));
+        std::string group{};
+        std::string field{};
+
+        char c = 0;
+        while(arg != NULL && (c = *arg++) && c != '.') {
+            group.push_back(c); 
+        }
+        if (c != '.' || group.empty()) {
+            ERROR("expected argument to get-config to be in the format of '<GROUP.CONFIG>'");
+        }
+
+        while(arg != NULL && (c = *arg++)) {
+            field.push_back(c); 
+        }
+        if (field.empty()) {
+            ERROR("expected argument to get-config to be in the format of '<GROUP.CONFIG>'");
+        }
+
+        std::optional<std::string> get = g_config.getConfigString(group.c_str(), field.c_str());
+        if (get.has_value()) {
+            printf("%s\n", get.value().c_str());
+            exit(1);
+        } else {
+            ERROR("%s.%s is not a valid config tuple\n", group.c_str(), field.c_str());
+        }
+
+        break;
+    }
+    case -3: {
+        // set-config
+        ASSERT(Config::initialize(true));
+        std::string group{};
+        std::string field{};
+        std::string value{};
+
+        char c = 0;
+        while(arg != NULL && (c = *arg++) && c != '.') {
+            group.push_back(c); 
+        }
+        if (c != '.' || group.empty()) {
+            ERROR("expected argument to get-config to be in the format of '<GROUP.CONFIG>=<VALUE>'");
+        }
+
+        while(arg != NULL && (c = *arg++) && c != '=') {
+            field.push_back(c); 
+        }
+        if (c != '=' || field.empty()) {
+            ERROR("expected argument to get-config to be in the format of '<GROUP.CONFIG>=<VALUE>'");
+        }
+
+        while(arg != NULL && (c = *arg++)) {
+            value.push_back(c); 
+        }        
+        // value can be an empty string
+
+        if (g_config.setConfigString(group.c_str(), field.c_str(), value.c_str())) {
+            Config::save(g_config.path(), g_config);
+            exit(1);
+        } else {
+            ERROR("%s.%s is not a valid config tuple, or %s is not a valid value for the configuration\n", group.c_str(), field.c_str(), value.c_str());
+        }
+
         break;
     }
     case 'i': {


### PR DESCRIPTION
Adds the arguments '--set-config' and '--get-config' for the main felix executable, for more easily retrieving and modifying persistent configuration.