### PR TITLE
Linux: Save/restore CS on signal handler correctly

### DIFF
--- a/src/felix86/common/utility.cpp
+++ b/src/felix86/common/utility.cpp
@@ -1243,7 +1243,7 @@ void felix86_set_segment(ThreadState* state, u64 value, int segment) {
         }
 
         if (old_cs != new_cs) {
-            WARN("Mode32 switched during %lx", state->ctx.rip);
+            VERBOSE("Mode32 switched during %lx", state->ctx.rip);
             // Technically there could be a code segment that runs on both 32-bit and 64-bit
             // and we'd need to clear the code cache on switch or have separate 32-bit and 64-bit
             // code caches to emulate it correctly. There's no known programs that do this

--- a/src/felix86/hle/signals.cpp
+++ b/src/felix86/hle/signals.cpp
@@ -534,6 +534,8 @@ static void setupFrame_x64(RegisteredSignal& signal, int sig, ThreadState* state
     frame->uc.uc_mcontext.gregs[REG_R13] = state->GetGpr(X86_REF_R13);
     frame->uc.uc_mcontext.gregs[REG_R14] = state->GetGpr(X86_REF_R14);
     frame->uc.uc_mcontext.gregs[REG_R15] = state->GetGpr(X86_REF_R15);
+    u64 csgsfs = (u64)state->ctx.cs | ((u64)state->ctx.gs << 16) | ((u64)state->ctx.fs << 32) | ((u64)state->ctx.ss << 48);
+    frame->uc.uc_mcontext.gregs[REG_CSGSFS] = csgsfs;
     frame->uc.uc_mcontext.gregs[REG_RIP] = state->GetRip();
     frame->uc.uc_mcontext.gregs[REG_EFL] = state->GetFlags();
     frame->uc.uc_mcontext.gregs[REG_TRAPNO] = get_reg_trapno(get_pc(host_context), sig, guest_info, host_context);
@@ -808,15 +810,16 @@ static void setupFrame_x86(RegisteredSignal& signal, int sig, ThreadState* state
 
 static void setupFrame(RegisteredSignal& signal, int sig, ThreadState* state, siginfo_t* guest_info, ucontext_t* host_context) {
     VERBOSE("Preparing frame for sig %d with si_code=%d", sig, guest_info->si_code);
-    if (!state->ctx.Mode32()) {
-        return setupFrame_x64(signal, sig, state, guest_info, host_context);
+    if (!signal.mode32) {
+        setupFrame_x64(signal, sig, state, guest_info, host_context);
     } else {
         if (signal.flags & SA_SIGINFO) {
-            return setupFrame_x86_rt(signal, sig, state, guest_info, host_context);
+            setupFrame_x86_rt(signal, sig, state, guest_info, host_context);
         } else {
-            return setupFrame_x86(signal, sig, state, guest_info, host_context);
+            setupFrame_x86(signal, sig, state, guest_info, host_context);
         }
     }
+    state->ctx.cs = signal.mode32 ? 0x23 : 0x33;
 }
 
 static void restore_sigcontext_32(ThreadState* state, x86_sigcontext_32* ctx) {
@@ -914,6 +917,10 @@ void Signals::sigreturn(ThreadState* state, bool rt) {
         state->SetGpr(X86_REF_R14, frame->uc.uc_mcontext.gregs[REG_R14]);
         state->SetGpr(X86_REF_R15, frame->uc.uc_mcontext.gregs[REG_R15]);
         state->SetRip(frame->uc.uc_mcontext.gregs[REG_RIP]);
+
+        u64 csgsfs = frame->uc.uc_mcontext.gregs[REG_CSGSFS];
+        state->ctx.cs = csgsfs & 0xFFFF;
+        state->ctx.ss = (csgsfs >> 48) & 0xFFFF;
 
         SIGLOG("------- 64-bit rt_sigreturn TID: %d returning to RIP=%lx -------", gettid(), state->GetRip());
 
@@ -1645,7 +1652,7 @@ void Signals::initialize() {
 void Signals::registerSignalHandler(ThreadState* state, int sig, u64 handler, u64 mask, int flags, u64 restorer) {
     ASSERT(sig >= 1 && sig <= 64);
 
-    SignalHandlerTable::registerSignal(state->signal_table, sig, handler, mask, flags, restorer);
+    SignalHandlerTable::registerSignal(state, sig, handler, mask, flags, restorer);
 
     // If not SIG_DFL or SIG_IGN, register the host signal handler to capture the signal
     // If SIG_DFL or SIG_IGN, we want to passthrough the handler to the kernel

--- a/src/felix86/hle/signals.hpp
+++ b/src/felix86/hle/signals.hpp
@@ -20,6 +20,7 @@ struct RegisteredSignal {
     u64 mask; // blocked during execution of this handler
     int flags;
     u64 restorer; // for 32-bit apps
+    bool mode32;
 };
 
 struct riscv_sigaction {
@@ -54,7 +55,8 @@ struct SignalHandlerTable {
         return &table->table[sig];
     }
 
-    static void registerSignal(SignalHandlerTable* table, int sig, u64 func, u64 mask, int flags, u64 restorer) {
+    static void registerSignal(ThreadState* state, int sig, u64 func, u64 mask, int flags, u64 restorer) {
+        SignalHandlerTable* table = state->signal_table;
         ASSERT(sig != SIGKILL && sig != SIGSTOP);
         sig -= 1;
         ASSERT(sig >= 0 && sig <= 63);
@@ -62,6 +64,7 @@ struct SignalHandlerTable {
         table->table[sig].mask = mask;
         table->table[sig].func = func;
         table->table[sig].restorer = restorer;
+        table->table[sig].mode32 = state->ctx.Mode32();
     }
 
     RegisteredSignal table[64];
@@ -72,7 +75,7 @@ static_assert(offsetof(RegisteredSignal, func) == 0);
 static_assert(offsetof(RegisteredSignal, mask) == 8);
 static_assert(offsetof(RegisteredSignal, flags) == 16);
 static_assert(offsetof(RegisteredSignal, restorer) == 24);
-static_assert(sizeof(RegisteredSignal) == 32);
+static_assert(sizeof(RegisteredSignal) == 40);
 static_assert(sizeof(SignalHandlerTable) == sizeof(RegisteredSignal) * 64);
 
 struct BlockMetadata;


### PR DESCRIPTION
Also chooses 64-bit frame if the signal handler was installed in 64-bit mode. This happens in wine which installs 64-bit signal handlers then switches to 32-bit mode.