### PR TITLE
Recompiler: Make compile return correct address

### DIFF
--- a/src/felix86/common/utility.cpp
+++ b/src/felix86/common/utility.cpp
@@ -1238,7 +1238,7 @@ void felix86_set_segment(ThreadState* state, u64 value, int segment) {
         state->ctx.cs = value;
         state->ctx.csbase = base;
         u8 new_cs = state->ctx.cs;
-        if (new_cs != 0x33 && new_cs != 0x22) {
+        if (new_cs != 0x33 && new_cs != 0x23) {
             WARN("Invalid cs %x during %lx", state->ctx.cs, state->ctx.rip);
         }
 

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -522,7 +522,7 @@ u64 Recompiler::compile(ThreadState* state, u64 rip) {
         g_process_globals.perf->addToFile(block_meta.host_address, size, "guest " + symbol.filename().string());
     }
 
-    return start;
+    return block_meta.host_address;
 }
 
 void Recompiler::insertSafepoint() {


### PR DESCRIPTION
Since we added padding in compileSequence we should be returning host_address instead of start