### PR TITLE
Added source origin for config

### DIFF
--- a/src/felix86/common/config.cpp
+++ b/src/felix86/common/config.cpp
@@ -442,8 +442,10 @@ Config Config::load(const std::filesystem::path& path, bool ignore_envs) {
         const char* env = getenv(#env_name);                                                                                                         \
         if (env && !ignore_envs) {                                                                                                                   \
             loaded = setFromString<type>(config, config.name, env);                                                                                  \
+            if (loaded) config.src.name = ConfigSource::Env;                                                                                         \
         } else if (!no_config_path) {                                                                                                                \
             loaded = loadFromToml<type>(result, #group, #name, config.name);                                                                         \
+            if (loaded) config.src.name = ConfigSource::File;                                                                                        \
         }                                                                                                                                            \
     }
 #include "config.inc"
@@ -575,6 +577,39 @@ std::optional<std::string> Config::getConfigString(const char* group, const char
 #undef X
     return std::optional<std::string>{};
 }
+
+std::optional<ConfigSource> Config::getConfigSource(const char* group, const char* field) {
+    std::string group_lower = lowercase(group);
+    std::string field_lower = lowercase(field);
+    // cmp_group and cmp_name are marked 'static' to avoid initializing more than once (first call of function). This is thread safe.
+#define X(group_, type_, name_, ...)                                                                                                                 \
+    {                                                                                                                                                \
+        static const std::string cmp_group = lowercase(#group_);                                                                                     \
+        static const std::string cmp_name = lowercase(#name_);                                                                                       \
+        if (group_lower == cmp_group && field_lower == cmp_name) {                                                                                   \
+            return std::optional{this->src.name_};                                                                                                   \
+        }                                                                                                                                            \
+    }
+#include "config.inc"
+#undef X
+    return std::optional<ConfigSource>{};
+}
+
+std::optional<std::string> Config::getConfigSourceString(const char* group, const char* field) {
+    std::optional<ConfigSource> src = getConfigSource(group, field);
+    if (src.has_value()) {
+        const char* s = "";
+        switch (src.value()) {
+            case ConfigSource::Default: s = "default"; break;
+            case ConfigSource::Env: s = "env"; break;
+            case ConfigSource::File: s = "file"; break;
+        }
+        return std::optional<std::string>(s);
+    } else {
+        return std::optional<std::string>();
+    }
+}
+
 
 bool Config::setConfigString(const char* group, const char* field, const char* value) {
     std::string group_lower = lowercase(group);

--- a/src/felix86/common/config.hpp
+++ b/src/felix86/common/config.hpp
@@ -9,6 +9,13 @@
 #include <optional>
 #include "felix86/common/types.hpp"
 
+/// Represents where the configuration was sourced from.
+enum class ConfigSource {
+    File,
+    Env,
+    Default,
+};
+
 struct Config {
 #define X(group, type, name, value, ...) type name = value;
 #include "config.inc"
@@ -26,6 +33,8 @@ struct Config {
     }
 
     std::optional<std::string> getConfigString(const char* group, const char* field);
+    std::optional<ConfigSource> getConfigSource(const char* group, const char* field);
+    std::optional<std::string> getConfigSourceString(const char* group, const char* field);
     /// Returns 'true' if a config value was updated, otherwise return `false`.
     bool setConfigString(const char* group, const char* field, const char* value);
 
@@ -42,6 +51,12 @@ private:
     std::filesystem::path config_path;
 
     friend void addToEnvironment(Config& config, const char* env_name, const char* env);
+
+    struct {
+    #define X(group, type, name, value, ...) ConfigSource name = ConfigSource::Default;
+    #include "config.inc"
+    #undef X
+    } src;
 };
 
 extern Config g_config;

--- a/src/felix86/main.cpp
+++ b/src/felix86/main.cpp
@@ -1,6 +1,7 @@
 #include <cstddef>
 #include <cstdio>
 #include <fstream>
+#include <optional>
 #include <argp.h>
 #include <dirent.h>
 #include <fcntl.h>
@@ -478,7 +479,10 @@ static error_t parse_opt(int key, char* arg, struct argp_state* state) {
         current_group = #group;                                                                                                                      \
         printf("\n[%s]\n", current_group.c_str());                                                                                                   \
     }                                                                                                                                                \
-    fmt::print("{} {} = {} (default: {}) -- Environment variable: {}\n", #type, #name, g_config.name, #def, #env);
+    fmt::print(                                                                                                                                      \
+        "{} {} = {} (default: {}, src: {}) -- Environment variable: {}\n",                                                                           \
+        #type, #name, g_config.name, #def, g_config.getConfigSourceString(#group, #name).value_or(""), #env                                          \
+    );
 #include "felix86/common/config.inc"
 #undef X
         exit(0);


### PR DESCRIPTION
the '-c' or `--configs` flag previously did not print out the origin of where a configuration was sourced. This minor change will include a small string describing the origin of the configuration (environment, file or default).