### PR TITLE
Thunks: Make sure executable stack is disabled on older compilers

### DIFF
--- a/src/felix86/hle/guest_libs/libEGL.asm
+++ b/src/felix86/hle/guest_libs/libEGL.asm
@@ -239,3 +239,4 @@ invlpg [rax]
 db "eglSwapInterval", 0
 ret
 
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/felix86/hle/guest_libs/libGL.asm
+++ b/src/felix86/hle/guest_libs/libGL.asm
@@ -9000,3 +9000,5 @@ glWindowPos3svARB:
 invlpg [rax]
 db "glWindowPos3svARB", 0
 ret
+
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/felix86/hle/guest_libs/libGLX.asm
+++ b/src/felix86/hle/guest_libs/libGLX.asm
@@ -390,3 +390,5 @@ __GLXGL_CORE_FUNCTIONS:
 
 section .init_array
     dq __felix86_constructor
+
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/felix86/hle/guest_libs/libluajit-5.1.asm
+++ b/src/felix86/hle/guest_libs/libluajit-5.1.asm
@@ -1010,3 +1010,5 @@ luaopen_base:
 invlpg [rax]
 db "luaopen_base", 0
 ret
+
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/felix86/hle/guest_libs/libvulkan.asm
+++ b/src/felix86/hle/guest_libs/libvulkan.asm
@@ -2284,3 +2284,5 @@ ret
 
 section .init_array
     dq __felix86_constructor
+
+section .note.GNU-stack noalloc noexec nowrite progbits

--- a/src/felix86/hle/guest_libs/libwayland-client.asm
+++ b/src/felix86/hle/guest_libs/libwayland-client.asm
@@ -440,3 +440,5 @@ ret
 
 section .init_array
     dq __felix86_constructor
+
+section .note.GNU-stack noalloc noexec nowrite progbits


### PR DESCRIPTION
Older compilers like the one in the CI would enable exec stack on the thunks by default.