### PR TITLE
Linux: Implement x86_64 getdents syscall on top of getdents64

### DIFF
--- a/src/felix86/hle/guest_types.hpp
+++ b/src/felix86/hle/guest_types.hpp
@@ -16,17 +16,30 @@
 
 using x86_fdset = u32;
 
-struct x86_linux_dirent {
+struct __attribute__((packed)) x86_linux_dirent64 {
     u64 d_ino;
     u64 d_off;
     u16 d_reclen;
     u8 d_type;
-    u8 _pad[5];
     char d_name[];
 };
 
+static_assert(std::is_trivially_copyable_v<x86_linux_dirent64>);
+static_assert(sizeof(x86_linux_dirent64) == 19);
+
+struct __attribute__((packed)) x86_linux_dirent {
+    u64 d_ino;
+    u64 d_off;
+    u16 d_reclen;
+    char d_name[]; // filename (null terminated)
+    /*
+    char pad[];    // padding
+    char d_type;   // file type; offset is (d_reclen - 1)
+    */
+};
+
 static_assert(std::is_trivially_copyable_v<x86_linux_dirent>);
-static_assert(sizeof(x86_linux_dirent) == 24);
+static_assert(sizeof(x86_linux_dirent) == 18);
 
 struct x86_sigset_argpack {
     u32 data; // pointer to u64

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -1988,6 +1988,27 @@ void felix86_syscall(felix86_frame* frame) {
             result = Filesystem::Rmdir((char*)arg1);
             break;
         }
+        case felix86_x86_64_getdents: {
+            u32 fd = arg1;
+            u64 dirp = arg2;
+            u32 count = arg3;
+
+            result = SYSCALL(getdents64, fd, dirp, count);
+            if (result > 0) {
+                size_t bytes = result;
+                for (size_t i = 0; i < bytes;) {
+                    u8* record = (u8*)(dirp + i);
+                    x86_linux_dirent64* src = (x86_linux_dirent64*)record;
+                    x86_linux_dirent* dst = (x86_linux_dirent*)record;
+                    u16 reclen = src->d_reclen;
+                    u8 type = src->d_type;
+                    memmove(dst->d_name, src->d_name, reclen - sizeof(x86_linux_dirent64));
+                    record[reclen - 1] = type;
+                    i += reclen;
+                }
+            }
+            break;
+        }
         case felix86_x86_64_fork: {
             CloneArgs args = {};
             u64 guest_flags = SIGCHLD;
@@ -2868,7 +2889,7 @@ void felix86_syscall32(felix86_frame* frame, u32 rip_next) {
                 size_t bytes = result;
                 size_t num = 0;
                 for (size_t i = 0; i < bytes;) {
-                    x86_linux_dirent* current = (x86_linux_dirent*)(dirp + i);
+                    x86_linux_dirent64* current = (x86_linux_dirent64*)(dirp + i);
                     current->d_off = num++;
                     i += current->d_reclen;
                 }


### PR DESCRIPTION
RISC-V only exposes getdents64