### PR TITLE
Linux: Guest memory tracking

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -264,6 +264,7 @@ if (BUILD_TESTS)
         tests/FEX/x87.cpp
         tests/Binaries/binary_test_loader.cpp
         tests/Unit/mmap.cpp
+        tests/Unit/shmat.cpp
         tests/Unit/paths.cpp
     )
 

--- a/src/felix86/common/config.inc
+++ b/src/felix86/common/config.inc
@@ -65,6 +65,7 @@ X(Debugging, bool, seccomp_always_allow, false, FELIX86_SECCOMP_ALWAYS_ALLOW, "D
 X(Debugging, bool, ptrace_enabled, true, FELIX86_PTRACE_ENABLED, "Enable ptrace(), allowing programs to debug other programs")
 X(Debugging, bool, stats_enabled, false, FELIX86_STATS_ENABLED, "Enable JIT stats")
 X(Debugging, bool, proc_self_auxv, true, FELIX86_PROC_SELF_AUXV, "Enable /proc/self/auxv emulation, breaks host gdb attaching to felix86, disable if you need to attach")
+X(Debugging, bool, guest_memory_tracking_enabled, false, FELIX86_GUEST_MEMORY_TRACKING_ENABLED, "Enable guest memory tracking")
 
 X(Performance, bool, link, true, FELIX86_LINK, "Enable basic block linking, important for performance")
 X(Performance, u64, max_block_size, 300, FELIX86_MAX_BLOCK_SIZE, "Maximum x86 instructions per block")

--- a/src/felix86/common/freelist.cpp
+++ b/src/felix86/common/freelist.cpp
@@ -139,11 +139,34 @@ void Freelist::deallocate(u32 addr, size_t size) {
                 list = new_node;
             }
             placed = true;
+            previous = new_node;
             break;
         }
 
         previous = current;
         current = current->next;
+    }
+
+    // Remove any other overlapping regions.
+    while (current) {
+        // No more region will be overlapping.
+        if (new_end < current->start) {
+            break;
+        }
+
+        if (current->end <= new_end) {
+            Node* to_remove = current;
+            if (previous) {
+                previous->next = current->next;
+                current = previous->next;
+            }
+            delete to_remove;
+        } else if (current->start > new_start) {
+            current->start = new_end;
+            current = current->next;
+        } else {
+            current = current->next;
+        }
     }
 
     if (!placed) {
@@ -152,9 +175,13 @@ void Freelist::deallocate(u32 addr, size_t size) {
         new_node->start = new_start;
         new_node->end = new_end;
         new_node->next = nullptr;
-        ASSERT(previous->next == nullptr);
         ASSERT(current == nullptr);
-        previous->next = new_node;
+        if (previous) {
+            ASSERT(previous->next == nullptr);
+            previous->next = new_node;
+        } else {
+            list = new_node;
+        }
     }
 
     consolidate();

--- a/src/felix86/emulator.cpp
+++ b/src/felix86/emulator.cpp
@@ -20,6 +20,7 @@
 #include "felix86/common/utility.hpp"
 #include "felix86/emulator.hpp"
 #include "felix86/hle/brk.hpp"
+#include "felix86/hle/mmap.hpp"
 #include "felix86/hle/signals.hpp"
 #include "felix86/hle/thread.hpp"
 #include "felix86/hle/thunks.hpp"
@@ -210,7 +211,7 @@ static void setupMainStack(ThreadState* state) {
         void* mem = mmap(nullptr, vdso_object.size(), PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
         ASSERT(mem != MAP_FAILED);
         memcpy(mem, vdso_object.data(), vdso_object.size());
-        mprotect(mem, vdso_object.size(), PROT_READ | PROT_EXEC);
+        g_mapper->protect(mem, vdso_object.size(), PROT_READ | PROT_EXEC);
         auxv_entries.push_back({AT_SYSINFO_EHDR, {(u64)mem}});
     }
 

--- a/src/felix86/hle/abi.cpp
+++ b/src/felix86/hle/abi.cpp
@@ -439,7 +439,7 @@ void* ABIMadness::hostToGuestTrampoline(const char* signature, const void* guest
     u8* const x86_code = state->x86_trampoline_storage;
     u8* curr = x86_code;
     // Our recompiler marks guest code as PROT_READ, we need to undo this as it may have marked previous trampolines
-    g_mapper->protect((u8*)((u64)x86_code & ~0xFFFull), 4096, PROT_READ | PROT_WRITE);
+    ::mprotect((u8*)((u64)x86_code & ~0xFFFull), 4096, PROT_READ | PROT_WRITE);
     // mov rax, u64
     curr[0] = 0x48;
     curr[1] = 0xb8;

--- a/src/felix86/hle/abi.cpp
+++ b/src/felix86/hle/abi.cpp
@@ -1,9 +1,11 @@
 #include <sys/mman.h>
+#include "felix86/common/global.hpp"
 #include "felix86/common/log.hpp"
 #include "felix86/common/state.hpp"
 #include "felix86/common/types.hpp"
 #include "felix86/common/utility.hpp"
 #include "felix86/hle/abi.hpp"
+#include "felix86/hle/mmap.hpp"
 #include "felix86/hle/signals.hpp"
 #include "felix86/v2/recompiler.hpp"
 
@@ -437,7 +439,7 @@ void* ABIMadness::hostToGuestTrampoline(const char* signature, const void* guest
     u8* const x86_code = state->x86_trampoline_storage;
     u8* curr = x86_code;
     // Our recompiler marks guest code as PROT_READ, we need to undo this as it may have marked previous trampolines
-    mprotect((u8*)((u64)x86_code & ~0xFFFull), 4096, PROT_READ | PROT_WRITE);
+    g_mapper->protect((u8*)((u64)x86_code & ~0xFFFull), 4096, PROT_READ | PROT_WRITE);
     // mov rax, u64
     curr[0] = 0x48;
     curr[1] = 0xb8;

--- a/src/felix86/hle/ipc32.cpp
+++ b/src/felix86/hle/ipc32.cpp
@@ -181,12 +181,15 @@ int ipc32(u32 call, u32 first, u64 second, u64 third, void* ptr, u64 fifth) {
         int shmid = first;
         void* address = ptr;
         int flags = second;
-        u32* result_address = (u32*)third;
-        return g_mapper->shmat32(shmid, address, flags, result_address);
+        u32* result_address_u32 = (u32*)third;
+        u64 result_address = 0;
+        auto ret = g_mapper->shmat(true, shmid, address, flags, &result_address);
+        *result_address_u32 = (u32)result_address;
+        return ret;
     }
     case felix86_SHMDT: {
         void* address = ptr;
-        return g_mapper->shmdt32(address);
+        return g_mapper->shmdt(true, address);
     }
     case felix86_MSGGET: {
         return ::syscall(SYS_msgget, first, second);

--- a/src/felix86/hle/ipc32.cpp
+++ b/src/felix86/hle/ipc32.cpp
@@ -184,7 +184,9 @@ int ipc32(u32 call, u32 first, u64 second, u64 third, void* ptr, u64 fifth) {
         u32* result_address_u32 = (u32*)third;
         u64 result_address = 0;
         auto ret = g_mapper->shmat(true, shmid, address, flags, &result_address);
-        *result_address_u32 = (u32)result_address;
+        if (ret == 0) {
+            *result_address_u32 = (u32)result_address;
+        }
         return ret;
     }
     case felix86_SHMDT: {

--- a/src/felix86/hle/mmap.cpp
+++ b/src/felix86/hle/mmap.cpp
@@ -17,7 +17,7 @@ void* Mapper::map32(void* addr, u64 size, int prot, int flags, int fd, u64 offse
 
     if ((flags & MAP_FIXED) || (flags & MAP_FIXED_NOREPLACE)) {
         // Fixed mapping, make sure it's inside 32-bit address space
-        ASSERT_MSG((u64)addr < UINT32_MAX, "felix86_mmap tried to FIXED allocate outside of 32-bit address space");
+        ASSERT_MSG((u64)addr <= UINT32_MAX, "felix86_mmap tried to FIXED allocate outside of 32-bit address space");
 
         // MAP_FIXED says allocate it at that address, and we don't care if it overlaps with other stuff
         // MAP_FIXED_NOREPLACE will fail if other stuff is at that address
@@ -70,7 +70,7 @@ void* Mapper::map32(void* addr, u64 size, int prot, int flags, int fd, u64 offse
 
 int Mapper::unmap32(void* addr, u64 size) {
     size = (size + 0xFFFull) & ~0xFFFull;
-    ASSERT((u64)addr < UINT32_MAX);
+    ASSERT((u64)addr <= UINT32_MAX);
     int result = munmap(addr, size);
     if (result != -1) {
         // unmap it from our freelist as well
@@ -97,7 +97,7 @@ void* Mapper::remap32(void* old_address, u64 old_size, u64 new_size, int flags, 
 
     if ((flags & MREMAP_FIXED) || !(flags & MREMAP_MAYMOVE)) {
         // Give it to the kernel first
-        ASSERT((u64)new_address < UINT32_MAX);
+        ASSERT((u64)new_address <= UINT32_MAX);
         void* result = ::mremap(old_address, old_size, new_size, flags, new_address);
         if (result == MAP_FAILED) {
             return MAP_FAILED;
@@ -287,22 +287,22 @@ int Mapper::shmdt(bool mode32, void* address) {
 
     auto it = page_to_shmid.find((u64)address & ~0xFFFull);
     if (it == page_to_shmid.end()) {
-        WARN("Could not find page during shmdt: %lx", (u64)address & ~0xFFFull);
-        return -EINVAL;
+        IMPORTANT("Could not find page during shmdt: %lx", (u64)address & ~0xFFFull);
+        return ::shmdt(address);
     }
 
     int shmid = it->second;
+    size_t size = 0;
+    bool size_known = false;
     struct shmid_ds ds;
     if (shmctl(shmid, IPC_STAT, &ds) == 0) {
-        size_t size = ds.shm_segsz;
+        size = ds.shm_segsz;
         if (size & 0xFFF) {
             size_t new_size = (size + 0xFFFull) & ~0xFFFull;
             WARN("shmctl returned size not aligned to a page: %lx, setting to new size: %lx", size, new_size);
             size = new_size;
         }
-        remove_tracked_region((u64)address, size);
-        if (mode32)
-            freelist.deallocate((u64)address, size);
+        size_known = true;
     } else {
         WARN("shmctl returned error %d", -errno);
     }
@@ -310,6 +310,11 @@ int Mapper::shmdt(bool mode32, void* address) {
     int result = ::shmdt(address);
 
     if (result == 0) {
+        if (size_known) {
+            remove_tracked_region((u64)address, size);
+            if (mode32)
+                freelist.deallocate((u64)address, size);
+        }
         page_to_shmid.erase(it);
     }
 

--- a/src/felix86/hle/mmap.cpp
+++ b/src/felix86/hle/mmap.cpp
@@ -12,6 +12,7 @@
 void* Mapper::map32(void* addr, u64 size, int prot, int flags, int fd, u64 offset) {
     size = (size + 0xFFFull) & ~0xFFFull;
     auto guard = freelist.lock();
+
     if ((flags & MAP_FIXED) || (flags & MAP_FIXED_NOREPLACE)) {
         // Fixed mapping, make sure it's inside 32-bit address space
         ASSERT_MSG((u64)addr < UINT32_MAX, "felix86_mmap tried to FIXED allocate outside of 32-bit address space");
@@ -42,7 +43,7 @@ void* Mapper::map32(void* addr, u64 size, int prot, int flags, int fd, u64 offse
 
         void* mapping = freelist.allocate((u64)result, size);
         ASSERT_MSG(mapping == result, "Failed with mmap(%lx, %lx, %x, %x, %d, %lx)", addr, size, prot, flags, fd, offset);
-        add_tracked_region((u64)result, size, flags);
+        add_tracked_region((u64)result, size, flags, prot);
         return result;
     } else {
         void* address = freelist.allocate(0, size);
@@ -53,13 +54,13 @@ void* Mapper::map32(void* addr, u64 size, int prot, int flags, int fd, u64 offse
 
         void* result = mmap(address, size, prot, flags | MAP_FIXED_NOREPLACE, fd, offset);
         if (result == MAP_FAILED) {
-            // TODO: should this free memory back from freelist again?
+            freelist.deallocate((u64)address, size);
             i64 error = -errno;
             WARN("Even though our freelist says we have memory at %lx-%lx, mmap failed with: %ld", (u64)address, (u64)address + size, error);
             return (void*)error;
         }
 
-        add_tracked_region((u64)result, size, flags);
+        add_tracked_region((u64)result, size, flags, prot);
         ASSERT(result == address);
         return address;
     }
@@ -92,6 +93,16 @@ void* Mapper::remap32(void* old_address, u64 old_size, u64 new_size, int flags, 
 
     auto guard = freelist.lock();
 
+    int prot = 0;
+    bool found = false;
+    for (auto& region : allocated_regions) {
+        if (region.start <= (u64)old_address && (u64)old_address < region.end) {
+            prot = region.prot;
+            found = true;
+            break;
+        }
+    }
+
     if ((flags & MREMAP_FIXED) || !(flags & MREMAP_MAYMOVE)) {
         // Give it to the kernel first
         ASSERT((u64)new_address < UINT32_MAX);
@@ -101,17 +112,20 @@ void* Mapper::remap32(void* old_address, u64 old_size, u64 new_size, int flags, 
         }
 
         ASSERT(result == new_address);
+        ASSERT(found);
 
         // Since the mapping succeeded we also need to update our freelist allocator
         if (!(flags & MREMAP_DONTUNMAP)) {
             freelist.deallocate((u64)old_address, old_size);
+            remove_tracked_region((u64)old_address, old_size);
+        } else {
+            remove_tracked_region((u64)result, new_size);
         }
 
         void* mapping = freelist.allocate((u64)result, new_size);
         ASSERT(mapping == result);
 
-        remove_tracked_region((u64)old_address, old_size);
-        add_tracked_region((u64)result, new_size, flags);
+        add_tracked_region((u64)result, new_size, flags, prot);
 
         return result;
     } else {
@@ -136,10 +150,14 @@ void* Mapper::remap32(void* old_address, u64 old_size, u64 new_size, int flags, 
         // After everything goes ok we can unmap the old region
         if (!(flags & MREMAP_DONTUNMAP)) {
             freelist.deallocate((u64)old_address, old_size);
+            remove_tracked_region((u64)old_address, old_size);
+        } else {
+            remove_tracked_region((u64)result, new_size);
         }
 
-        remove_tracked_region((u64)old_address, old_size);
-        add_tracked_region((u64)result, new_size, flags);
+        ASSERT(found);
+
+        add_tracked_region((u64)result, new_size, flags, prot);
 
         ASSERT(result == new_address);
         return result;
@@ -154,7 +172,8 @@ void* Mapper::map(bool mode32, void* addr, u64 size, int prot, int flags, int fd
 
         // On success, add tracked allocation.
         if (result != (void*)-1) {
-            add_tracked_region((u64)result, size, flags);
+            auto guard = freelist.lock();
+            add_tracked_region((u64)result, size, flags, prot);
         }
 
         return result;
@@ -169,6 +188,7 @@ int Mapper::unmap(bool mode32, void* addr, u64 size) {
 
         // On success, remove tracked allocation.
         if (result != -1) {
+            auto guard = freelist.lock();
             remove_tracked_region((u64)addr, size);
         }
 
@@ -191,10 +211,24 @@ void* Mapper::remap(bool mode32, void* old_address, u64 old_size, u64 new_size, 
             // we don't want an allocation in the low 32-bit area
             ASSERT((u64)result > UINT32_MAX);
 
+            // Lock access to 'allocated_regions'.
+            auto guard = freelist.lock();
+
+            int prot = 0;
+            bool found = false;
+            for (auto& region : allocated_regions) {
+                if (region.start <= (u64)old_address && (u64)old_address < region.end) {
+                    prot = region.prot;
+                    found = true;
+                    break;
+                }
+            }
+
             // On success, remap the tracked allocation
             if (result != (void*)-1) {
+                ASSERT(found);
                 remove_tracked_region((u64)old_address, old_size);
-                add_tracked_region((u64)result, new_size, flags);
+                add_tracked_region((u64)result, new_size, flags, prot);
             }
 
             return result;
@@ -202,7 +236,7 @@ void* Mapper::remap(bool mode32, void* old_address, u64 old_size, u64 new_size, 
     }
 }
 
-void Mapper::add_tracked_region(u64 address, u64 len, int flags, bool shmem) {
+void Mapper::add_tracked_region(u64 address, u64 len, int flags, int prot, bool shmem) {
     if (len == 0)
         return;
 
@@ -216,11 +250,11 @@ void Mapper::add_tracked_region(u64 address, u64 len, int flags, bool shmem) {
     // an already existing mapping UNLESS it has the MAP_FIXED flag, in which case the mapped region
     // is removed before a call to this function.
 
-    AllocatedRegion v = AllocatedRegion{address, end, flags, shmem};
+    GuestRegion v = GuestRegion{address, end, flags, prot, shmem};
 
     for (auto it = allocated_regions.begin(); it != allocated_regions.end(); it++) {
         auto& r = *it;
-        bool can_merge = r.flags == flags && r.shmem == shmem;
+        bool can_merge = r.flags == flags && r.prot == prot && r.shmem == shmem;
 
         // Region extends another leading.
         if (can_merge && r.start == end) {
@@ -234,7 +268,7 @@ void Mapper::add_tracked_region(u64 address, u64 len, int flags, bool shmem) {
             // Check if we can continue merging onwards.
             it++;
             for (; it != allocated_regions.end(); it++) {
-                if ((*it).start == r.end && (*it).shmem == shmem && (*it).flags == flags) {
+                if ((*it).start == r.end && (*it).shmem == shmem && (*it).prot == prot && (*it).flags == flags) {
                     r.end = (*it).end;
                     it = allocated_regions.erase(it);
                 } else if ((*it).start < r.end) {
@@ -252,7 +286,7 @@ void Mapper::add_tracked_region(u64 address, u64 len, int flags, bool shmem) {
         else if ((r.start >= address && r.start < end) || (r.end > address && r.end <= end) || (address >= r.start && address < r.end) ||
                  (end > r.start && end <= r.end)) {
             remove_tracked_region(address, len);
-            add_tracked_region(address, len, flags, shmem);
+            add_tracked_region(address, len, flags, prot, shmem);
             return;
         } else if (end <= r.start) {
             allocated_regions.insert(it, v);
@@ -290,11 +324,11 @@ void Mapper::remove_tracked_region(u64 address, u64 len) {
             it = allocated_regions.erase(it);
 
             if (address - r.start > 0) {
-                it = allocated_regions.insert(it, AllocatedRegion{r.start, address, r.flags, r.shmem});
+                it = allocated_regions.insert(it, GuestRegion{r.start, address, r.flags, r.prot, r.shmem});
                 it++;
             }
             if (r.end - end > 0) {
-                it = allocated_regions.insert(it, AllocatedRegion{end, r.end, r.flags, r.shmem});
+                it = allocated_regions.insert(it, GuestRegion{end, r.end, r.flags, r.prot, r.shmem});
                 it++;
             }
             continue;
@@ -319,13 +353,13 @@ void Mapper::remove_tracked_region(u64 address, u64 len) {
     }
 }
 
-void Mapper::reserve(u64 address, u64 len, int flags) {
+void Mapper::reserve(u64 address, u64 len, int flags, int prot) {
     // Ensure no race conditions.
     auto guard = freelist.lock();
 
     freelist.deallocate(address, len);
     remove_tracked_region(address, len);
-    add_tracked_region(address, len, flags, false);
+    add_tracked_region(address, len, flags, prot, false);
 }
 
 uint64_t Mapper::total_mapped_memory() {
@@ -356,11 +390,11 @@ bool Mapper::is_guest_address(void* address) {
     return false;
 }
 
-std::vector<AllocatedRegion> Mapper::get_allocated_regions() {
+std::vector<GuestRegion> Mapper::get_guest_regions() {
     // Ensure no race conditions.
     auto guard = freelist.lock();
 
-    std::vector<AllocatedRegion> regions;
+    std::vector<GuestRegion> regions;
     for (auto region : allocated_regions) {
         regions.push_back(region);
     }
@@ -372,7 +406,7 @@ std::vector<std::pair<u32, u32>> Mapper::getRegions() {
     return freelist.getRegions();
 }
 
-int Mapper::shmat32(int shmid, void* address, int flags, u32* result_address) {
+int Mapper::shmat(bool mode32, int shmid, void* address, int flags, u64* result_address) {
     auto guard = freelist.lock();
     struct shmid_ds ds;
     int result = shmctl(shmid, IPC_STAT, &ds);
@@ -393,7 +427,7 @@ int Mapper::shmat32(int shmid, void* address, int flags, u32* result_address) {
 
     void *our_mem, *shm_mem;
 
-    if (address == nullptr) {
+    if (mode32 && address == nullptr) {
         // Use our freelist allocator to find a region in memory, but don't mmap it
         our_mem = freelist.allocate(0, size);
         if ((i64)our_mem < 0) {
@@ -404,43 +438,45 @@ int Mapper::shmat32(int shmid, void* address, int flags, u32* result_address) {
         // Now we need to place the shmat exactly at that address. If that fails then we return an error
         // We can't let the shmat decide for itself what address it wants to go in, because it will
         // almost always choose a 64-bit address which can't be used in 32-bit mode
-        shm_mem = shmat(shmid, our_mem, flags);
+        shm_mem = ::shmat(shmid, our_mem, flags);
     } else {
-        ASSERT_MSG((u64)address + size <= UINT32_MAX, "shmat segment would end up outside of address space");
+        ASSERT_MSG(!mode32 || (u64)address + size <= UINT32_MAX, "shmat segment would end up outside of address space");
 
         // Since an address is provided by the application, we are going to assume it's
         // inside 32-bit address space and just check after the shmat
         shm_mem = ::shmat(shmid, address, flags);
         if ((i64)shm_mem != -1) {
             u64 top_bits = (u64)shm_mem >> 32;
-            ASSERT_MSG(top_bits == 0 || top_bits == 0xFFFF'FFFF, "shmat returned address in 64-bit address space?");
+            ASSERT_MSG(!mode32 || top_bits == 0 || top_bits == 0xFFFF'FFFF, "shmat returned address in 64-bit address space?");
 
             // Now remove it from the freelist to avoid overlaps
-            our_mem = freelist.allocate((u64)shm_mem, size);
-            if ((i64)our_mem < 0) {
-                ERROR("shmat succeeded, but freelistAllocate failed for address: %lx", address);
-                return (i64)our_mem;
+            if (mode32) {
+                our_mem = freelist.allocate((u64)shm_mem, size);
+                if ((i64)our_mem < 0) {
+                    ERROR("shmat succeeded, but freelistAllocate failed for address: %lx", address);
+                    return (i64)our_mem;
+                }
             }
         } else {
             return (i64)-1ull;
         }
     }
 
-    if (shm_mem != our_mem) {
+    if (mode32 && shm_mem != our_mem) {
         ERROR("While our freelistAllocate returned %lx, shmat failed to place the segment there and returned %lx", our_mem, shm_mem);
         return (i64)-errno;
     }
 
     u64 top_bits = (u64)shm_mem >> 32;
-    ASSERT_MSG(top_bits == 0 || top_bits == 0xFFFF'FFFF, "shmat returned address in 64-bit address space?");
-    *result_address = (u32)(u64)shm_mem;
+    ASSERT_MSG(!mode32 || top_bits == 0 || top_bits == 0xFFFF'FFFF, "shmat returned address in 64-bit address space?");
+    *result_address = (u64)shm_mem;
     page_to_shmid[(u32)(u64)shm_mem & ~0xFFFull] = shmid;
     add_tracked_region((u64)shm_mem, size, flags, true);
 
     return 0;
 }
 
-int Mapper::shmdt32(void* address) {
+int Mapper::shmdt(bool mode32, void* address) {
     auto it = page_to_shmid.find((u32)(u64)address & ~0xFFFull);
     if (it == page_to_shmid.end()) {
         WARN("Could not find page during shmdt: %lx", (u64)address & ~0xFFFull);
@@ -457,7 +493,8 @@ int Mapper::shmdt32(void* address) {
             size = new_size;
         }
         remove_tracked_region((u64)address, size);
-        freelist.deallocate((u64)address, size);
+        if (mode32)
+            freelist.deallocate((u64)address, size);
     } else {
         WARN("shmctl returned error %d", -errno);
     }

--- a/src/felix86/hle/mmap.cpp
+++ b/src/felix86/hle/mmap.cpp
@@ -49,7 +49,7 @@ void* Mapper::map32(void* addr, u64 size, int prot, int flags, int fd, u64 offse
             // and dirty solution of unallocating it in freelist so we can reallocate it
             ASSERT((u64)result < UINT32_MAX);
             freelist.deallocate((u64)result, size);
-            remove_tracked_region((u64)result, size);
+            remove_tracked_region((u64)result, size, false);
         }
 
         void* mapping = freelist.allocate((u64)result, size);
@@ -86,7 +86,7 @@ int Mapper::unmap32(void* addr, u64 size) {
         auto guard = freelist.lock();
         freelist.deallocate((u64)addr, size);
         // also unmap it from the allocation tracker.
-        remove_tracked_region((u64)addr, size);
+        remove_tracked_region((u64)addr, size, false);
 
         return result;
     } else {
@@ -197,7 +197,7 @@ int Mapper::unmap(bool mode32, void* addr, u64 size) {
 
         // On success, remove tracked allocation.
         if (result != -1) {
-            remove_tracked_region((u64)addr, size);
+            remove_tracked_region((u64)addr, size, false);
             if ((u64)addr <= (u64)UINT32_MAX) {
                 u64 to_free_s = std::max((u64)addr, mmap_min_addr());
                 u64 to_free_e = std::min((u64)addr + size, (u64)UINT32_MAX + 1);
@@ -299,7 +299,9 @@ int Mapper::shmat(bool mode32, int shmid, void* address, int flags, u64* result_
         // almost always choose a 64-bit address which can't be used in 32-bit mode
         shm_mem = ::shmat(shmid, our_mem, flags);
     } else {
-        ASSERT_MSG(!mode32 || (u64)address + size <= UINT32_MAX, "shmat segment would end up outside of address space");
+        if (mode32 && (u64)address + size > (u64)UINT32_MAX + 1) {
+            return (i64)-1;
+        }
 
         // Since an address is provided by the application, we are going to assume it's
         // inside 32-bit address space and just check after the shmat
@@ -322,7 +324,9 @@ int Mapper::shmat(bool mode32, int shmid, void* address, int flags, u64* result_
     }
 
     if (mode32 && shm_mem != our_mem) {
-        ERROR("While our freelistAllocate returned %lx, shmat failed to place the segment there and returned %lx", our_mem, shm_mem);
+        if ((u64)our_mem > 0) {
+            freelist.deallocate((u64)our_mem, size);
+        }
         return (i64)-errno;
     }
 
@@ -369,9 +373,33 @@ int Mapper::shmdt(bool mode32, void* address) {
 
     if (result == 0) {
         if (size_known) {
-            remove_tracked_region((u64)address, size);
-            if (mode32)
-                freelist.deallocate((u64)address, size);
+            if ((u64)address <= UINT32_MAX) {
+                // We need to check what guest regions are actually allocated by shmat
+                // and add those regions to the freelist explicitly.
+                for (auto region : allocated_regions) {
+                    // Region is not allocated by shmat.
+                    if (region.shmid == -1) {
+                        continue;
+                    }
+
+                    u64 start = (u64)address;
+                    u64 end = start + size;
+
+                    if (region.start >= end) {
+                        break;
+                    }
+
+                    if (region.end < start) {
+                        continue;
+                    }
+
+                    if (region.start >= start) {
+                        u64 size = end - region.start;
+                        freelist.deallocate((u64)region.start, size);
+                    }
+                }
+            }
+            remove_tracked_region((u64)address, size, true);
         }
         page_to_shmid.erase(it);
     }
@@ -402,7 +430,7 @@ void Mapper::add_tracked_region(u64 address, u64 len, int prot, dev_t dev, ino_t
 
     GuestRegion v = GuestRegion{address, end, prot, dev, ino, offset, shmid, shmem, anon};
 
-    remove_tracked_region(address, len);
+    remove_tracked_region(address, len, false);
     for (auto it = allocated_regions.begin(); it != allocated_regions.end(); it++) {
         auto& r = *it;
 
@@ -481,15 +509,15 @@ void Mapper::move_tracked_region(u64 old_address, u64 old_len, u64 new_address, 
     ASSERT(!is_increase || to_add.size() <= 1);
 
     if (remove_src)
-        remove_tracked_region(old_address, old_len);
+        remove_tracked_region(old_address, old_len, false);
 
-    remove_tracked_region(new_address, new_len);
+    remove_tracked_region(new_address, new_len, false);
     for (auto add : std::move(to_add)) {
         add_tracked_region(add.start, add.end - add.start, add.prot, add.dev, add.ino, add.offset, add.shmem, add.shmid, add.anonymous);
     }
 }
 
-void Mapper::remove_tracked_region(u64 address, u64 len) {
+void Mapper::remove_tracked_region(u64 address, u64 len, bool only_shmat) {
     if (len == 0)
         return;
 
@@ -499,6 +527,24 @@ void Mapper::remove_tracked_region(u64 address, u64 len) {
 
     for (auto it = allocated_regions.begin(); it != allocated_regions.end();) {
         auto& r = *it;
+
+        // If shmid is -1, the memory was not allocated by a call to shmat.
+        if (r.shmid == -1 && only_shmat) {
+            it++;
+            continue;
+        }
+
+        // When removing only shmat, base address must align and entire regions must be removed.
+        if (only_shmat) {
+            if (r.start == address) {
+                allocated_regions.erase(it);
+                return;
+            }
+
+            it++;
+            continue;
+        }
+
         // Because the linked list is ordered, we know if the start address is greater than end,
         // then there is no more regions to remove with this unmap.
         if (end <= r.start || address == end) {

--- a/src/felix86/hle/mmap.cpp
+++ b/src/felix86/hle/mmap.cpp
@@ -150,18 +150,14 @@ void* Mapper::map(bool mode32, void* addr, u64 size, int prot, int flags, int fd
     if (mode32) {
         return map32(addr, size, prot, flags, fd, offset);
     } else {
-        if ((flags & (MAP_FIXED | MAP_FIXED_NOREPLACE)) && (u64)addr < UINT32_MAX) {
-            return map32(addr, size, prot, flags, fd, offset);
-        } else {
-            void* result = mmap(addr, size, prot, flags, fd, offset);
+        void* result = mmap(addr, size, prot, flags, fd, offset);
 
-            // On success, add tracked allocation.
-            if (result != (void*)-1) {
-                add_tracked_region((u64)result, size, flags);
-            }
-
-            return result;
+        // On success, add tracked allocation.
+        if (result != (void*)-1) {
+            add_tracked_region((u64)result, size, flags);
         }
+
+        return result;
     }
 }
 
@@ -169,18 +165,14 @@ int Mapper::unmap(bool mode32, void* addr, u64 size) {
     if (mode32) {
         return unmap32(addr, size);
     } else {
-        if ((u64)addr < UINT32_MAX) {
-            return unmap32(addr, size);
-        } else {
-            int result = munmap(addr, size);
+        int result = munmap(addr, size);
 
-            // On success, remove tracked allocation.
-            if (result != -1) {
-                remove_tracked_region((u64)addr, size);
-            }
-
-            return result;
+        // On success, remove tracked allocation.
+        if (result != -1) {
+            remove_tracked_region((u64)addr, size);
         }
+
+        return result;
     }
 }
 
@@ -201,7 +193,7 @@ void* Mapper::remap(bool mode32, void* old_address, u64 old_size, u64 new_size, 
 
             // On success, remap the tracked allocation
             if (result != (void*)-1) {
-                remove_tracked_region((u64)old_address, new_size);
+                remove_tracked_region((u64)old_address, old_size);
                 add_tracked_region((u64)result, new_size, flags);
             }
 

--- a/src/felix86/hle/mmap.cpp
+++ b/src/felix86/hle/mmap.cpp
@@ -233,6 +233,7 @@ void* Mapper::remap(bool mode32, void* old_address, u64 old_size, u64 new_size, 
             if ((u64)result <= (u64)UINT32_MAX) {
                 u64 to_alloc_s = (u64)result;
                 u64 to_alloc_e = std::min(to_alloc_s + new_size, (u64)UINT32_MAX + 1);
+                freelist.deallocate(to_alloc_s, to_alloc_e - to_alloc_s);
                 freelist.allocate(to_alloc_s, to_alloc_e - to_alloc_s);
             }
             move_tracked_region((u64)old_address, old_size, (u64)result, new_size, !(flags & MREMAP_DONTUNMAP));

--- a/src/felix86/hle/mmap.cpp
+++ b/src/felix86/hle/mmap.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <cstdint>
 #include <cstdio>
 #include <iterator>
@@ -51,7 +52,7 @@ void* Mapper::map32(void* addr, u64 size, int prot, int flags, int fd, u64 offse
 
         void* mapping = freelist.allocate((u64)result, size);
         ASSERT_MSG(mapping == result, "Failed with mmap(%lx, %lx, %x, %x, %d, %lx)", addr, size, prot, flags, fd, offset);
-        add_tracked_region((u64)result, size, prot, stat.st_dev, stat.st_ino, offset, (flags & MAP_SHARED) != 0);
+        add_tracked_region((u64)result, size, prot, stat.st_dev, stat.st_ino, offset, (flags & MAP_SHARED) != 0, -1);
         return result;
     } else {
         void* address = freelist.allocate(0, size);
@@ -68,7 +69,7 @@ void* Mapper::map32(void* addr, u64 size, int prot, int flags, int fd, u64 offse
             return (void*)error;
         }
 
-        add_tracked_region((u64)result, size, prot, stat.st_dev, stat.st_ino, offset, (flags & MAP_SHARED) != 0);
+        add_tracked_region((u64)result, size, prot, stat.st_dev, stat.st_ino, offset, (flags & MAP_SHARED) != 0, -1);
         ASSERT(result == address);
         return address;
     }
@@ -102,6 +103,7 @@ void* Mapper::remap32(void* old_address, u64 old_size, u64 new_size, int flags, 
     auto guard = freelist.lock();
 
     if ((flags & MREMAP_FIXED) || !(flags & MREMAP_MAYMOVE)) {
+
         // Give it to the kernel first
         ASSERT((u64)new_address <= UINT32_MAX);
         void* result = ::mremap(old_address, old_size, new_size, flags, new_address);
@@ -109,17 +111,16 @@ void* Mapper::remap32(void* old_address, u64 old_size, u64 new_size, int flags, 
             return MAP_FAILED;
         }
 
-        ASSERT(result == new_address);
-
         // Since the mapping succeeded we also need to update our freelist allocator
         if (!(flags & MREMAP_DONTUNMAP)) {
             freelist.deallocate((u64)old_address, old_size);
         }
 
+        freelist.deallocate((u64)result, new_size);
         void* mapping = freelist.allocate((u64)result, new_size);
-        ASSERT(mapping == result);
-
         move_tracked_region((u64)old_address, old_size, (u64)result, new_size, !(flags & MREMAP_DONTUNMAP));
+        ASSERT(result == new_address);
+        ASSERT(mapping == result);
 
         return result;
     } else {
@@ -136,7 +137,6 @@ void* Mapper::remap32(void* old_address, u64 old_size, u64 new_size, int flags, 
         // Actually perform the remap now, but make it fixed
         void* result = ::mremap(old_address, old_size, new_size, flags | MREMAP_MAYMOVE | MREMAP_FIXED, new_address);
         if (result == MAP_FAILED) {
-            ERROR("Freelist and mremap disagree during mremap32: %ld vs %p", result, new_address);
             freelist.deallocate((u64)new_address, new_size);
             return MAP_FAILED;
         }
@@ -157,18 +157,25 @@ void* Mapper::map(bool mode32, void* addr, u64 size, int prot, int flags, int fd
     if (mode32) {
         return map32(addr, size, prot, flags, fd, offset);
     } else {
+        auto guard = freelist.lock();
+
+        size = (size + 0xFFFull) & ~0xFFFull;
         void* result = mmap(addr, size, prot, flags, fd, offset);
 
         // On success, add tracked allocation.
         if (result != (void*)-1) {
-            auto guard = freelist.lock();
+            if ((u64)addr <= (u64)UINT32_MAX) {
+                u64 to_alloc_s = (u64)addr;
+                u64 to_alloc_e = std::min(to_alloc_s + size, (u64)UINT32_MAX + 1);
+                freelist.allocate(to_alloc_s, to_alloc_e - to_alloc_s);
+            }
 
             struct stat64 stat{0};
             if ((flags & MAP_ANONYMOUS) == 0) {
                 fstat64(fd, &stat);
             }
 
-            add_tracked_region((u64)result, size, prot, stat.st_dev, stat.st_ino, offset, (flags & MAP_SHARED) != 0);
+            add_tracked_region((u64)result, size, prot, stat.st_dev, stat.st_ino, offset, (flags & MAP_SHARED) != 0, -1);
         }
 
         return result;
@@ -179,12 +186,19 @@ int Mapper::unmap(bool mode32, void* addr, u64 size) {
     if (mode32) {
         return unmap32(addr, size);
     } else {
+        auto guard = freelist.lock();
+
+        size = (size + 0xFFFull) & ~0xFFFull;
         int result = munmap(addr, size);
 
         // On success, remove tracked allocation.
         if (result != -1) {
-            auto guard = freelist.lock();
             remove_tracked_region((u64)addr, size);
+            if ((u64)addr <= (u64)UINT32_MAX) {
+                u64 to_free_s = (u64)addr;
+                u64 to_free_e = std::min(to_free_s + size, (u64)UINT32_MAX + 1);
+                freelist.deallocate(to_free_s, to_free_e - to_free_s);
+            }
         }
 
         return result;
@@ -202,21 +216,42 @@ void* Mapper::remap(bool mode32, void* old_address, u64 old_size, u64 new_size, 
             ASSERT(!(flags & MREMAP_FIXED));
             return remap32(old_address, old_size, new_size, flags, old_address);
         } else {
-            void* result = ::mremap(old_address, old_size, new_size, flags, new_address);
-            // we don't want an allocation in the low 32-bit area
-            ASSERT((u64)result > UINT32_MAX);
-
             // Lock access to 'allocated_regions'.
             auto guard = freelist.lock();
 
+            old_size = (old_size + 0xFFFull) & ~0xFFFull;
+            new_size = (new_size + 0xFFFull) & ~0xFFFull;
+
+            void* result = ::mremap(old_address, old_size, new_size, flags, new_address);
+
             // On success, remap the tracked allocation
             if (result != (void*)-1) {
+                if ((u64)old_address <= (u64)UINT32_MAX && !(flags & MREMAP_DONTUNMAP)) {
+                    u64 to_free_s = (u64)old_address;
+                    u64 to_free_e = std::min(to_free_s + old_size, (u64)UINT32_MAX + 1);
+                    freelist.deallocate(to_free_s, to_free_e - to_free_s);
+                }
+                if ((u64)result <= (u64)UINT32_MAX) {
+                    u64 to_alloc_s = (u64)result;
+                    u64 to_alloc_e = std::min(to_alloc_s + new_size, (u64)UINT32_MAX + 1);
+                    freelist.allocate(to_alloc_s, to_alloc_e - to_alloc_s);
+                }
                 move_tracked_region((u64)old_address, old_size, (u64)result, new_size, !(flags & MREMAP_DONTUNMAP));
             }
 
             return result;
         }
     }
+}
+
+int Mapper::protect(void* addr, u64 size, int prot) {
+    auto guard = freelist.lock();
+
+    int res = ::mprotect(addr, size, prot);
+    if (res != -1)
+        move_tracked_region((u64)addr, size, (u64)addr, size, true, prot);
+
+    return res;
 }
 
 std::vector<std::pair<u32, u32>> Mapper::getRegions() {
@@ -226,6 +261,7 @@ std::vector<std::pair<u32, u32>> Mapper::getRegions() {
 
 int Mapper::shmat(bool mode32, int shmid, void* address, int flags, u64* result_address) {
     auto guard = freelist.lock();
+
     struct shmid_ds ds;
     int result = shmctl(shmid, IPC_STAT, &ds);
     if (result != 0) {
@@ -294,7 +330,7 @@ int Mapper::shmat(bool mode32, int shmid, void* address, int flags, u64* result_
         prot |= PROT_EXEC;
     if ((flags & SHM_RDONLY) != 0)
         prot &= ~PROT_WRITE;
-    add_tracked_region((u64)shm_mem, size, prot, 0, 0, 0, true);
+    add_tracked_region((u64)shm_mem, size, prot, 0, 0, 0, true, shmid);
 
     return 0;
 }
@@ -338,12 +374,12 @@ int Mapper::shmdt(bool mode32, void* address) {
     return result;
 }
 
-static bool can_guest_regions_merge(GuestRegion& a, GuestRegion& b) {
-    return a.prot == b.prot && a.dev == b.dev && a.ino == b.ino &&
-           ((a.offset + (a.end - a.start) == b.offset) || (b.offset + (b.end - b.start) == a.offset) || !a.ino) && a.shmem == b.shmem;
+static bool can_guest_regions_merge(GuestRegion& l, GuestRegion& h) {
+    return l.prot == h.prot && l.dev == h.dev && l.ino == h.ino && ((l.offset + (l.end - l.start) == h.offset) || !l.ino) && l.shmem == h.shmem &&
+           l.shmid == h.shmid;
 }
 
-void Mapper::add_tracked_region(u64 address, u64 len, int prot, dev_t dev, ino_t ino, u64 offset, bool shmem) {
+void Mapper::add_tracked_region(u64 address, u64 len, int prot, dev_t dev, ino_t ino, u64 offset, bool shmem, int shmid) {
     if (len == 0)
         return;
 
@@ -352,20 +388,20 @@ void Mapper::add_tracked_region(u64 address, u64 len, int prot, dev_t dev, ino_t
     u64 end = address + len;
     end = (end + 0xfff) & ~0xfff;
 
-    GuestRegion v = GuestRegion{address, end, prot, dev, ino, offset, shmem};
+    GuestRegion v = GuestRegion{address, end, prot, dev, ino, offset, shmem, shmid};
 
     remove_tracked_region(address, len);
     for (auto it = allocated_regions.begin(); it != allocated_regions.end(); it++) {
         auto& r = *it;
-        bool can_merge = can_guest_regions_merge(v, r);
 
         // Region extends another leading.
-        if (can_merge && r.start == end) {
+        if (r.start == end && can_guest_regions_merge(v, r)) {
             r.start = address;
+            r.offset = offset;
             return;
         }
         // Region extends another trailing.
-        else if (can_merge && r.end == address) {
+        else if (r.end == address && can_guest_regions_merge(r, v)) {
             r.end = std::max(r.end, end);
             // Check if we can continue merging onwards.
             it++;
@@ -378,12 +414,6 @@ void Mapper::add_tracked_region(u64 address, u64 len, int prot, dev_t dev, ino_t
                 }
             }
             return;
-        }
-        // Overlap.
-        else if ((r.start >= address && r.start < end) || (r.end > address && r.end <= end) || (address >= r.start && address < r.end) ||
-                 (end > r.start && end <= r.end)) {
-            add_tracked_region(address, len, prot, dev, ino, offset, shmem);
-            return;
         } else if (end <= r.start) {
             allocated_regions.insert(it, v);
             return;
@@ -393,7 +423,7 @@ void Mapper::add_tracked_region(u64 address, u64 len, int prot, dev_t dev, ino_t
     allocated_regions.emplace_back(v);
 }
 
-void Mapper::move_tracked_region(u64 old_address, u64 old_len, u64 new_address, u64 new_len, bool remove_src) {
+void Mapper::move_tracked_region(u64 old_address, u64 old_len, u64 new_address, u64 new_len, bool remove_src, int new_prot) {
     old_address &= ~0xfff;
     old_len = (old_len + 0xfff) & ~0xfff;
     new_address &= ~0xfff;
@@ -406,60 +436,36 @@ void Mapper::move_tracked_region(u64 old_address, u64 old_len, u64 new_address, 
 
     for (auto it = allocated_regions.begin(); it != allocated_regions.end();) {
         auto& r = *it;
+        auto n = r;
+        n.prot = new_prot == -1 ? n.prot : new_prot;
 
         if (old_address > r.start && old_end < r.end) {
-            auto n = r;
             n.start = new_address;
             n.end = new_address + new_len;
-            auto nl = r;
-            nl.end = old_address;
-            auto nr = r;
-            nr.start = old_end;
-            it = allocated_regions.erase(it);
-
+            n.offset += old_address - r.start;
             to_add.push_back(n);
-            it = allocated_regions.insert(it, nr);
-            it = allocated_regions.insert(it, nl);
-            it++;
             it++;
             continue;
         }
 
-        bool is_start_in = r.start >= old_address && r.start < old_end;
-        bool is_end_in = r.end > old_address && r.end <= old_end;
-
-        auto n = r;
+        n.offset += (old_address - r.offset);
         n.start = new_address + std::min((std::max(r.start, old_address) - old_address), new_len);
         n.end = new_address + (is_increase ? new_len : std::min((std::min(r.end, old_end) - old_address), new_len));
-        if (is_start_in && is_end_in) {
-            to_add.push_back(n);
-            if (remove_src)
-                it = allocated_regions.erase(it);
-            else
-                it++;
-        } else if (is_start_in) {
-            to_add.push_back(n);
-            if (remove_src)
-                r.start = old_end;
-            it++;
-        } else if (is_end_in) {
-            to_add.push_back(n);
-            if (remove_src)
-                r.end = old_address;
-            it++;
-        } else {
-            it++;
-        }
+        to_add.push_back(n);
+        it++;
 
-        if (is_increase && (is_start_in || is_end_in))
+        if (is_increase)
             break;
     }
 
     ASSERT(!is_increase || to_add.size() <= 1);
 
+    if (remove_src)
+        remove_tracked_region(old_address, old_len);
+
     remove_tracked_region(new_address, new_len);
     for (auto add : std::move(to_add)) {
-        add_tracked_region(add.start, add.end - add.start, add.prot, add.dev, add.ino, add.offset, add.shmem);
+        add_tracked_region(add.start, add.end - add.start, add.prot, add.dev, add.ino, add.offset, add.shmem, add.shmid);
     }
 }
 
@@ -491,11 +497,11 @@ void Mapper::remove_tracked_region(u64 address, u64 len) {
             it = allocated_regions.erase(it);
 
             if (address - m.start > 0) {
-                it = allocated_regions.insert(it, GuestRegion{m.start, address, m.prot, m.dev, m.ino, m.offset, m.shmem});
+                it = allocated_regions.insert(it, GuestRegion{m.start, address, m.prot, m.dev, m.ino, m.offset, m.shmem, m.shmid});
                 it++;
             }
             if (m.end - end > 0) {
-                it = allocated_regions.insert(it, GuestRegion{end, m.end, m.prot, m.dev, m.ino, m.offset, m.shmem});
+                it = allocated_regions.insert(it, GuestRegion{end, m.end, m.prot, m.dev, m.ino, m.offset + (end - m.start), m.shmem, m.shmid});
                 it++;
             }
             continue;
@@ -503,6 +509,7 @@ void Mapper::remove_tracked_region(u64 address, u64 len) {
 
         /// The unmapped region removes from the left side.
         if (r.start >= address && r.start < end) {
+            r.offset += end - r.start;
             r.start = end;
         }
 

--- a/src/felix86/hle/mmap.cpp
+++ b/src/felix86/hle/mmap.cpp
@@ -352,7 +352,7 @@ uint64_t Mapper::total_mapped_memory() {
     return total_bytes;
 }
 
-bool Mapper::is_address_guest(void* address) {
+bool Mapper::is_guest_address(void* address) {
     // Ensure no race conditions.
     auto guard = freelist.lock();
 

--- a/src/felix86/hle/mmap.cpp
+++ b/src/felix86/hle/mmap.cpp
@@ -164,8 +164,8 @@ void* Mapper::map(bool mode32, void* addr, u64 size, int prot, int flags, int fd
 
         // On success, add tracked allocation.
         if (result != (void*)-1) {
-            if ((u64)addr <= (u64)UINT32_MAX) {
-                u64 to_alloc_s = (u64)addr;
+            if ((u64)result <= (u64)UINT32_MAX) {
+                u64 to_alloc_s = (u64)result;
                 u64 to_alloc_e = std::min(to_alloc_s + size, (u64)UINT32_MAX + 1);
                 freelist.allocate(to_alloc_s, to_alloc_e - to_alloc_s);
             }

--- a/src/felix86/hle/mmap.cpp
+++ b/src/felix86/hle/mmap.cpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <sys/mman.h>
 #include <sys/shm.h>
+#include <sys/stat.h>
 #include "felix86/common/global.hpp"
 #include "felix86/common/log.hpp"
 #include "felix86/hle/mmap.hpp"
@@ -44,7 +45,7 @@ void* Mapper::map32(void* addr, u64 size, int prot, int flags, int fd, u64 offse
 
         void* mapping = freelist.allocate((u64)result, size);
         ASSERT_MSG(mapping == result, "Failed with mmap(%lx, %lx, %x, %x, %d, %lx)", addr, size, prot, flags, fd, offset);
-        add_tracked_region((u64)result, size, flags, prot);
+        add_tracked_region((u64)result, size, flags, prot, fd);
         return result;
     } else {
         void* address = freelist.allocate(0, size);
@@ -61,7 +62,7 @@ void* Mapper::map32(void* addr, u64 size, int prot, int flags, int fd, u64 offse
             return (void*)error;
         }
 
-        add_tracked_region((u64)result, size, flags, prot);
+        add_tracked_region((u64)result, size, flags, prot, fd);
         ASSERT(result == address);
         return address;
     }
@@ -155,7 +156,7 @@ void* Mapper::map(bool mode32, void* addr, u64 size, int prot, int flags, int fd
         // On success, add tracked allocation.
         if (result != (void*)-1) {
             auto guard = freelist.lock();
-            add_tracked_region((u64)result, size, flags, prot);
+            add_tracked_region((u64)result, size, flags, prot, fd);
         }
 
         return result;
@@ -204,234 +205,6 @@ void* Mapper::remap(bool mode32, void* old_address, u64 old_size, u64 new_size, 
             return result;
         }
     }
-}
-
-void Mapper::add_tracked_region(u64 address, u64 len, int flags, int prot, bool shmem) {
-    if (len == 0)
-        return;
-
-    // Assume 4KiB alignment.
-    address = address & ~0xfff;
-    u64 end = address + len;
-    end = (end + 0xfff) & ~0xfff;
-
-    // We assume at this point, that the allocated region will not overlap with any existing region.
-    // This works because any invocation to mmap cannot share the same region of address space as
-    // an already existing mapping UNLESS it has the MAP_FIXED flag, in which case the mapped region
-    // is removed before a call to this function.
-
-    GuestRegion v = GuestRegion{address, end, flags, prot, shmem};
-
-    for (auto it = allocated_regions.begin(); it != allocated_regions.end(); it++) {
-        auto& r = *it;
-        bool can_merge = r.flags == flags && r.prot == prot && r.shmem == shmem;
-
-        // Region extends another leading.
-        if (can_merge && r.start == end) {
-            r.start = address;
-            return;
-        }
-        // Region extends another trailing.
-        else if (can_merge && r.end == address) {
-            r.end = std::max(r.end, end);
-            // Check if we can continue merging onwards.
-            it++;
-            while (it != allocated_regions.end()) {
-                if ((*it).start <= r.end && (*it).shmem == shmem && (*it).prot == prot && (*it).flags == flags) {
-                    r.end = std::max(r.end, (*it).end);
-                    it = allocated_regions.erase(it);
-                } else {
-                    break;
-                }
-            }
-            return;
-        }
-        // Overlap.
-        else if ((r.start >= address && r.start < end) || (r.end > address && r.end <= end) || (address >= r.start && address < r.end) ||
-                 (end > r.start && end <= r.end)) {
-            remove_tracked_region(address, len);
-            add_tracked_region(address, len, flags, prot, shmem);
-            return;
-        } else if (end <= r.start) {
-            allocated_regions.insert(it, v);
-            return;
-        }
-    }
-
-    allocated_regions.emplace_back(v);
-}
-
-void Mapper::move_tracked_region(u64 old_address, u64 old_len, u64 new_address, u64 new_len, bool remove_src) {
-    old_address &= ~0xfff;
-    old_len = (old_len + 0xfff) & ~0xfff;
-    new_address &= ~0xfff;
-    new_len = (new_len + 0xfff) & ~0xfff;
-
-    std::vector<GuestRegion> to_add;
-
-    bool is_increase = new_len > old_len;
-    u64 old_end = old_address + old_len;
-
-    for (auto it = allocated_regions.begin(); it != allocated_regions.end();) {
-        auto& r = *it;
-
-        if (old_address > r.start && old_end < r.end) {
-            auto n = r;
-            n.start = new_address;
-            n.end = new_address + new_len;
-            auto nl = r;
-            nl.end = old_address;
-            auto nr = r;
-            nr.start = old_end;
-            it = allocated_regions.erase(it);
-
-            to_add.push_back(n);
-            it = allocated_regions.insert(it, nr);
-            it = allocated_regions.insert(it, nl);
-            it++;
-            continue;
-        }
-
-        bool is_start_in = r.start >= old_address && r.start < old_end;
-        bool is_end_in = r.end > old_address && r.end <= old_end;
-
-        auto n = r;
-        n.start = new_address + std::min((std::max(r.start, old_address) - old_address), new_len);
-        n.end = new_address + (is_increase ? new_len : std::min((std::min(r.end, old_end) - old_address), new_len));
-        if (is_start_in && is_end_in) {
-            to_add.push_back(n);
-            if (remove_src)
-                it = allocated_regions.erase(it);
-            else
-                it++;
-        } else if (is_start_in) {
-            to_add.push_back(n);
-            if (remove_src)
-                r.start = old_end;
-            it++;
-        } else if (is_end_in) {
-            to_add.push_back(n);
-            if (remove_src)
-                r.end = old_address;
-            it++;
-        } else {
-            it++;
-        }
-
-        if (is_increase && (is_start_in || is_end_in))
-            break;
-    }
-
-    ASSERT(!is_increase || to_add.size() <= 1);
-
-    remove_tracked_region(new_address, new_len);
-    for (auto add : to_add) {
-        add_tracked_region(add.start, add.end - add.start, add.flags, add.prot, add.shmem);
-    }
-}
-
-void Mapper::remove_tracked_region(u64 address, u64 len) {
-    if (len == 0)
-        return;
-
-    address = address & ~0xfff;
-    u64 end = address + len;
-    end = (end + 0xfff) & ~0xfff;
-
-    for (auto it = allocated_regions.begin(); it != allocated_regions.end();) {
-        auto& r = *it;
-        // Because the linked list is ordered, we know if the start address is greater than end,
-        // then there is no more regions to remove with this unmap.
-        if (end <= r.start || address == end) {
-            break;
-        }
-
-        /// The mapped region is entirely within the unmapped region
-        if (address <= r.start && end >= r.end) {
-            it = allocated_regions.erase(it);
-            continue;
-        }
-
-        /// The unmapped region is entirely within an existing region.
-        if (r.start <= address && r.end >= end) {
-            auto m = r;
-            it = allocated_regions.erase(it);
-
-            if (address - m.start > 0) {
-                it = allocated_regions.insert(it, GuestRegion{m.start, address, m.flags, m.prot, m.shmem});
-                it++;
-            }
-            if (m.end - end > 0) {
-                it = allocated_regions.insert(it, GuestRegion{end, m.end, m.flags, m.prot, m.shmem});
-                it++;
-            }
-            continue;
-        }
-
-        /// The unmapped region removes from the left side.
-        if (r.start >= address && r.start < end) {
-            r.start = end;
-        }
-
-        /// The unmapped region removes from the right side.
-        if (r.end > address && r.end <= end) {
-            r.end = address;
-        }
-
-        if (r.start >= r.end) {
-            it = allocated_regions.erase(it);
-        } else {
-            it++;
-        }
-    }
-}
-
-void Mapper::reserve(u64 address, u64 len, int flags, int prot) {
-    // Ensure no race conditions.
-    auto guard = freelist.lock();
-
-    freelist.deallocate(address, len);
-    remove_tracked_region(address, len);
-    add_tracked_region(address, len, flags, prot, false);
-}
-
-uint64_t Mapper::total_mapped_memory() {
-    // Ensure no race conditions.
-    auto guard = freelist.lock();
-
-    uint64_t total_bytes = 0;
-    for (auto r : allocated_regions) {
-        total_bytes += r.end - r.start;
-    }
-
-    return total_bytes;
-}
-
-bool Mapper::is_guest_address(void* address) {
-    // Ensure no race conditions.
-    auto guard = freelist.lock();
-
-    // TODO: could maybe be done faster using caching?
-    // Optionally, an ordered map could maybe be iterated faster?
-    u64 a = (u64)address;
-    for (auto r : allocated_regions) {
-        if (r.start <= a && a < r.end) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-std::vector<GuestRegion> Mapper::get_guest_regions() {
-    // Ensure no race conditions.
-    auto guard = freelist.lock();
-
-    std::vector<GuestRegion> regions;
-    for (auto region : allocated_regions) {
-        regions.push_back(region);
-    }
-    return regions;
 }
 
 std::vector<std::pair<u32, u32>> Mapper::getRegions() {
@@ -504,13 +277,13 @@ int Mapper::shmat(bool mode32, int shmid, void* address, int flags, u64* result_
     ASSERT_MSG(!mode32 || top_bits == 0 || top_bits == 0xFFFF'FFFF, "shmat returned address in 64-bit address space?");
     *result_address = (u64)shm_mem;
     page_to_shmid[(u64)shm_mem & ~0xFFFull] = shmid;
-    add_tracked_region((u64)shm_mem, size, flags, 0, true);
+    add_tracked_region((u64)shm_mem, size, flags, 0, 0, true);
 
     return 0;
 }
 
 int Mapper::shmdt(bool mode32, void* address) {
-    let guard = freelist.lock();
+    auto guard = freelist.lock();
 
     auto it = page_to_shmid.find((u64)address & ~0xFFFull);
     if (it == page_to_shmid.end()) {
@@ -541,4 +314,236 @@ int Mapper::shmdt(bool mode32, void* address) {
     }
 
     return result;
+}
+
+static bool can_guest_regions_merge(GuestRegion& a, GuestRegion& b) {
+    return a.flags == b.flags && a.prot == b.prot && a.dev == b.dev && a.ino == b.ino && a.fd == b.fd && a.shmem == b.shmem;
+}
+
+void Mapper::add_tracked_region(u64 address, u64 len, int flags, int prot, int fd, bool shmem) {
+    if (len == 0)
+        return;
+
+    // Assume 4KiB alignment.
+    address = address & ~0xfff;
+    u64 end = address + len;
+    end = (end + 0xfff) & ~0xfff;
+
+    struct stat64 stat{0};
+    if ((flags & MAP_ANONYMOUS) == 0 && !shmem) {
+        fstat64(fd, &stat);
+    }
+    GuestRegion v = GuestRegion{address, end, flags, prot, fd, stat.st_dev, stat.st_ino, shmem};
+
+    // We assume at this point, that the allocated region will not overlap with any existing region.
+    // This works because any invocation to mmap cannot share the same region of address space as
+    // an already existing mapping UNLESS it has the MAP_FIXED flag, in which case the mapped region
+    // is removed before a call to this function.
+
+    for (auto it = allocated_regions.begin(); it != allocated_regions.end(); it++) {
+        auto& r = *it;
+        bool can_merge = can_guest_regions_merge(v, r);
+
+        // Region extends another leading.
+        if (can_merge && r.start == end) {
+            r.start = address;
+            return;
+        }
+        // Region extends another trailing.
+        else if (can_merge && r.end == address) {
+            r.end = std::max(r.end, end);
+            // Check if we can continue merging onwards.
+            it++;
+            while (it != allocated_regions.end()) {
+                if ((*it).start <= r.end && can_guest_regions_merge(r, *it)) {
+                    r.end = std::max(r.end, (*it).end);
+                    it = allocated_regions.erase(it);
+                } else {
+                    break;
+                }
+            }
+            return;
+        }
+        // Overlap.
+        else if ((r.start >= address && r.start < end) || (r.end > address && r.end <= end) || (address >= r.start && address < r.end) ||
+                 (end > r.start && end <= r.end)) {
+            remove_tracked_region(address, len);
+            add_tracked_region(address, len, flags, prot, fd, shmem);
+            return;
+        } else if (end <= r.start) {
+            allocated_regions.insert(it, v);
+            return;
+        }
+    }
+
+    allocated_regions.emplace_back(v);
+}
+
+void Mapper::move_tracked_region(u64 old_address, u64 old_len, u64 new_address, u64 new_len, bool remove_src) {
+    old_address &= ~0xfff;
+    old_len = (old_len + 0xfff) & ~0xfff;
+    new_address &= ~0xfff;
+    new_len = (new_len + 0xfff) & ~0xfff;
+
+    std::vector<GuestRegion> to_add;
+
+    bool is_increase = new_len > old_len;
+    u64 old_end = old_address + old_len;
+
+    for (auto it = allocated_regions.begin(); it != allocated_regions.end();) {
+        auto& r = *it;
+
+        printf("%lx, %lx, %lx, %lx\n", r.start, r.end, old_address, old_end);
+        if (old_address > r.start && old_end < r.end) {
+            auto n = r;
+            n.start = new_address;
+            n.end = new_address + new_len;
+            auto nl = r;
+            nl.end = old_address;
+            auto nr = r;
+            nr.start = old_end;
+            it = allocated_regions.erase(it);
+
+            printf("split!\n %lx, %lx, %lx, %lx | %lx %lx\n", nl.start, nl.end, nr.start, nr.end, n.start, n.end);
+            to_add.push_back(n);
+            it = allocated_regions.insert(it, nr);
+            it = allocated_regions.insert(it, nl);
+            it++;
+            it++;
+            continue;
+        }
+        printf("clean!\n");
+
+        bool is_start_in = r.start >= old_address && r.start < old_end;
+        bool is_end_in = r.end > old_address && r.end <= old_end;
+
+        auto n = r;
+        n.start = new_address + std::min((std::max(r.start, old_address) - old_address), new_len);
+        n.end = new_address + (is_increase ? new_len : std::min((std::min(r.end, old_end) - old_address), new_len));
+        if (is_start_in && is_end_in) {
+            to_add.push_back(n);
+            printf("remove!\n");
+            if (remove_src)
+                it = allocated_regions.erase(it);
+            else
+                it++;
+        } else if (is_start_in) {
+            to_add.push_back(n);
+            if (remove_src)
+                r.start = old_end;
+            it++;
+        } else if (is_end_in) {
+            to_add.push_back(n);
+            if (remove_src)
+                r.end = old_address;
+            it++;
+        } else {
+            it++;
+        }
+
+        if (is_increase && (is_start_in || is_end_in))
+            break;
+    }
+
+    ASSERT(!is_increase || to_add.size() <= 1);
+
+    remove_tracked_region(new_address, new_len);
+    for (auto add : to_add) {
+        add_tracked_region(add.start, add.end - add.start, add.flags, add.prot, add.fd, add.shmem);
+    }
+}
+
+void Mapper::remove_tracked_region(u64 address, u64 len) {
+    if (len == 0)
+        return;
+
+    address = address & ~0xfff;
+    u64 end = address + len;
+    end = (end + 0xfff) & ~0xfff;
+
+    for (auto it = allocated_regions.begin(); it != allocated_regions.end();) {
+        auto& r = *it;
+        // Because the linked list is ordered, we know if the start address is greater than end,
+        // then there is no more regions to remove with this unmap.
+        if (end <= r.start || address == end) {
+            break;
+        }
+
+        /// The mapped region is entirely within the unmapped region
+        if (address <= r.start && end >= r.end) {
+            it = allocated_regions.erase(it);
+            continue;
+        }
+
+        /// The unmapped region is entirely within an existing region.
+        if (r.start <= address && r.end >= end) {
+            auto m = r;
+            it = allocated_regions.erase(it);
+
+            if (address - m.start > 0) {
+                it = allocated_regions.insert(it, GuestRegion{m.start, address, m.flags, m.prot, m.fd, m.dev, m.ino, m.shmem});
+                it++;
+            }
+            if (m.end - end > 0) {
+                it = allocated_regions.insert(it, GuestRegion{end, m.end, m.flags, m.prot, m.fd, m.dev, m.ino, m.shmem});
+                it++;
+            }
+            continue;
+        }
+
+        /// The unmapped region removes from the left side.
+        if (r.start >= address && r.start < end) {
+            r.start = end;
+        }
+
+        /// The unmapped region removes from the right side.
+        if (r.end > address && r.end <= end) {
+            r.end = address;
+        }
+
+        if (r.start >= r.end) {
+            it = allocated_regions.erase(it);
+        } else {
+            it++;
+        }
+    }
+}
+
+uint64_t Mapper::total_mapped_memory() {
+    // Ensure no race conditions.
+    auto guard = freelist.lock();
+
+    uint64_t total_bytes = 0;
+    for (auto r : allocated_regions) {
+        total_bytes += r.end - r.start;
+    }
+
+    return total_bytes;
+}
+
+bool Mapper::is_guest_address(void* address) {
+    // Ensure no race conditions.
+    auto guard = freelist.lock();
+
+    // TODO: could maybe be done faster using caching?
+    // Optionally, an ordered map could maybe be iterated faster?
+    u64 a = (u64)address;
+    for (auto r : allocated_regions) {
+        if (r.start <= a && a < r.end) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+std::vector<GuestRegion> Mapper::get_guest_regions() {
+    // Ensure no race conditions.
+    auto guard = freelist.lock();
+
+    std::vector<GuestRegion> regions;
+    for (auto region : allocated_regions) {
+        regions.push_back(region);
+    }
+    return regions;
 }

--- a/src/felix86/hle/mmap.cpp
+++ b/src/felix86/hle/mmap.cpp
@@ -503,14 +503,16 @@ int Mapper::shmat(bool mode32, int shmid, void* address, int flags, u64* result_
     u64 top_bits = (u64)shm_mem >> 32;
     ASSERT_MSG(!mode32 || top_bits == 0 || top_bits == 0xFFFF'FFFF, "shmat returned address in 64-bit address space?");
     *result_address = (u64)shm_mem;
-    page_to_shmid[(u32)(u64)shm_mem & ~0xFFFull] = shmid;
-    add_tracked_region((u64)shm_mem, size, flags, true);
+    page_to_shmid[(u64)shm_mem & ~0xFFFull] = shmid;
+    add_tracked_region((u64)shm_mem, size, flags, 0, true);
 
     return 0;
 }
 
 int Mapper::shmdt(bool mode32, void* address) {
-    auto it = page_to_shmid.find((u32)(u64)address & ~0xFFFull);
+    let guard = freelist.lock();
+
+    auto it = page_to_shmid.find((u64)address & ~0xFFFull);
     if (it == page_to_shmid.end()) {
         WARN("Could not find page during shmdt: %lx", (u64)address & ~0xFFFull);
         return -EINVAL;

--- a/src/felix86/hle/mmap.cpp
+++ b/src/felix86/hle/mmap.cpp
@@ -214,37 +214,31 @@ void* Mapper::remap(bool mode32, void* old_address, u64 old_size, u64 new_size, 
     if (mode32) {
         return remap32(old_address, old_size, new_size, flags, new_address);
     } else {
-        if (!(flags & MREMAP_MAYMOVE) && (u64)old_address < UINT32_MAX) {
-            // Expands the old mapping, since the old mapping is in 32-bit area we need to pass it to remap32
-            ASSERT(!(flags & MREMAP_FIXED));
-            return remap32(old_address, old_size, new_size, flags, old_address);
-        } else {
-            // Lock access to 'allocated_regions'.
-            auto guard = freelist.lock();
+        // Lock access to 'allocated_regions'.
+        auto guard = freelist.lock();
 
-            old_size = (old_size + 0xFFFull) & ~0xFFFull;
-            new_size = (new_size + 0xFFFull) & ~0xFFFull;
+        old_size = (old_size + 0xFFFull) & ~0xFFFull;
+        new_size = (new_size + 0xFFFull) & ~0xFFFull;
 
-            void* result = ::mremap(old_address, old_size, new_size, flags, new_address);
+        void* result = ::mremap(old_address, old_size, new_size, flags, new_address);
 
-            // On success, remap the tracked allocation
-            if (result != (void*)-1) {
-                if ((u64)old_address <= (u64)UINT32_MAX && !(flags & MREMAP_DONTUNMAP)) {
-                    u64 to_free_s = std::max((u64)old_address, mmap_min_addr());
-                    u64 to_free_e = std::min((u64)old_address + old_size, (u64)UINT32_MAX + 1);
-                    if (to_free_e > to_free_s)
-                        freelist.deallocate(to_free_s, to_free_e - to_free_s);
-                }
-                if ((u64)result <= (u64)UINT32_MAX) {
-                    u64 to_alloc_s = (u64)result;
-                    u64 to_alloc_e = std::min(to_alloc_s + new_size, (u64)UINT32_MAX + 1);
-                    freelist.allocate(to_alloc_s, to_alloc_e - to_alloc_s);
-                }
-                move_tracked_region((u64)old_address, old_size, (u64)result, new_size, !(flags & MREMAP_DONTUNMAP));
+        // On success, remap the tracked allocation
+        if (result != (void*)-1) {
+            if ((u64)old_address <= (u64)UINT32_MAX && !(flags & MREMAP_DONTUNMAP)) {
+                u64 to_free_s = std::max((u64)old_address, mmap_min_addr());
+                u64 to_free_e = std::min((u64)old_address + old_size, (u64)UINT32_MAX + 1);
+                if (to_free_e > to_free_s)
+                    freelist.deallocate(to_free_s, to_free_e - to_free_s);
             }
-
-            return result;
+            if ((u64)result <= (u64)UINT32_MAX) {
+                u64 to_alloc_s = (u64)result;
+                u64 to_alloc_e = std::min(to_alloc_s + new_size, (u64)UINT32_MAX + 1);
+                freelist.allocate(to_alloc_s, to_alloc_e - to_alloc_s);
+            }
+            move_tracked_region((u64)old_address, old_size, (u64)result, new_size, !(flags & MREMAP_DONTUNMAP));
         }
+
+        return result;
     }
 }
 

--- a/src/felix86/hle/mmap.cpp
+++ b/src/felix86/hle/mmap.cpp
@@ -7,6 +7,7 @@
 #include <sys/mman.h>
 #include <sys/shm.h>
 #include <sys/stat.h>
+#include <sys/types.h>
 #include "felix86/common/global.hpp"
 #include "felix86/common/log.hpp"
 #include "felix86/hle/mmap.hpp"
@@ -14,6 +15,11 @@
 void* Mapper::map32(void* addr, u64 size, int prot, int flags, int fd, u64 offset) {
     size = (size + 0xFFFull) & ~0xFFFull;
     auto guard = freelist.lock();
+
+    struct stat64 stat{0};
+    if ((flags & MAP_ANONYMOUS) == 0) {
+        fstat64(fd, &stat);
+    }
 
     if ((flags & MAP_FIXED) || (flags & MAP_FIXED_NOREPLACE)) {
         // Fixed mapping, make sure it's inside 32-bit address space
@@ -45,7 +51,7 @@ void* Mapper::map32(void* addr, u64 size, int prot, int flags, int fd, u64 offse
 
         void* mapping = freelist.allocate((u64)result, size);
         ASSERT_MSG(mapping == result, "Failed with mmap(%lx, %lx, %x, %x, %d, %lx)", addr, size, prot, flags, fd, offset);
-        add_tracked_region((u64)result, size, flags, prot, fd);
+        add_tracked_region((u64)result, size, prot, stat.st_dev, stat.st_ino, offset, (flags & MAP_SHARED) != 0);
         return result;
     } else {
         void* address = freelist.allocate(0, size);
@@ -62,7 +68,7 @@ void* Mapper::map32(void* addr, u64 size, int prot, int flags, int fd, u64 offse
             return (void*)error;
         }
 
-        add_tracked_region((u64)result, size, flags, prot, fd);
+        add_tracked_region((u64)result, size, prot, stat.st_dev, stat.st_ino, offset, (flags & MAP_SHARED) != 0);
         ASSERT(result == address);
         return address;
     }
@@ -156,7 +162,13 @@ void* Mapper::map(bool mode32, void* addr, u64 size, int prot, int flags, int fd
         // On success, add tracked allocation.
         if (result != (void*)-1) {
             auto guard = freelist.lock();
-            add_tracked_region((u64)result, size, flags, prot, fd);
+
+            struct stat64 stat{0};
+            if ((flags & MAP_ANONYMOUS) == 0) {
+                fstat64(fd, &stat);
+            }
+
+            add_tracked_region((u64)result, size, prot, stat.st_dev, stat.st_ino, offset, (flags & MAP_SHARED) != 0);
         }
 
         return result;
@@ -277,7 +289,12 @@ int Mapper::shmat(bool mode32, int shmid, void* address, int flags, u64* result_
     ASSERT_MSG(!mode32 || top_bits == 0 || top_bits == 0xFFFF'FFFF, "shmat returned address in 64-bit address space?");
     *result_address = (u64)shm_mem;
     page_to_shmid[(u64)shm_mem & ~0xFFFull] = shmid;
-    add_tracked_region((u64)shm_mem, size, flags, 0, 0, true);
+    int prot = PROT_READ | PROT_WRITE;
+    if ((flags & SHM_EXEC) != 0)
+        prot |= PROT_EXEC;
+    if ((flags & SHM_RDONLY) != 0)
+        prot &= ~PROT_WRITE;
+    add_tracked_region((u64)shm_mem, size, prot, 0, 0, 0, true);
 
     return 0;
 }
@@ -322,10 +339,11 @@ int Mapper::shmdt(bool mode32, void* address) {
 }
 
 static bool can_guest_regions_merge(GuestRegion& a, GuestRegion& b) {
-    return a.flags == b.flags && a.prot == b.prot && a.dev == b.dev && a.ino == b.ino && a.fd == b.fd && a.shmem == b.shmem;
+    return a.prot == b.prot && a.dev == b.dev && a.ino == b.ino &&
+           ((a.offset + (a.end - a.start) == b.offset) || (b.offset + (b.end - b.start) == a.offset) || !a.ino) && a.shmem == b.shmem;
 }
 
-void Mapper::add_tracked_region(u64 address, u64 len, int flags, int prot, int fd, bool shmem) {
+void Mapper::add_tracked_region(u64 address, u64 len, int prot, dev_t dev, ino_t ino, u64 offset, bool shmem) {
     if (len == 0)
         return;
 
@@ -334,17 +352,9 @@ void Mapper::add_tracked_region(u64 address, u64 len, int flags, int prot, int f
     u64 end = address + len;
     end = (end + 0xfff) & ~0xfff;
 
-    struct stat64 stat{0};
-    if ((flags & MAP_ANONYMOUS) == 0 && !shmem) {
-        fstat64(fd, &stat);
-    }
-    GuestRegion v = GuestRegion{address, end, flags, prot, fd, stat.st_dev, stat.st_ino, shmem};
+    GuestRegion v = GuestRegion{address, end, prot, dev, ino, offset, shmem};
 
-    // We assume at this point, that the allocated region will not overlap with any existing region.
-    // This works because any invocation to mmap cannot share the same region of address space as
-    // an already existing mapping UNLESS it has the MAP_FIXED flag, in which case the mapped region
-    // is removed before a call to this function.
-
+    remove_tracked_region(address, len);
     for (auto it = allocated_regions.begin(); it != allocated_regions.end(); it++) {
         auto& r = *it;
         bool can_merge = can_guest_regions_merge(v, r);
@@ -372,8 +382,7 @@ void Mapper::add_tracked_region(u64 address, u64 len, int flags, int prot, int f
         // Overlap.
         else if ((r.start >= address && r.start < end) || (r.end > address && r.end <= end) || (address >= r.start && address < r.end) ||
                  (end > r.start && end <= r.end)) {
-            remove_tracked_region(address, len);
-            add_tracked_region(address, len, flags, prot, fd, shmem);
+            add_tracked_region(address, len, prot, dev, ino, offset, shmem);
             return;
         } else if (end <= r.start) {
             allocated_regions.insert(it, v);
@@ -398,7 +407,6 @@ void Mapper::move_tracked_region(u64 old_address, u64 old_len, u64 new_address, 
     for (auto it = allocated_regions.begin(); it != allocated_regions.end();) {
         auto& r = *it;
 
-        printf("%lx, %lx, %lx, %lx\n", r.start, r.end, old_address, old_end);
         if (old_address > r.start && old_end < r.end) {
             auto n = r;
             n.start = new_address;
@@ -409,7 +417,6 @@ void Mapper::move_tracked_region(u64 old_address, u64 old_len, u64 new_address, 
             nr.start = old_end;
             it = allocated_regions.erase(it);
 
-            printf("split!\n %lx, %lx, %lx, %lx | %lx %lx\n", nl.start, nl.end, nr.start, nr.end, n.start, n.end);
             to_add.push_back(n);
             it = allocated_regions.insert(it, nr);
             it = allocated_regions.insert(it, nl);
@@ -417,7 +424,6 @@ void Mapper::move_tracked_region(u64 old_address, u64 old_len, u64 new_address, 
             it++;
             continue;
         }
-        printf("clean!\n");
 
         bool is_start_in = r.start >= old_address && r.start < old_end;
         bool is_end_in = r.end > old_address && r.end <= old_end;
@@ -427,7 +433,6 @@ void Mapper::move_tracked_region(u64 old_address, u64 old_len, u64 new_address, 
         n.end = new_address + (is_increase ? new_len : std::min((std::min(r.end, old_end) - old_address), new_len));
         if (is_start_in && is_end_in) {
             to_add.push_back(n);
-            printf("remove!\n");
             if (remove_src)
                 it = allocated_regions.erase(it);
             else
@@ -453,8 +458,8 @@ void Mapper::move_tracked_region(u64 old_address, u64 old_len, u64 new_address, 
     ASSERT(!is_increase || to_add.size() <= 1);
 
     remove_tracked_region(new_address, new_len);
-    for (auto add : to_add) {
-        add_tracked_region(add.start, add.end - add.start, add.flags, add.prot, add.fd, add.shmem);
+    for (auto add : std::move(to_add)) {
+        add_tracked_region(add.start, add.end - add.start, add.prot, add.dev, add.ino, add.offset, add.shmem);
     }
 }
 
@@ -486,11 +491,11 @@ void Mapper::remove_tracked_region(u64 address, u64 len) {
             it = allocated_regions.erase(it);
 
             if (address - m.start > 0) {
-                it = allocated_regions.insert(it, GuestRegion{m.start, address, m.flags, m.prot, m.fd, m.dev, m.ino, m.shmem});
+                it = allocated_regions.insert(it, GuestRegion{m.start, address, m.prot, m.dev, m.ino, m.offset, m.shmem});
                 it++;
             }
             if (m.end - end > 0) {
-                it = allocated_regions.insert(it, GuestRegion{end, m.end, m.flags, m.prot, m.fd, m.dev, m.ino, m.shmem});
+                it = allocated_regions.insert(it, GuestRegion{end, m.end, m.prot, m.dev, m.ino, m.offset, m.shmem});
                 it++;
             }
             continue;

--- a/src/felix86/hle/mmap.cpp
+++ b/src/felix86/hle/mmap.cpp
@@ -436,6 +436,14 @@ void Mapper::move_tracked_region(u64 old_address, u64 old_len, u64 new_address, 
 
     for (auto it = allocated_regions.begin(); it != allocated_regions.end();) {
         auto& r = *it;
+        if (r.end <= old_address) {
+            it++;
+            continue;
+        }
+        if (r.start >= old_end) {
+            break;
+        }
+
         auto n = r;
         n.prot = new_prot == -1 ? n.prot : new_prot;
 

--- a/src/felix86/hle/mmap.cpp
+++ b/src/felix86/hle/mmap.cpp
@@ -58,7 +58,7 @@ void* Mapper::map32(void* addr, u64 size, int prot, int flags, int fd, u64 offse
             WARN("Even though our freelist says we have memory at %lx-%lx, mmap failed with: %ld", (u64)address, (u64)address + size, error);
             return (void*)error;
         }
-        
+
         add_tracked_region((u64)result, size, flags);
         ASSERT(result == address);
         return address;
@@ -72,10 +72,10 @@ int Mapper::unmap32(void* addr, u64 size) {
     if (result != -1) {
         // unmap it from our freelist as well
         auto guard = freelist.lock();
-        freelist.deallocate((u64)addr, size); 
+        freelist.deallocate((u64)addr, size);
         // also unmap it from the allocation tracker.
         remove_tracked_region((u64)addr, size);
-        
+
         return result;
     } else {
         return -errno;
@@ -159,7 +159,7 @@ void* Mapper::map(bool mode32, void* addr, u64 size, int prot, int flags, int fd
             if (result != (void*)-1) {
                 add_tracked_region((u64)result, size, flags);
             }
-            
+
             return result;
         }
     }
@@ -204,26 +204,27 @@ void* Mapper::remap(bool mode32, void* old_address, u64 old_size, u64 new_size, 
                 remove_tracked_region((u64)old_address, new_size);
                 add_tracked_region((u64)result, new_size, flags);
             }
-            
+
             return result;
         }
     }
 }
 
 void Mapper::add_tracked_region(u64 address, u64 len, int flags, bool shmem) {
-    if (len == 0) return;
-    
+    if (len == 0)
+        return;
+
     // Assume 4KiB alignment.
     address = address & ~0x3ff;
     u64 end = address + len;
     end = (end + 0x3ff) & ~0x3ff;
-    
+
     // We assume at this point, that the allocated region will not overlap with any existing region.
     // This works because any invocation to mmap cannot share the same region of address space as
     // an already existing mapping UNLESS it has the MAP_FIXED flag, in which case the mapped region
     // is removed before a call to this function.
 
-    AllocatedRegion v = AllocatedRegion { address, end, flags, shmem };
+    AllocatedRegion v = AllocatedRegion{address, end, flags, shmem};
 
     for (auto it = allocated_regions.begin(); it != allocated_regions.end(); it++) {
         auto& r = *it;
@@ -240,7 +241,7 @@ void Mapper::add_tracked_region(u64 address, u64 len, int flags, bool shmem) {
             r.end = end;
             // Check if we can continue merging onwards.
             it++;
-            for (;it != allocated_regions.end(); it++) {
+            for (; it != allocated_regions.end(); it++) {
                 if ((*it).start == r.end && (*it).shmem == shmem && (*it).flags == flags) {
                     r.end = (*it).end;
                     it = allocated_regions.erase(it);
@@ -256,17 +257,12 @@ void Mapper::add_tracked_region(u64 address, u64 len, int flags, bool shmem) {
             return;
         }
         // Overlap.
-        else if (
-            (r.start >= address && r.start < end)
-            || (r.end > address && r.end <= end)
-            || (address >= r.start && address < r.end)
-            || (end > r.start && end <= r.end)
-        ) {
+        else if ((r.start >= address && r.start < end) || (r.end > address && r.end <= end) || (address >= r.start && address < r.end) ||
+                 (end > r.start && end <= r.end)) {
             remove_tracked_region(address, len);
             add_tracked_region(address, len, flags, shmem);
             return;
-        }
-        else if (end <= r.start) {
+        } else if (end <= r.start) {
             allocated_regions.insert(it, v);
             return;
         }
@@ -276,7 +272,8 @@ void Mapper::add_tracked_region(u64 address, u64 len, int flags, bool shmem) {
 }
 
 void Mapper::remove_tracked_region(u64 address, u64 len) {
-    if (len == 0) return;
+    if (len == 0)
+        return;
 
     address = address & ~0x3ff;
     u64 end = address + len;
@@ -301,11 +298,11 @@ void Mapper::remove_tracked_region(u64 address, u64 len) {
             it = allocated_regions.erase(it);
 
             if (address - r.start > 0) {
-                it = allocated_regions.insert(it, AllocatedRegion {r.start, address, r.flags, r.shmem});
+                it = allocated_regions.insert(it, AllocatedRegion{r.start, address, r.flags, r.shmem});
                 it++;
             }
             if (r.end - end > 0) {
-                it = allocated_regions.insert(it, AllocatedRegion {end, r.end, r.flags, r.shmem});
+                it = allocated_regions.insert(it, AllocatedRegion{end, r.end, r.flags, r.shmem});
                 it++;
             }
             continue;
@@ -315,7 +312,6 @@ void Mapper::remove_tracked_region(u64 address, u64 len) {
         /// The unmapped region removes from the left side.
         if (m.start >= address && m.end > address) {
             m.start = end;
-
         }
 
         /// The unmapped region removes from the right side.
@@ -345,7 +341,7 @@ uint64_t Mapper::total_mapped_memory() {
     auto guard = freelist.lock();
 
     uint64_t total_bytes = 0;
-    for (auto r: allocated_regions) {
+    for (auto r : allocated_regions) {
         total_bytes += r.end - r.start;
     }
 
@@ -359,7 +355,7 @@ bool Mapper::is_guest_address(void* address) {
     // TODO: could maybe be done faster using caching?
     // Optionally, an ordered map could maybe be iterated faster?
     u64 a = (u64)address;
-    for (auto r: allocated_regions) {
+    for (auto r : allocated_regions) {
         if (r.start <= a && a < r.end) {
             return true;
         }
@@ -373,7 +369,7 @@ std::vector<AllocatedRegion> Mapper::get_allocated_regions() {
     auto guard = freelist.lock();
 
     std::vector<AllocatedRegion> regions;
-    for (auto region: allocated_regions) {
+    for (auto region : allocated_regions) {
         regions.push_back(region);
     }
     return regions;

--- a/src/felix86/hle/mmap.cpp
+++ b/src/felix86/hle/mmap.cpp
@@ -11,6 +11,7 @@
 #include <sys/types.h>
 #include "felix86/common/global.hpp"
 #include "felix86/common/log.hpp"
+#include "felix86/common/utility.hpp"
 #include "felix86/hle/mmap.hpp"
 
 void* Mapper::map32(void* addr, u64 size, int prot, int flags, int fd, u64 offset) {
@@ -18,6 +19,7 @@ void* Mapper::map32(void* addr, u64 size, int prot, int flags, int fd, u64 offse
     auto guard = freelist.lock();
 
     struct stat64 stat{0};
+    stat.st_ino = ino_anon_ctr++;
     if ((flags & MAP_ANONYMOUS) == 0) {
         fstat64(fd, &stat);
     }
@@ -52,7 +54,7 @@ void* Mapper::map32(void* addr, u64 size, int prot, int flags, int fd, u64 offse
 
         void* mapping = freelist.allocate((u64)result, size);
         ASSERT_MSG(mapping == result, "Failed with mmap(%lx, %lx, %x, %x, %d, %lx)", addr, size, prot, flags, fd, offset);
-        add_tracked_region((u64)result, size, prot, stat.st_dev, stat.st_ino, offset, (flags & MAP_SHARED) != 0, -1);
+        add_tracked_region((u64)result, size, prot, stat.st_dev, stat.st_ino, offset, (flags & MAP_SHARED) != 0, -1, (flags & MAP_ANONYMOUS) != 0);
         return result;
     } else {
         void* address = freelist.allocate(0, size);
@@ -69,7 +71,7 @@ void* Mapper::map32(void* addr, u64 size, int prot, int flags, int fd, u64 offse
             return (void*)error;
         }
 
-        add_tracked_region((u64)result, size, prot, stat.st_dev, stat.st_ino, offset, (flags & MAP_SHARED) != 0, -1);
+        add_tracked_region((u64)result, size, prot, stat.st_dev, stat.st_ino, offset, (flags & MAP_SHARED) != 0, -1, (flags & MAP_ANONYMOUS) != 0);
         ASSERT(result == address);
         return address;
     }
@@ -171,11 +173,13 @@ void* Mapper::map(bool mode32, void* addr, u64 size, int prot, int flags, int fd
             }
 
             struct stat64 stat{0};
+            stat.st_ino = ino_anon_ctr++;
             if ((flags & MAP_ANONYMOUS) == 0) {
                 fstat64(fd, &stat);
             }
 
-            add_tracked_region((u64)result, size, prot, stat.st_dev, stat.st_ino, offset, (flags & MAP_SHARED) != 0, -1);
+            add_tracked_region((u64)result, size, prot, stat.st_dev, stat.st_ino, offset, (flags & MAP_SHARED) != 0, -1,
+                               (flags & MAP_ANONYMOUS) != 0);
         }
 
         return result;
@@ -195,9 +199,10 @@ int Mapper::unmap(bool mode32, void* addr, u64 size) {
         if (result != -1) {
             remove_tracked_region((u64)addr, size);
             if ((u64)addr <= (u64)UINT32_MAX) {
-                u64 to_free_s = (u64)addr;
-                u64 to_free_e = std::min(to_free_s + size, (u64)UINT32_MAX + 1);
-                freelist.deallocate(to_free_s, to_free_e - to_free_s);
+                u64 to_free_s = std::max((u64)addr, mmap_min_addr());
+                u64 to_free_e = std::min((u64)addr + size, (u64)UINT32_MAX + 1);
+                if (to_free_e > to_free_s)
+                    freelist.deallocate(to_free_s, to_free_e - to_free_s);
             }
         }
 
@@ -209,9 +214,7 @@ void* Mapper::remap(bool mode32, void* old_address, u64 old_size, u64 new_size, 
     if (mode32) {
         return remap32(old_address, old_size, new_size, flags, new_address);
     } else {
-        if ((flags & MREMAP_FIXED) && (u64)new_address <= UINT32_MAX) {
-            return remap32(old_address, old_size, new_size, flags, new_address);
-        } else if (!(flags & MREMAP_MAYMOVE) && (u64)old_address < UINT32_MAX) {
+        if (!(flags & MREMAP_MAYMOVE) && (u64)old_address < UINT32_MAX) {
             // Expands the old mapping, since the old mapping is in 32-bit area we need to pass it to remap32
             ASSERT(!(flags & MREMAP_FIXED));
             return remap32(old_address, old_size, new_size, flags, old_address);
@@ -227,9 +230,10 @@ void* Mapper::remap(bool mode32, void* old_address, u64 old_size, u64 new_size, 
             // On success, remap the tracked allocation
             if (result != (void*)-1) {
                 if ((u64)old_address <= (u64)UINT32_MAX && !(flags & MREMAP_DONTUNMAP)) {
-                    u64 to_free_s = (u64)old_address;
-                    u64 to_free_e = std::min(to_free_s + old_size, (u64)UINT32_MAX + 1);
-                    freelist.deallocate(to_free_s, to_free_e - to_free_s);
+                    u64 to_free_s = std::max((u64)old_address, mmap_min_addr());
+                    u64 to_free_e = std::min((u64)old_address + old_size, (u64)UINT32_MAX + 1);
+                    if (to_free_e > to_free_s)
+                        freelist.deallocate(to_free_s, to_free_e - to_free_s);
                 }
                 if ((u64)result <= (u64)UINT32_MAX) {
                     u64 to_alloc_s = (u64)result;
@@ -249,7 +253,8 @@ int Mapper::protect(void* addr, u64 size, int prot) {
 
     int res = ::mprotect(addr, size, prot);
     if (res != -1)
-        move_tracked_region((u64)addr, size, (u64)addr, size, true, prot);
+        move_tracked_region((u64)addr, size, (u64)addr, size, true, prot & (PROT_READ | PROT_WRITE | PROT_EXEC | PROT_GROWSDOWN | PROT_GROWSUP),
+                            false);
 
     return res;
 }
@@ -330,7 +335,7 @@ int Mapper::shmat(bool mode32, int shmid, void* address, int flags, u64* result_
         prot |= PROT_EXEC;
     if ((flags & SHM_RDONLY) != 0)
         prot &= ~PROT_WRITE;
-    add_tracked_region((u64)shm_mem, size, prot, 0, 0, 0, true, shmid);
+    add_tracked_region((u64)shm_mem, size, prot, 0, 0, 0, true, shmid, false);
 
     return 0;
 }
@@ -375,11 +380,18 @@ int Mapper::shmdt(bool mode32, void* address) {
 }
 
 static bool can_guest_regions_merge(GuestRegion& l, GuestRegion& h) {
-    return l.prot == h.prot && l.dev == h.dev && l.ino == h.ino && ((l.offset + (l.end - l.start) == h.offset) || !l.ino) && l.shmem == h.shmem &&
-           l.shmid == h.shmid;
+    return
+        // Mappings must share protection.
+        l.prot == h.prot
+        // Mappings must share device id.
+        && l.dev == h.dev
+        // If both mappings are not anonymous, do they share the same backing file? If both are anonymous, it is irrelevant.
+        && ((l.anonymous && h.anonymous) || ((l.offset + (l.end - l.start) == h.offset) && (l.ino == h.ino)))
+        // If both mappings are shared memory, do they refer to the same underlying file/anonymous memory?
+        && ((!l.shmem && !h.shmem) || (l.ino == h.ino));
 }
 
-void Mapper::add_tracked_region(u64 address, u64 len, int prot, dev_t dev, ino_t ino, u64 offset, bool shmem, int shmid) {
+void Mapper::add_tracked_region(u64 address, u64 len, int prot, dev_t dev, ino_t ino, u64 offset, bool shmem, int shmid, bool anon) {
     if (len == 0)
         return;
 
@@ -388,7 +400,7 @@ void Mapper::add_tracked_region(u64 address, u64 len, int prot, dev_t dev, ino_t
     u64 end = address + len;
     end = (end + 0xfff) & ~0xfff;
 
-    GuestRegion v = GuestRegion{address, end, prot, dev, ino, offset, shmem, shmid};
+    GuestRegion v = GuestRegion{address, end, prot, dev, ino, offset, shmid, shmem, anon};
 
     remove_tracked_region(address, len);
     for (auto it = allocated_regions.begin(); it != allocated_regions.end(); it++) {
@@ -423,7 +435,7 @@ void Mapper::add_tracked_region(u64 address, u64 len, int prot, dev_t dev, ino_t
     allocated_regions.emplace_back(v);
 }
 
-void Mapper::move_tracked_region(u64 old_address, u64 old_len, u64 new_address, u64 new_len, bool remove_src, int new_prot) {
+void Mapper::move_tracked_region(u64 old_address, u64 old_len, u64 new_address, u64 new_len, bool remove_src, int new_prot, bool can_grow) {
     old_address &= ~0xfff;
     old_len = (old_len + 0xfff) & ~0xfff;
     new_address &= ~0xfff;
@@ -447,9 +459,9 @@ void Mapper::move_tracked_region(u64 old_address, u64 old_len, u64 new_address, 
         auto n = r;
         n.prot = new_prot == -1 ? n.prot : new_prot;
 
-        if (old_address > r.start && old_end < r.end) {
+        if (old_address >= r.start && old_end <= r.end) {
             n.start = new_address;
-            n.end = new_address + new_len;
+            n.end = can_grow ? new_address + new_len : new_address + old_len;
             n.offset += old_address - r.start;
             to_add.push_back(n);
             it++;
@@ -458,7 +470,7 @@ void Mapper::move_tracked_region(u64 old_address, u64 old_len, u64 new_address, 
 
         n.offset += (old_address - r.offset);
         n.start = new_address + std::min((std::max(r.start, old_address) - old_address), new_len);
-        n.end = new_address + (is_increase ? new_len : std::min((std::min(r.end, old_end) - old_address), new_len));
+        n.end = new_address + (is_increase && can_grow ? new_len : std::min((std::min(r.end, old_end) - old_address), new_len));
         to_add.push_back(n);
         it++;
 
@@ -473,7 +485,7 @@ void Mapper::move_tracked_region(u64 old_address, u64 old_len, u64 new_address, 
 
     remove_tracked_region(new_address, new_len);
     for (auto add : std::move(to_add)) {
-        add_tracked_region(add.start, add.end - add.start, add.prot, add.dev, add.ino, add.offset, add.shmem, add.shmid);
+        add_tracked_region(add.start, add.end - add.start, add.prot, add.dev, add.ino, add.offset, add.shmem, add.shmid, add.anonymous);
     }
 }
 
@@ -505,11 +517,12 @@ void Mapper::remove_tracked_region(u64 address, u64 len) {
             it = allocated_regions.erase(it);
 
             if (address - m.start > 0) {
-                it = allocated_regions.insert(it, GuestRegion{m.start, address, m.prot, m.dev, m.ino, m.offset, m.shmem, m.shmid});
+                it = allocated_regions.insert(it, GuestRegion{m.start, address, m.prot, m.dev, m.ino, m.offset, m.shmid, m.shmem, m.anonymous});
                 it++;
             }
             if (m.end - end > 0) {
-                it = allocated_regions.insert(it, GuestRegion{end, m.end, m.prot, m.dev, m.ino, m.offset + (end - m.start), m.shmem, m.shmid});
+                it = allocated_regions.insert(
+                    it, GuestRegion{end, m.end, m.prot, m.dev, m.ino, m.offset + (end - m.start), m.shmid, m.shmem, m.anonymous});
                 it++;
             }
             continue;

--- a/src/felix86/hle/mmap.cpp
+++ b/src/felix86/hle/mmap.cpp
@@ -3,6 +3,7 @@
 #include <iterator>
 #include <memory>
 #include <utility>
+#include <vector>
 #include <sys/mman.h>
 #include <sys/shm.h>
 #include "felix86/common/global.hpp"
@@ -93,16 +94,6 @@ void* Mapper::remap32(void* old_address, u64 old_size, u64 new_size, int flags, 
 
     auto guard = freelist.lock();
 
-    int prot = 0;
-    bool found = false;
-    for (auto& region : allocated_regions) {
-        if (region.start <= (u64)old_address && (u64)old_address < region.end) {
-            prot = region.prot;
-            found = true;
-            break;
-        }
-    }
-
     if ((flags & MREMAP_FIXED) || !(flags & MREMAP_MAYMOVE)) {
         // Give it to the kernel first
         ASSERT((u64)new_address < UINT32_MAX);
@@ -112,20 +103,16 @@ void* Mapper::remap32(void* old_address, u64 old_size, u64 new_size, int flags, 
         }
 
         ASSERT(result == new_address);
-        ASSERT(found);
 
         // Since the mapping succeeded we also need to update our freelist allocator
         if (!(flags & MREMAP_DONTUNMAP)) {
             freelist.deallocate((u64)old_address, old_size);
-            remove_tracked_region((u64)old_address, old_size);
-        } else {
-            remove_tracked_region((u64)result, new_size);
         }
 
         void* mapping = freelist.allocate((u64)result, new_size);
         ASSERT(mapping == result);
 
-        add_tracked_region((u64)result, new_size, flags, prot);
+        move_tracked_region((u64)old_address, old_size, (u64)result, new_size, !(flags & MREMAP_DONTUNMAP));
 
         return result;
     } else {
@@ -150,14 +137,9 @@ void* Mapper::remap32(void* old_address, u64 old_size, u64 new_size, int flags, 
         // After everything goes ok we can unmap the old region
         if (!(flags & MREMAP_DONTUNMAP)) {
             freelist.deallocate((u64)old_address, old_size);
-            remove_tracked_region((u64)old_address, old_size);
-        } else {
-            remove_tracked_region((u64)result, new_size);
         }
 
-        ASSERT(found);
-
-        add_tracked_region((u64)result, new_size, flags, prot);
+        move_tracked_region((u64)old_address, old_size, (u64)result, new_size, !(flags & MREMAP_DONTUNMAP));
 
         ASSERT(result == new_address);
         return result;
@@ -214,21 +196,9 @@ void* Mapper::remap(bool mode32, void* old_address, u64 old_size, u64 new_size, 
             // Lock access to 'allocated_regions'.
             auto guard = freelist.lock();
 
-            int prot = 0;
-            bool found = false;
-            for (auto& region : allocated_regions) {
-                if (region.start <= (u64)old_address && (u64)old_address < region.end) {
-                    prot = region.prot;
-                    found = true;
-                    break;
-                }
-            }
-
             // On success, remap the tracked allocation
             if (result != (void*)-1) {
-                ASSERT(found);
-                remove_tracked_region((u64)old_address, old_size);
-                add_tracked_region((u64)result, new_size, flags, prot);
+                move_tracked_region((u64)old_address, old_size, (u64)result, new_size, !(flags & MREMAP_DONTUNMAP));
             }
 
             return result;
@@ -241,9 +211,9 @@ void Mapper::add_tracked_region(u64 address, u64 len, int flags, int prot, bool 
         return;
 
     // Assume 4KiB alignment.
-    address = address & ~0x3ff;
+    address = address & ~0xfff;
     u64 end = address + len;
-    end = (end + 0x3ff) & ~0x3ff;
+    end = (end + 0xfff) & ~0xfff;
 
     // We assume at this point, that the allocated region will not overlap with any existing region.
     // This works because any invocation to mmap cannot share the same region of address space as
@@ -263,19 +233,13 @@ void Mapper::add_tracked_region(u64 address, u64 len, int flags, int prot, bool 
         }
         // Region extends another trailing.
         else if (can_merge && r.end == address) {
-            auto r = *it;
-            r.end = end;
+            r.end = std::max(r.end, end);
             // Check if we can continue merging onwards.
             it++;
-            for (; it != allocated_regions.end(); it++) {
-                if ((*it).start == r.end && (*it).shmem == shmem && (*it).prot == prot && (*it).flags == flags) {
-                    r.end = (*it).end;
+            while (it != allocated_regions.end()) {
+                if ((*it).start <= r.end && (*it).shmem == shmem && (*it).prot == prot && (*it).flags == flags) {
+                    r.end = std::max(r.end, (*it).end);
                     it = allocated_regions.erase(it);
-                } else if ((*it).start < r.end) {
-                    (*it).start = r.end;
-                    if ((*it).start >= (*it).end) {
-                        it = allocated_regions.erase(it);
-                    }
                 } else {
                     break;
                 }
@@ -297,16 +261,85 @@ void Mapper::add_tracked_region(u64 address, u64 len, int flags, int prot, bool 
     allocated_regions.emplace_back(v);
 }
 
+void Mapper::move_tracked_region(u64 old_address, u64 old_len, u64 new_address, u64 new_len, bool remove_src) {
+    old_address &= ~0xfff;
+    old_len = (old_len + 0xfff) & ~0xfff;
+    new_address &= ~0xfff;
+    new_len = (new_len + 0xfff) & ~0xfff;
+
+    std::vector<GuestRegion> to_add;
+
+    bool is_increase = new_len > old_len;
+    u64 old_end = old_address + old_len;
+
+    for (auto it = allocated_regions.begin(); it != allocated_regions.end();) {
+        auto& r = *it;
+
+        if (old_address > r.start && old_end < r.end) {
+            auto n = r;
+            n.start = new_address;
+            n.end = new_address + new_len;
+            auto nl = r;
+            nl.end = old_address;
+            auto nr = r;
+            nr.start = old_end;
+            it = allocated_regions.erase(it);
+
+            to_add.push_back(n);
+            it = allocated_regions.insert(it, nr);
+            it = allocated_regions.insert(it, nl);
+            it++;
+            continue;
+        }
+
+        bool is_start_in = r.start >= old_address && r.start < old_end;
+        bool is_end_in = r.end > old_address && r.end <= old_end;
+
+        auto n = r;
+        n.start = new_address + std::min((std::max(r.start, old_address) - old_address), new_len);
+        n.end = new_address + (is_increase ? new_len : std::min((std::min(r.end, old_end) - old_address), new_len));
+        if (is_start_in && is_end_in) {
+            to_add.push_back(n);
+            if (remove_src)
+                it = allocated_regions.erase(it);
+            else
+                it++;
+        } else if (is_start_in) {
+            to_add.push_back(n);
+            if (remove_src)
+                r.start = old_end;
+            it++;
+        } else if (is_end_in) {
+            to_add.push_back(n);
+            if (remove_src)
+                r.end = old_address;
+            it++;
+        } else {
+            it++;
+        }
+
+        if (is_increase && (is_start_in || is_end_in))
+            break;
+    }
+
+    ASSERT(!is_increase || to_add.size() <= 1);
+
+    remove_tracked_region(new_address, new_len);
+    for (auto add : to_add) {
+        add_tracked_region(add.start, add.end - add.start, add.flags, add.prot, add.shmem);
+    }
+}
+
 void Mapper::remove_tracked_region(u64 address, u64 len) {
     if (len == 0)
         return;
 
-    address = address & ~0x3ff;
+    address = address & ~0xfff;
     u64 end = address + len;
-    end = (end + 0x3ff) & ~0x3ff;
+    end = (end + 0xfff) & ~0xfff;
 
     for (auto it = allocated_regions.begin(); it != allocated_regions.end();) {
-        auto r = *it;
+        auto& r = *it;
         // Because the linked list is ordered, we know if the start address is greater than end,
         // then there is no more regions to remove with this unmap.
         if (end <= r.start || address == end) {
@@ -321,31 +354,31 @@ void Mapper::remove_tracked_region(u64 address, u64 len) {
 
         /// The unmapped region is entirely within an existing region.
         if (r.start <= address && r.end >= end) {
+            auto m = r;
             it = allocated_regions.erase(it);
 
-            if (address - r.start > 0) {
-                it = allocated_regions.insert(it, GuestRegion{r.start, address, r.flags, r.prot, r.shmem});
+            if (address - m.start > 0) {
+                it = allocated_regions.insert(it, GuestRegion{m.start, address, m.flags, m.prot, m.shmem});
                 it++;
             }
-            if (r.end - end > 0) {
-                it = allocated_regions.insert(it, GuestRegion{end, r.end, r.flags, r.prot, r.shmem});
+            if (m.end - end > 0) {
+                it = allocated_regions.insert(it, GuestRegion{end, m.end, m.flags, m.prot, m.shmem});
                 it++;
             }
             continue;
         }
 
-        auto& m = *it;
         /// The unmapped region removes from the left side.
-        if (m.start >= address && m.end > address) {
-            m.start = end;
+        if (r.start >= address && r.start < end) {
+            r.start = end;
         }
 
         /// The unmapped region removes from the right side.
-        if (m.start <= address && m.end > address) {
-            m.end = address;
+        if (r.end > address && r.end <= end) {
+            r.end = address;
         }
 
-        if (m.start >= m.end) {
+        if (r.start >= r.end) {
             it = allocated_regions.erase(it);
         } else {
             it++;

--- a/src/felix86/hle/mmap.cpp
+++ b/src/felix86/hle/mmap.cpp
@@ -1,4 +1,8 @@
 #include <cstdint>
+#include <cstdio>
+#include <iterator>
+#include <memory>
+#include <utility>
 #include <sys/mman.h>
 #include <sys/shm.h>
 #include "felix86/common/global.hpp"
@@ -33,10 +37,12 @@ void* Mapper::map32(void* addr, u64 size, int prot, int flags, int fd, u64 offse
             // and dirty solution of unallocating it in freelist so we can reallocate it
             ASSERT((u64)result < UINT32_MAX);
             freelist.deallocate((u64)result, size);
+            remove_tracked_region((u64)result, size);
         }
 
         void* mapping = freelist.allocate((u64)result, size);
         ASSERT_MSG(mapping == result, "Failed with mmap(%lx, %lx, %x, %x, %d, %lx)", addr, size, prot, flags, fd, offset);
+        add_tracked_region((u64)result, size, flags);
         return result;
     } else {
         void* address = freelist.allocate(0, size);
@@ -47,10 +53,13 @@ void* Mapper::map32(void* addr, u64 size, int prot, int flags, int fd, u64 offse
 
         void* result = mmap(address, size, prot, flags | MAP_FIXED_NOREPLACE, fd, offset);
         if (result == MAP_FAILED) {
+            // TODO: should this free memory back from freelist again?
             i64 error = -errno;
             WARN("Even though our freelist says we have memory at %lx-%lx, mmap failed with: %ld", (u64)address, (u64)address + size, error);
             return (void*)error;
         }
+        
+        add_tracked_region((u64)result, size, flags);
         ASSERT(result == address);
         return address;
     }
@@ -61,8 +70,12 @@ int Mapper::unmap32(void* addr, u64 size) {
     ASSERT((u64)addr < UINT32_MAX);
     int result = munmap(addr, size);
     if (result != -1) {
+        // unmap it from our freelist as well
         auto guard = freelist.lock();
-        freelist.deallocate((u64)addr, size); // unmap it from our freelist as well
+        freelist.deallocate((u64)addr, size); 
+        // also unmap it from the allocation tracker.
+        remove_tracked_region((u64)addr, size);
+        
         return result;
     } else {
         return -errno;
@@ -96,6 +109,10 @@ void* Mapper::remap32(void* old_address, u64 old_size, u64 new_size, int flags, 
 
         void* mapping = freelist.allocate((u64)result, new_size);
         ASSERT(mapping == result);
+
+        remove_tracked_region((u64)old_address, old_size);
+        add_tracked_region((u64)result, new_size, flags);
+
         return result;
     } else {
         // If we are here it means there's MREMAP_MAYMOVE and not MREMAP_FIXED
@@ -121,6 +138,9 @@ void* Mapper::remap32(void* old_address, u64 old_size, u64 new_size, int flags, 
             freelist.deallocate((u64)old_address, old_size);
         }
 
+        remove_tracked_region((u64)old_address, old_size);
+        add_tracked_region((u64)result, new_size, flags);
+
         ASSERT(result == new_address);
         return result;
     }
@@ -133,7 +153,14 @@ void* Mapper::map(bool mode32, void* addr, u64 size, int prot, int flags, int fd
         if ((flags & (MAP_FIXED | MAP_FIXED_NOREPLACE)) && (u64)addr < UINT32_MAX) {
             return map32(addr, size, prot, flags, fd, offset);
         } else {
-            return mmap(addr, size, prot, flags, fd, offset);
+            void* result = mmap(addr, size, prot, flags, fd, offset);
+
+            // On success, add tracked allocation.
+            if (result != (void*)-1) {
+                add_tracked_region((u64)result, size, flags);
+            }
+            
+            return result;
         }
     }
 }
@@ -145,7 +172,14 @@ int Mapper::unmap(bool mode32, void* addr, u64 size) {
         if ((u64)addr < UINT32_MAX) {
             return unmap32(addr, size);
         } else {
-            return munmap(addr, size);
+            int result = munmap(addr, size);
+
+            // On success, remove tracked allocation.
+            if (result != -1) {
+                remove_tracked_region((u64)addr, size);
+            }
+
+            return result;
         }
     }
 }
@@ -164,9 +198,185 @@ void* Mapper::remap(bool mode32, void* old_address, u64 old_size, u64 new_size, 
             void* result = ::mremap(old_address, old_size, new_size, flags, new_address);
             // we don't want an allocation in the low 32-bit area
             ASSERT((u64)result > UINT32_MAX);
+
+            // On success, remap the tracked allocation
+            if (result != (void*)-1) {
+                remove_tracked_region((u64)old_address, new_size);
+                add_tracked_region((u64)result, new_size, flags);
+            }
+            
             return result;
         }
     }
+}
+
+void Mapper::add_tracked_region(u64 address, u64 len, int flags, bool shmem) {
+    if (len == 0) return;
+    
+    // Assume 4KiB alignment.
+    address = address & ~0x3ff;
+    u64 end = address + len;
+    end = (end + 0x3ff) & ~0x3ff;
+    
+    // We assume at this point, that the allocated region will not overlap with any existing region.
+    // This works because any invocation to mmap cannot share the same region of address space as
+    // an already existing mapping UNLESS it has the MAP_FIXED flag, in which case the mapped region
+    // is removed before a call to this function.
+
+    AllocatedRegion v = AllocatedRegion { address, end, flags, shmem };
+
+    for (auto it = allocated_regions.begin(); it != allocated_regions.end(); it++) {
+        auto& r = *it;
+        bool can_merge = r.flags == flags && r.shmem == shmem;
+
+        // Region extends another leading.
+        if (can_merge && r.start == end) {
+            r.start = address;
+            return;
+        }
+        // Region extends another trailing.
+        else if (can_merge && r.end == address) {
+            auto r = *it;
+            r.end = end;
+            // Check if we can continue merging onwards.
+            it++;
+            for (;it != allocated_regions.end(); it++) {
+                if ((*it).start == r.end && (*it).shmem == shmem && (*it).flags == flags) {
+                    r.end = (*it).end;
+                    it = allocated_regions.erase(it);
+                } else if ((*it).start < r.end) {
+                    (*it).start = r.end;
+                    if ((*it).start >= (*it).end) {
+                        it = allocated_regions.erase(it);
+                    }
+                } else {
+                    break;
+                }
+            }
+            return;
+        }
+        // Overlap.
+        else if (
+            (r.start >= address && r.start < end)
+            || (r.end > address && r.end <= end)
+            || (address >= r.start && address < r.end)
+            || (end > r.start && end <= r.end)
+        ) {
+            remove_tracked_region(address, len);
+            add_tracked_region(address, len, flags, shmem);
+            return;
+        }
+        else if (end <= r.start) {
+            allocated_regions.insert(it, v);
+            return;
+        }
+    }
+
+    allocated_regions.emplace_back(v);
+}
+
+void Mapper::remove_tracked_region(u64 address, u64 len) {
+    if (len == 0) return;
+
+    address = address & ~0x3ff;
+    u64 end = address + len;
+    end = (end + 0x3ff) & ~0x3ff;
+
+    for (auto it = allocated_regions.begin(); it != allocated_regions.end();) {
+        auto r = *it;
+        // Because the linked list is ordered, we know if the start address is greater than end,
+        // then there is no more regions to remove with this unmap.
+        if (end <= r.start || address == end) {
+            break;
+        }
+
+        /// The mapped region is entirely within the unmapped region
+        if (address <= r.start && end >= r.end) {
+            it = allocated_regions.erase(it);
+            continue;
+        }
+
+        /// The unmapped region is entirely within an existing region.
+        if (r.start <= address && r.end >= end) {
+            it = allocated_regions.erase(it);
+
+            if (address - r.start > 0) {
+                it = allocated_regions.insert(it, AllocatedRegion {r.start, address, r.flags, r.shmem});
+                it++;
+            }
+            if (r.end - end > 0) {
+                it = allocated_regions.insert(it, AllocatedRegion {end, r.end, r.flags, r.shmem});
+                it++;
+            }
+            continue;
+        }
+
+        auto& m = *it;
+        /// The unmapped region removes from the left side.
+        if (m.start >= address && m.end > address) {
+            m.start = end;
+
+        }
+
+        /// The unmapped region removes from the right side.
+        if (m.start <= address && m.end > address) {
+            m.end = address;
+        }
+
+        if (m.start >= m.end) {
+            it = allocated_regions.erase(it);
+        } else {
+            it++;
+        }
+    }
+}
+
+void Mapper::reserve(u64 address, u64 len, int flags) {
+    // Ensure no race conditions.
+    auto guard = freelist.lock();
+
+    freelist.deallocate(address, len);
+    remove_tracked_region(address, len);
+    add_tracked_region(address, len, flags, false);
+}
+
+uint64_t Mapper::total_mapped_memory() {
+    // Ensure no race conditions.
+    auto guard = freelist.lock();
+
+    uint64_t total_bytes = 0;
+    for (auto r: allocated_regions) {
+        total_bytes += r.end - r.start;
+    }
+
+    return total_bytes;
+}
+
+bool Mapper::is_address_guest(void* address) {
+    // Ensure no race conditions.
+    auto guard = freelist.lock();
+
+    // TODO: could maybe be done faster using caching?
+    // Optionally, an ordered map could maybe be iterated faster?
+    u64 a = (u64)address;
+    for (auto r: allocated_regions) {
+        if (r.start <= a && a < r.end) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+std::vector<AllocatedRegion> Mapper::get_allocated_regions() {
+    // Ensure no race conditions.
+    auto guard = freelist.lock();
+
+    std::vector<AllocatedRegion> regions;
+    for (auto region: allocated_regions) {
+        regions.push_back(region);
+    }
+    return regions;
 }
 
 std::vector<std::pair<u32, u32>> Mapper::getRegions() {
@@ -212,7 +422,7 @@ int Mapper::shmat32(int shmid, void* address, int flags, u32* result_address) {
 
         // Since an address is provided by the application, we are going to assume it's
         // inside 32-bit address space and just check after the shmat
-        shm_mem = shmat(shmid, address, flags);
+        shm_mem = ::shmat(shmid, address, flags);
         if ((i64)shm_mem != -1) {
             u64 top_bits = (u64)shm_mem >> 32;
             ASSERT_MSG(top_bits == 0 || top_bits == 0xFFFF'FFFF, "shmat returned address in 64-bit address space?");
@@ -237,6 +447,8 @@ int Mapper::shmat32(int shmid, void* address, int flags, u32* result_address) {
     ASSERT_MSG(top_bits == 0 || top_bits == 0xFFFF'FFFF, "shmat returned address in 64-bit address space?");
     *result_address = (u32)(u64)shm_mem;
     page_to_shmid[(u32)(u64)shm_mem & ~0xFFFull] = shmid;
+    add_tracked_region((u64)shm_mem, size, flags, true);
+
     return 0;
 }
 
@@ -247,7 +459,6 @@ int Mapper::shmdt32(void* address) {
         return -EINVAL;
     }
 
-    auto guard = freelist.lock();
     int shmid = it->second;
     struct shmid_ds ds;
     if (shmctl(shmid, IPC_STAT, &ds) == 0) {
@@ -257,12 +468,13 @@ int Mapper::shmdt32(void* address) {
             WARN("shmctl returned size not aligned to a page: %lx, setting to new size: %lx", size, new_size);
             size = new_size;
         }
+        remove_tracked_region((u64)address, size);
         freelist.deallocate((u64)address, size);
     } else {
         WARN("shmctl returned error %d", -errno);
     }
 
-    int result = shmdt(address);
+    int result = ::shmdt(address);
 
     if (result == 0) {
         page_to_shmid.erase(it);

--- a/src/felix86/hle/mmap.cpp
+++ b/src/felix86/hle/mmap.cpp
@@ -485,13 +485,15 @@ void Mapper::move_tracked_region(u64 old_address, u64 old_len, u64 new_address, 
         if (old_address >= r.start && old_end <= r.end) {
             n.start = new_address;
             n.end = can_grow ? new_address + new_len : new_address + old_len;
-            n.offset += old_address - r.start;
+            if (can_grow)
+                n.offset += old_address - r.start;
             to_add.push_back(n);
             it++;
             continue;
         }
 
-        n.offset += (old_address - r.offset);
+        if (can_grow)
+            n.offset += (old_address - r.offset);
         n.start = new_address + std::min((std::max(r.start, old_address) - old_address), new_len);
         n.end = new_address + (is_increase && can_grow ? new_len : std::min((std::min(r.end, old_end) - old_address), new_len));
         to_add.push_back(n);
@@ -531,12 +533,12 @@ void Mapper::remove_tracked_region(u64 address, u64 len, bool only_shmat) {
 
         // When removing only shmat, base address must align and entire regions must be removed.
         if (only_shmat) {
-            if (r.start == address) {
-                allocated_regions.erase(it);
-                return;
+            if (r.start >= address && r.start < address + len) {
+                it = allocated_regions.erase(it);
+            } else {
+                it++;
             }
 
-            it++;
             continue;
         }
 

--- a/src/felix86/hle/mmap.cpp
+++ b/src/felix86/hle/mmap.cpp
@@ -9,6 +9,7 @@
 #include <sys/shm.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include "felix86/common/config.hpp"
 #include "felix86/common/global.hpp"
 #include "felix86/common/log.hpp"
 #include "felix86/common/utility.hpp"
@@ -369,29 +370,38 @@ int Mapper::shmdt(bool mode32, void* address) {
     if (result == 0) {
         if (size_known) {
             if ((u64)address <= UINT32_MAX) {
-                // We need to check what guest regions are actually allocated by shmat
-                // and add those regions to the freelist explicitly.
-                for (auto region : allocated_regions) {
-                    // Region is not allocated by shmat.
-                    if (region.shmid == -1) {
-                        continue;
-                    }
+                if (g_config.guest_memory_tracking_enabled) {
+                    // We need to check what guest regions are actually allocated by shmat
+                    // and add those regions to the freelist explicitly.
+                    for (auto region : allocated_regions) {
+                        // Region is not allocated by shmat.
+                        if (region.shmid == -1) {
+                            continue;
+                        }
 
-                    u64 start = (u64)address;
-                    u64 end = start + size;
+                        u64 start = (u64)address;
+                        u64 end = start + size;
 
-                    if (region.start >= end) {
-                        break;
-                    }
+                        if (region.start >= end) {
+                            break;
+                        }
 
-                    if (region.end < start) {
-                        continue;
-                    }
+                        if (region.end < start) {
+                            continue;
+                        }
 
-                    if (region.start >= start) {
-                        u64 size = end - region.start;
-                        freelist.deallocate((u64)region.start, size);
+                        if (region.start >= start) {
+                            u64 size = end - region.start;
+                            freelist.deallocate((u64)region.start, size);
+                        }
                     }
+                } else {
+                    // In case guest memory trackiong is disabled, then use an incorrect
+                    // but unlikely to cause bug solution of just assuming the entire
+                    // region may be deallocated by shmdt. This could cause a bug where memory
+                    // which is not freed is marked freed in the freelist, but solving this
+                    // without guest memory tracking is an issue in of itself.
+                    freelist.deallocate((u64)address, size);
                 }
             }
             remove_tracked_region((u64)address, size, true);
@@ -415,6 +425,10 @@ static bool can_guest_regions_merge(GuestRegion& l, GuestRegion& h) {
 }
 
 void Mapper::add_tracked_region(u64 address, u64 len, int prot, dev_t dev, ino_t ino, u64 offset, bool shmem, int shmid, bool anon) {
+    if (!g_config.guest_memory_tracking_enabled) {
+        return;
+    }
+
     if (len == 0)
         return;
 
@@ -459,6 +473,10 @@ void Mapper::add_tracked_region(u64 address, u64 len, int prot, dev_t dev, ino_t
 }
 
 void Mapper::move_tracked_region(u64 old_address, u64 old_len, u64 new_address, u64 new_len, bool remove_src, int new_prot, bool can_grow) {
+    if (!g_config.guest_memory_tracking_enabled) {
+        return;
+    }
+
     old_address &= ~0xfff;
     old_len = (old_len + 0xfff) & ~0xfff;
     new_address &= ~0xfff;
@@ -515,6 +533,10 @@ void Mapper::move_tracked_region(u64 old_address, u64 old_len, u64 new_address, 
 }
 
 void Mapper::remove_tracked_region(u64 address, u64 len, bool only_shmat) {
+    if (!g_config.guest_memory_tracking_enabled) {
+        return;
+    }
+
     if (len == 0)
         return;
 

--- a/src/felix86/hle/mmap.hpp
+++ b/src/felix86/hle/mmap.hpp
@@ -71,5 +71,5 @@ private:
 
     void add_tracked_region(u64 address, u64 len, int prot, dev_t dev, ino_t ino, u64 offset, bool shmem, int shmid, bool anon);
     void move_tracked_region(u64 old_address, u64 old_len, u64 new_address, u64 new_len, bool remove_source, int new_prot = -1, bool can_grow = true);
-    void remove_tracked_region(u64 address, u64 len);
+    void remove_tracked_region(u64 address, u64 len, bool only_shmat);
 };

--- a/src/felix86/hle/mmap.hpp
+++ b/src/felix86/hle/mmap.hpp
@@ -50,7 +50,7 @@ struct Mapper {
 
 private:
     Freelist freelist;
-    std::unordered_map<u32, int> page_to_shmid{};
+    std::unordered_map<u64, int> page_to_shmid{};
     /// Tracks the amount of currently mapped regions in memory.
     /// This will merge multiple mappings together.
     std::list<GuestRegion> allocated_regions;

--- a/src/felix86/hle/mmap.hpp
+++ b/src/felix86/hle/mmap.hpp
@@ -2,6 +2,7 @@
 
 #include <list>
 #include <unordered_map>
+#include <sys/types.h>
 #include "felix86/common/freelist.hpp"
 #include "felix86/common/types.hpp"
 
@@ -14,8 +15,18 @@ struct GuestRegion {
     int flags;
     /// Protection levels of the mapped region.
     int prot;
+    /// The file descriptor the region was mapped with.
+    int fd;
+    /// The device containing the file.
+    dev_t dev;
+    /// The associated inode.
+    ino_t ino;
     /// If the allocated region is shared memory.
     bool shmem;
+
+    inline bool has_associated_file() {
+        return ino != 0;
+    }
 };
 
 // TODO: add verifications using /proc/self/maps and optional debugging mode that always verifies
@@ -45,9 +56,6 @@ struct Mapper {
     /// Return the tracked allocated regions.
     std::vector<GuestRegion> get_guest_regions();
 
-    /// Marks memory as reserved and tracked by the guest.
-    void reserve(u64 address, u64 len, int flags, int prot);
-
 private:
     Freelist freelist;
     std::unordered_map<u64, int> page_to_shmid{};
@@ -59,7 +67,7 @@ private:
 
     friend void verifyRegions(Mapper& mapper, const std::vector<std::pair<u32, u32>>& regions);
 
-    void add_tracked_region(u64 address, u64 len, int flags, int prot, bool shmem = false);
+    void add_tracked_region(u64 address, u64 len, int flags, int prot, int fd, bool shmem = false);
     void move_tracked_region(u64 old_address, u64 old_len, u64 new_address, u64 new_len, bool remove_source);
     void remove_tracked_region(u64 address, u64 len);
 };

--- a/src/felix86/hle/mmap.hpp
+++ b/src/felix86/hle/mmap.hpp
@@ -60,5 +60,6 @@ private:
     friend void verifyRegions(Mapper& mapper, const std::vector<std::pair<u32, u32>>& regions);
 
     void add_tracked_region(u64 address, u64 len, int flags, int prot, bool shmem = false);
+    void move_tracked_region(u64 old_address, u64 old_len, u64 new_address, u64 new_len, bool remove_source);
     void remove_tracked_region(u64 address, u64 len);
 };

--- a/src/felix86/hle/mmap.hpp
+++ b/src/felix86/hle/mmap.hpp
@@ -5,13 +5,15 @@
 #include "felix86/common/freelist.hpp"
 #include "felix86/common/types.hpp"
 
-struct AllocatedRegion {
+struct GuestRegion {
     /// Inclusive end address.
     u64 start;
     /// Non inclusive end address.
     u64 end;
     /// Flags used for mapping this region.
     int flags;
+    /// Protection levels of the mapped region.
+    int prot;
     /// If the allocated region is shared memory.
     bool shmem;
 };
@@ -26,8 +28,8 @@ struct Mapper {
     int unmap32(void* addr, u64 size);
     [[nodiscard]] void* remap32(void* old_address, u64 old_size, u64 new_size, int flags, void* new_address);
 
-    int shmat32(int shmid, void* address, int flags, u32* result_address);
-    int shmdt32(void* address);
+    int shmat(bool mode32, int shmid, void* address, int flags, u64* result_address);
+    int shmdt(bool mode32, void* address);
 
     // Directly allocate in the freelist
     void* allocate(u64 addr, u64 size) {
@@ -41,22 +43,22 @@ struct Mapper {
     bool is_guest_address(void* address);
 
     /// Return the tracked allocated regions.
-    std::vector<AllocatedRegion> get_allocated_regions();
+    std::vector<GuestRegion> get_guest_regions();
 
     /// Marks memory as reserved and tracked by the guest.
-    void reserve(u64 address, u64 len, int flags);
+    void reserve(u64 address, u64 len, int flags, int prot);
 
 private:
     Freelist freelist;
     std::unordered_map<u32, int> page_to_shmid{};
     /// Tracks the amount of currently mapped regions in memory.
     /// This will merge multiple mappings together.
-    std::list<AllocatedRegion> allocated_regions;
+    std::list<GuestRegion> allocated_regions;
 
     std::vector<std::pair<u32, u32>> getRegions();
 
     friend void verifyRegions(Mapper& mapper, const std::vector<std::pair<u32, u32>>& regions);
 
-    void add_tracked_region(u64 address, u64 len, int flags, bool shmem = false);
+    void add_tracked_region(u64 address, u64 len, int flags, int prot, bool shmem = false);
     void remove_tracked_region(u64 address, u64 len);
 };

--- a/src/felix86/hle/mmap.hpp
+++ b/src/felix86/hle/mmap.hpp
@@ -38,7 +38,7 @@ struct Mapper {
     uint64_t total_mapped_memory();
 
     /// Is the provided address mapped by the guest.
-    bool is_address_guest(void* address);
+    bool is_guest_address(void* address);
 
     /// Return the tracked allocated regions.
     std::vector<AllocatedRegion> get_allocated_regions();

--- a/src/felix86/hle/mmap.hpp
+++ b/src/felix86/hle/mmap.hpp
@@ -5,6 +5,7 @@
 #include <sys/types.h>
 #include "felix86/common/freelist.hpp"
 #include "felix86/common/types.hpp"
+#include "felix86/common/utility.hpp"
 
 struct GuestRegion {
     /// Inclusive end address.
@@ -15,19 +16,17 @@ struct GuestRegion {
     int prot;
     /// The device containing the file.
     dev_t dev;
-    /// The associated inode.
+    /// The associated inode. This is an incrementing value in case of anonmyous mapping.
     ino_t ino;
     /// Offset into the associated file.
     u64 offset;
-    /// If the allocated region is shared memory.
-    bool shmem;
     /// The id if shmat was used for the guest region.
     // If the region is not allocated by shmat, this is -1.
     int shmid;
-
-    inline bool has_associated_file() {
-        return ino != 0;
-    }
+    /// If the allocated region is shared memory.
+    bool shmem;
+    /// Determines if the mapping is anonymous.
+    bool anonymous;
 };
 
 // TODO: add verifications using /proc/self/maps and optional debugging mode that always verifies
@@ -64,12 +63,13 @@ private:
     /// Tracks the amount of currently mapped regions in memory.
     /// This will merge multiple mappings together.
     std::list<GuestRegion> allocated_regions;
+    ino_t ino_anon_ctr{0};
 
     std::vector<std::pair<u32, u32>> getRegions();
 
     friend void verifyRegions(Mapper& mapper, const std::vector<std::pair<u32, u32>>& regions);
 
-    void add_tracked_region(u64 address, u64 len, int prot, dev_t dev, ino_t ino, u64 offset, bool shmem, int shmid);
-    void move_tracked_region(u64 old_address, u64 old_len, u64 new_address, u64 new_len, bool remove_source, int new_prot = -1);
+    void add_tracked_region(u64 address, u64 len, int prot, dev_t dev, ino_t ino, u64 offset, bool shmem, int shmid, bool anon);
+    void move_tracked_region(u64 old_address, u64 old_len, u64 new_address, u64 new_len, bool remove_source, int new_prot = -1, bool can_grow = true);
     void remove_tracked_region(u64 address, u64 len);
 };

--- a/src/felix86/hle/mmap.hpp
+++ b/src/felix86/hle/mmap.hpp
@@ -11,16 +11,14 @@ struct GuestRegion {
     u64 start;
     /// Non inclusive end address.
     u64 end;
-    /// Flags used for mapping this region.
-    int flags;
     /// Protection levels of the mapped region.
     int prot;
-    /// The file descriptor the region was mapped with.
-    int fd;
     /// The device containing the file.
     dev_t dev;
     /// The associated inode.
     ino_t ino;
+    /// Offset into the associated file.
+    u64 offset;
     /// If the allocated region is shared memory.
     bool shmem;
 
@@ -67,7 +65,7 @@ private:
 
     friend void verifyRegions(Mapper& mapper, const std::vector<std::pair<u32, u32>>& regions);
 
-    void add_tracked_region(u64 address, u64 len, int flags, int prot, int fd, bool shmem = false);
+    void add_tracked_region(u64 address, u64 len, int prot, dev_t dev, ino_t ino, u64 offset, bool shmem);
     void move_tracked_region(u64 old_address, u64 old_len, u64 new_address, u64 new_len, bool remove_source);
     void remove_tracked_region(u64 address, u64 len);
 };

--- a/src/felix86/hle/mmap.hpp
+++ b/src/felix86/hle/mmap.hpp
@@ -1,8 +1,20 @@
 #pragma once
 
+#include <list>
 #include <unordered_map>
 #include "felix86/common/freelist.hpp"
 #include "felix86/common/types.hpp"
+
+struct AllocatedRegion {
+    /// Inclusive end address.
+    u64 start;
+    /// Non inclusive end address.
+    u64 end;
+    /// Flags used for mapping this region.
+    int flags;
+    /// If the allocated region is shared memory.
+    bool shmem;
+};
 
 // TODO: add verifications using /proc/self/maps and optional debugging mode that always verifies
 struct Mapper {
@@ -22,11 +34,29 @@ struct Mapper {
         return freelist.allocate(addr, size);
     }
 
+    /// Return the total amount of bytes allocated by the guest.
+    uint64_t total_mapped_memory();
+
+    /// Is the provided address mapped by the guest.
+    bool is_address_guest(void* address);
+
+    /// Return the tracked allocated regions.
+    std::vector<AllocatedRegion> get_allocated_regions();
+
+    /// Marks memory as reserved and tracked by the guest.
+    void reserve(u64 address, u64 len, int flags);
+
 private:
     Freelist freelist;
     std::unordered_map<u32, int> page_to_shmid{};
+    /// Tracks the amount of currently mapped regions in memory.
+    /// This will merge multiple mappings together.
+    std::list<AllocatedRegion> allocated_regions;
 
     std::vector<std::pair<u32, u32>> getRegions();
 
     friend void verifyRegions(Mapper& mapper, const std::vector<std::pair<u32, u32>>& regions);
+
+    void add_tracked_region(u64 address, u64 len, int flags, bool shmem = false);
+    void remove_tracked_region(u64 address, u64 len);
 };

--- a/src/felix86/hle/mmap.hpp
+++ b/src/felix86/hle/mmap.hpp
@@ -21,6 +21,9 @@ struct GuestRegion {
     u64 offset;
     /// If the allocated region is shared memory.
     bool shmem;
+    /// The id if shmat was used for the guest region.
+    // If the region is not allocated by shmat, this is -1.
+    int shmid;
 
     inline bool has_associated_file() {
         return ino != 0;
@@ -32,6 +35,7 @@ struct Mapper {
     [[nodiscard]] void* map(bool mode32, void* addr, u64 size, int prot, int flags, int fd, u64 offset);
     int unmap(bool mode32, void* addr, u64 size);
     [[nodiscard]] void* remap(bool mode32, void* old_address, u64 old_size, u64 new_size, int flags, void* new_address);
+    int protect(void* addr, u64 size, int prot);
 
     [[nodiscard]] void* map32(void* addr, u64 size, int prot, int flags, int fd, u64 offset);
     int unmap32(void* addr, u64 size);
@@ -65,7 +69,7 @@ private:
 
     friend void verifyRegions(Mapper& mapper, const std::vector<std::pair<u32, u32>>& regions);
 
-    void add_tracked_region(u64 address, u64 len, int prot, dev_t dev, ino_t ino, u64 offset, bool shmem);
-    void move_tracked_region(u64 old_address, u64 old_len, u64 new_address, u64 new_len, bool remove_source);
+    void add_tracked_region(u64 address, u64 len, int prot, dev_t dev, ino_t ino, u64 offset, bool shmem, int shmid);
+    void move_tracked_region(u64 old_address, u64 old_len, u64 new_address, u64 new_len, bool remove_source, int new_prot = -1);
     void remove_tracked_region(u64 address, u64 len);
 };

--- a/src/felix86/hle/signals.cpp
+++ b/src/felix86/hle/signals.cpp
@@ -1,6 +1,5 @@
 #include <array>
 #include <csignal>
-#include <cstdio>
 #include <cstring>
 #include <bits/types/sigset_t.h>
 #include <sys/mman.h>
@@ -19,7 +18,6 @@
 #include "felix86/hle/ptrace.hpp"
 #include "felix86/hle/signals.hpp"
 #include "felix86/v2/recompiler.hpp"
-#include "felix86/hle/mmap.hpp"
 #undef si_pid
 
 #define FP_XSTATE_MAGIC1 0x46505853U

--- a/src/felix86/hle/signals.cpp
+++ b/src/felix86/hle/signals.cpp
@@ -1,5 +1,6 @@
 #include <array>
 #include <csignal>
+#include <cstdio>
 #include <cstring>
 #include <bits/types/sigset_t.h>
 #include <sys/mman.h>
@@ -18,6 +19,7 @@
 #include "felix86/hle/ptrace.hpp"
 #include "felix86/hle/signals.hpp"
 #include "felix86/v2/recompiler.hpp"
+#include "felix86/hle/mmap.hpp"
 #undef si_pid
 
 #define FP_XSTATE_MAGIC1 0x46505853U
@@ -1428,6 +1430,11 @@ static bool handle_breakpoint(ThreadState* current_state, siginfo_t* info, ucont
 }
 
 static bool handle_wild_sigsegv(ThreadState* current_state, siginfo_t* info, ucontext_t* context, u64 pc) {
+    // If the segmentation fault is caused by the guest
+    if (g_mapper->is_address_guest(info->si_addr)) {
+        return true;
+    }
+
     if (g_config.abort_sigsegv) {
         // A bug that may pop up if we have issues in our address cache or code cache is an invalid address
         // These would usually manifest as jump to null page or to a bogus address with upper bits set

--- a/src/felix86/hle/signals.cpp
+++ b/src/felix86/hle/signals.cpp
@@ -1287,7 +1287,7 @@ static void defer_signal(ThreadState* state, int sig, siginfo_t* info, void* ctx
     // Make our safepoints fault
     u64 effective_deferred_signals = state->deferred_signals & ~state->signal_mask.__val[0];
     if (effective_deferred_signals != 0) {
-        ASSERT(g_mapper->protect(state->deferred_fault_page, 4096, PROT_NONE) == 0);
+        ASSERT(::mprotect(state->deferred_fault_page, 4096, PROT_NONE) == 0);
     }
     state->effective_deferred_signals = effective_deferred_signals;
     SIGLOG("Deferring signal %s (%d) during RIP=%lx", sigdescr_np(sig), sig, state->GetRip());

--- a/src/felix86/hle/signals.cpp
+++ b/src/felix86/hle/signals.cpp
@@ -1430,11 +1430,6 @@ static bool handle_breakpoint(ThreadState* current_state, siginfo_t* info, ucont
 }
 
 static bool handle_wild_sigsegv(ThreadState* current_state, siginfo_t* info, ucontext_t* context, u64 pc) {
-    // If the segmentation fault is caused by the guest
-    if (g_mapper->is_address_guest(info->si_addr)) {
-        return true;
-    }
-
     if (g_config.abort_sigsegv) {
         // A bug that may pop up if we have issues in our address cache or code cache is an invalid address
         // These would usually manifest as jump to null page or to a bogus address with upper bits set

--- a/src/felix86/hle/signals.cpp
+++ b/src/felix86/hle/signals.cpp
@@ -15,6 +15,7 @@
 #include "felix86/common/types.hpp"
 #include "felix86/common/utility.hpp"
 #include "felix86/common/xsave.hpp"
+#include "felix86/hle/mmap.hpp"
 #include "felix86/hle/ptrace.hpp"
 #include "felix86/hle/signals.hpp"
 #include "felix86/v2/recompiler.hpp"
@@ -1286,7 +1287,7 @@ static void defer_signal(ThreadState* state, int sig, siginfo_t* info, void* ctx
     // Make our safepoints fault
     u64 effective_deferred_signals = state->deferred_signals & ~state->signal_mask.__val[0];
     if (effective_deferred_signals != 0) {
-        ASSERT(mprotect(state->deferred_fault_page, 4096, PROT_NONE) == 0);
+        ASSERT(g_mapper->protect(state->deferred_fault_page, 4096, PROT_NONE) == 0);
     }
     state->effective_deferred_signals = effective_deferred_signals;
     SIGLOG("Deferring signal %s (%d) during RIP=%lx", sigdescr_np(sig), sig, state->GetRip());

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -1,3 +1,4 @@
+#include <cassert>
 #include <csignal>
 #include <memory>
 #include <new>
@@ -342,6 +343,7 @@ static Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 a
             g_is_single_thread = false;
             Recompiler::invalidateRangeGlobal(0, UINT64_MAX & ~0xFFFull, "shmat happened");
         }
+        // TODO: use g_mapper here to track 64-bit shmat.
         result = SYSCALL(shmat, arg1, arg2, arg3);
         if (result >= 0 && ((u64)result) > mmap_min_addr() && result < UINT32_MAX) {
             WARN("shmat in 32-bit address space, this could cause problems with MAP_32BIT");
@@ -353,6 +355,7 @@ static Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 a
         break;
     }
     case felix86_riscv64_shmdt: {
+        // TODO: use g_mapper here to track 64-bit shmdt.
         if (arg1 > mmap_min_addr() && arg1 < UINT32_MAX) {
             WARN("shmdt in 32-bit address space, this could cause problems with MAP_32BIT");
         }
@@ -883,8 +886,8 @@ static Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 a
             // We need to also track fixed mappings in the 32-bit address space
             result = (ssize_t)g_mapper->map32((void*)arg1, arg2, arg3, (int)arg4, (int)arg5, arg6);
         } else {
-            // No need to use mapper
-            result = SYSCALL(mmap, arg1, arg2, arg3, (int)arg4, (int)arg5, arg6);
+            // Use mapper to track memory allocation.
+            result = (ssize_t)g_mapper->map(false, (void*)arg1, arg2, arg3, (int)arg4, (int)arg5, arg6);
         }
 
         // If there's any blocks in any threads that match this mmapped range they need to be invalidated
@@ -904,7 +907,8 @@ static Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 a
             // Track unmaps in the 32-bit address space for MAP_32BIT in 64-bit mode
             result = g_mapper->unmap32((void*)arg1, arg2);
         } else {
-            result = SYSCALL(munmap, arg1, arg2, arg3, arg4, arg5, arg6);
+            // Use mapper to track memory allocation.
+            result = g_mapper->unmap(false, (void*)arg1, arg2);
         }
 
         if (result == 0) {

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -343,8 +343,12 @@ static Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 a
             g_is_single_thread = false;
             Recompiler::invalidateRangeGlobal(0, UINT64_MAX & ~0xFFFull, "shmat happened");
         }
-        // TODO: use g_mapper here to track 64-bit shmat.
-        result = SYSCALL(shmat, arg1, arg2, arg3);
+        u64 result_address = 0;
+        result = g_mapper->shmat(false, (int)arg1, (void*)arg2, (int)arg3, &result_address);
+        if (result == 0) {
+            ASSERT(result_address != 0);
+            result = result_address;
+        }
         if (result >= 0 && ((u64)result) > mmap_min_addr() && result <= UINT32_MAX) {
             WARN("shmat in 32-bit address space, this could cause problems with MAP_32BIT");
         }
@@ -355,11 +359,10 @@ static Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 a
         break;
     }
     case felix86_riscv64_shmdt: {
-        // TODO: use g_mapper here to track 64-bit shmdt.
         if (arg1 > mmap_min_addr() && arg1 <= UINT32_MAX) {
             WARN("shmdt in 32-bit address space, this could cause problems with MAP_32BIT");
         }
-        result = SYSCALL(shmdt, arg1);
+        result = g_mapper->shmdt(false, (void*)arg1);
         break;
     }
     case felix86_riscv64_getsid: {
@@ -2754,16 +2757,17 @@ void felix86_syscall32(felix86_frame* frame, u32 rip_next) {
                 g_is_single_thread = false;
                 Recompiler::invalidateRangeGlobal(0, UINT64_MAX & ~0xFFFull, "shmat happened");
             }
-            u32 result_address = 0;
-            result = g_mapper->shmat32((int)arg1, (void*)arg2, (int)arg3, &result_address);
+            u64 result_address = 0;
+            result = g_mapper->shmat(true, (int)arg1, (void*)arg2, (int)arg3, &result_address);
             if (result == 0) {
                 ASSERT(result_address != 0);
+                ASSERT(result_address >> 32 == 0 || result_address >> 32 == 0xFFFF'FFFF);
                 result = result_address;
             }
             break;
         }
         case felix86_x86_32_shmdt: {
-            result = g_mapper->shmdt32((void*)arg1);
+            result = g_mapper->shmdt(true, (void*)arg1);
             break;
         }
         case felix86_x86_32_waitid: {

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -305,7 +305,7 @@ static Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 a
         break;
     }
     case felix86_riscv64_mprotect: {
-        result = SYSCALL(mprotect, arg1, arg2, arg3, arg4, arg5, arg6);
+        result = g_mapper->protect((void*)arg1, arg2, arg3);
         u64 start = arg1;
         u64 size = arg2;
         int prot = arg3;
@@ -1815,7 +1815,7 @@ static Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 a
         state->signal_mask.__val[0] = new_mask.__val[0];
         state->effective_deferred_signals |= state->deferred_signals & ~new_mask.__val[0];
         if (state->effective_deferred_signals) {
-            ASSERT(mprotect(state->deferred_fault_page, 4096, PROT_NONE) == 0);
+            ASSERT(g_mapper->protect(state->deferred_fault_page, 4096, PROT_NONE) == 0);
             state->signal_mask.__val[0] = old_mask.__val[0];
             ASSERT(syscall(SYS_rt_sigprocmask, SIG_SETMASK, &old_host_mask, nullptr, sizeof(old_host_mask)) == 0);
             SIGLOG("rt_sigsuspend returning without waiting, a deferred signal is already deliverable");

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -1815,7 +1815,7 @@ static Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 a
         state->signal_mask.__val[0] = new_mask.__val[0];
         state->effective_deferred_signals |= state->deferred_signals & ~new_mask.__val[0];
         if (state->effective_deferred_signals) {
-            ASSERT(g_mapper->protect(state->deferred_fault_page, 4096, PROT_NONE) == 0);
+            ASSERT(::mprotect(state->deferred_fault_page, 4096, PROT_NONE) == 0);
             state->signal_mask.__val[0] = old_mask.__val[0];
             ASSERT(syscall(SYS_rt_sigprocmask, SIG_SETMASK, &old_host_mask, nullptr, sizeof(old_host_mask)) == 0);
             SIGLOG("rt_sigsuspend returning without waiting, a deferred signal is already deliverable");

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -345,7 +345,7 @@ static Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 a
         }
         // TODO: use g_mapper here to track 64-bit shmat.
         result = SYSCALL(shmat, arg1, arg2, arg3);
-        if (result >= 0 && ((u64)result) > mmap_min_addr() && result < UINT32_MAX) {
+        if (result >= 0 && ((u64)result) > mmap_min_addr() && result <= UINT32_MAX) {
             WARN("shmat in 32-bit address space, this could cause problems with MAP_32BIT");
         }
         break;
@@ -356,7 +356,7 @@ static Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 a
     }
     case felix86_riscv64_shmdt: {
         // TODO: use g_mapper here to track 64-bit shmdt.
-        if (arg1 > mmap_min_addr() && arg1 < UINT32_MAX) {
+        if (arg1 > mmap_min_addr() && arg1 <= UINT32_MAX) {
             WARN("shmdt in 32-bit address space, this could cause problems with MAP_32BIT");
         }
         result = SYSCALL(shmdt, arg1);
@@ -877,18 +877,13 @@ static Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 a
             g_is_single_thread = false;
             Recompiler::invalidateRangeGlobal(0, UINT64_MAX & ~0xFFFull, "MAP_SHARED happened");
         }
-
-        bool is_fixed = (flags & MAP_FIXED) || (flags & MAP_FIXED_NOREPLACE);
-        if ((flags & MAP_32BIT) || (is_fixed && arg1 < UINT32_MAX) || mode32) {
-            // The MAP_32BIT flag is x86 only so we need to emulate it
-            // For example, Mono tries to use it to allocate code cache pages near the executable so that it can use
-            // +-2GiB jumps. If it doesn't get them near enough it will eventually crash and die.
-            // We need to also track fixed mappings in the 32-bit address space
-            result = (ssize_t)g_mapper->map32((void*)arg1, arg2, arg3, (int)arg4, (int)arg5, arg6);
-        } else {
-            // Use mapper to track memory allocation.
-            result = (ssize_t)g_mapper->map(false, (void*)arg1, arg2, arg3, (int)arg4, (int)arg5, arg6);
-        }
+        // The MAP_32BIT flag is x86 only so we need to emulate it
+        // For example, Mono tries to use it to allocate code cache pages near the executable so that it can use
+        // +-2GiB jumps. If it doesn't get them near enough it will eventually crash and die.
+        // We need to also track fixed mappings in the 32-bit address space
+        bool is_fixed = ((flags & MAP_FIXED) || (flags & MAP_FIXED_NOREPLACE)) && arg1 <= UINT32_MAX;
+        bool is_mmap32 = is_fixed || (flags & MAP_32BIT) || mode32;
+        result = (ssize_t)g_mapper->map(is_mmap32, (void*)arg1, arg2, arg3, (int)arg4, (int)arg5, arg6);
 
         // If there's any blocks in any threads that match this mmapped range they need to be invalidated
         if (result > 0) {
@@ -903,13 +898,9 @@ static Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 a
         break;
     }
     case felix86_riscv64_munmap: {
-        if (arg1 < UINT32_MAX || mode32) {
-            // Track unmaps in the 32-bit address space for MAP_32BIT in 64-bit mode
-            result = g_mapper->unmap32((void*)arg1, arg2);
-        } else {
-            // Use mapper to track memory allocation.
-            result = g_mapper->unmap(false, (void*)arg1, arg2);
-        }
+        // Track unmaps in the 32-bit address space for MAP_32BIT in 64-bit mode
+        bool is_munmap32 = arg1 <= UINT32_MAX || mode32;
+        result = g_mapper->unmap(is_munmap32, (void*)arg1, arg2);
 
         if (result == 0) {
             Recompiler::invalidateRangeGlobal(arg1, arg1 + arg2, "munmap");

--- a/src/felix86/hle/thunks.cpp
+++ b/src/felix86/hle/thunks.cpp
@@ -1,3 +1,5 @@
+#include "felix86/common/global.hpp"
+#include "felix86/hle/mmap.hpp"
 #include "felix86/hle/thunks.hpp"
 
 // TODO: this file is messy. Split it up to separate files per library once our thunking implementation is more concrete
@@ -408,7 +410,7 @@ static void* generate_guest_pointer(const char* name, u64 host_ptr) {
     // We can't put this code in code cache, because it needs to outlive potential code cache clears
     u8* memory = state->x86_trampoline_storage;
     // Our recompiler marks guest code as PROT_READ, we need to undo this as it may have marked previous trampolines
-    mprotect((u8*)((u64)memory & ~0xFFFull), 4096, PROT_READ | PROT_WRITE);
+    g_mapper->protect((u8*)((u64)memory & ~0xFFFull), 4096, PROT_READ | PROT_WRITE);
 
     // 0f 01 39 ; invlpg [rcx] ; see handlers.cpp -- invlpg (magic instruction that generates jump to host code)
     // 00 00 00 00 00 00 00 00 ; pointer we jump to
@@ -1308,7 +1310,7 @@ void Thunks::runConstructor(const char* lib, GuestPointers* pointers) {
             ASSERT_MSG(host_ptr != 0, "Could not find host libwayland-client pointer for %s", host_ptr);
             // Interfaces are placed in RO memory but we need to change their values to match our host library
             // So hack away the protection
-            mprotect((void*)((u64)ptr & ~0xFFFull), 4096, PROT_READ | PROT_WRITE);
+            g_mapper->protect((void*)((u64)ptr & ~0xFFFull), 4096, PROT_READ | PROT_WRITE);
             memcpy((void*)ptr, (void*)host_ptr, sizeof(wl_interface));
             VERBOSE("libwayland-client thunk: %s set to %p (guest ptr: %p)", name, host_ptr, ptr);
 

--- a/src/felix86/hle/thunks.cpp
+++ b/src/felix86/hle/thunks.cpp
@@ -410,7 +410,7 @@ static void* generate_guest_pointer(const char* name, u64 host_ptr) {
     // We can't put this code in code cache, because it needs to outlive potential code cache clears
     u8* memory = state->x86_trampoline_storage;
     // Our recompiler marks guest code as PROT_READ, we need to undo this as it may have marked previous trampolines
-    g_mapper->protect((u8*)((u64)memory & ~0xFFFull), 4096, PROT_READ | PROT_WRITE);
+    ::mprotect((u8*)((u64)memory & ~0xFFFull), 4096, PROT_READ | PROT_WRITE);
 
     // 0f 01 39 ; invlpg [rcx] ; see handlers.cpp -- invlpg (magic instruction that generates jump to host code)
     // 00 00 00 00 00 00 00 00 ; pointer we jump to
@@ -1310,7 +1310,7 @@ void Thunks::runConstructor(const char* lib, GuestPointers* pointers) {
             ASSERT_MSG(host_ptr != 0, "Could not find host libwayland-client pointer for %s", host_ptr);
             // Interfaces are placed in RO memory but we need to change their values to match our host library
             // So hack away the protection
-            g_mapper->protect((void*)((u64)ptr & ~0xFFFull), 4096, PROT_READ | PROT_WRITE);
+            ::mprotect((void*)((u64)ptr & ~0xFFFull), 4096, PROT_READ | PROT_WRITE);
             memcpy((void*)ptr, (void*)host_ptr, sizeof(wl_interface));
             VERBOSE("libwayland-client thunk: %s set to %p (guest ptr: %p)", name, host_ptr, ptr);
 

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -14,6 +14,7 @@
 #include "felix86/common/types.hpp"
 #include "felix86/common/utility.hpp"
 #include "felix86/emulator.hpp"
+#include "felix86/hle/mmap.hpp"
 #include "felix86/hle/ptrace.hpp"
 #include "felix86/hle/syscall.hpp"
 #include "felix86/v2/handlers.hpp"
@@ -557,7 +558,7 @@ void Recompiler::markPagesAsReadOnly(u64 start, u64 end) {
     u64 start_page = start & ~0xFFFull;
     u64 end_page = (end + 0xFFF) & ~0xFFFull;
     u64 size = end_page - start_page;
-    int result = mprotect((void*)start_page, size, PROT_READ);
+    int result = g_mapper->protect((void*)start_page, size, PROT_READ);
     if (result != 0) {
         ERROR("Failed to protect pages %016lx-%016lx -- Error: %s", start_page, end_page, strerror(errno));
     }

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -558,7 +558,7 @@ void Recompiler::markPagesAsReadOnly(u64 start, u64 end) {
     u64 start_page = start & ~0xFFFull;
     u64 end_page = (end + 0xFFF) & ~0xFFFull;
     u64 size = end_page - start_page;
-    int result = g_mapper->protect((void*)start_page, size, PROT_READ);
+    int result = ::mprotect((void*)start_page, size, PROT_READ);
     if (result != 0) {
         ERROR("Failed to protect pages %016lx-%016lx -- Error: %s", start_page, end_page, strerror(errno));
     }

--- a/tests/Unit/mmap.cpp
+++ b/tests/Unit/mmap.cpp
@@ -1823,3 +1823,236 @@ CATCH_TEST_CASE("Map64DoesNotReserveLowMemory", "[mmap]") {
     munmap(low, 0x1000);
     SUCCESS_MESSAGE();
 }
+
+CATCH_TEST_CASE("Map64DoesNotConsumeFreelist", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    verifyRegions(mapper, {{(u32)mmap_min_addr(), UINT32_MAX}});
+
+    void* address = nullptr;
+    MMAP_AT_R(address, 0x10000, PROT_NONE, 0);
+    CATCH_REQUIRE(address != MAP_FAILED);
+    CATCH_REQUIRE((u64)address > UINT32_MAX);
+
+    verifyRegions(mapper, {{(u32)mmap_min_addr(), UINT32_MAX}});
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("Remap64IntoLowDoesNotFreeUnrelated", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    const u64 high = 0x200050000ull;
+    CATCH_REQUIRE(mapper.map(true, (void*)0x50000, 0x1000, PROT_NONE, FCOMMON_FIXED, -1, 0) == (void*)0x50000);
+    CATCH_REQUIRE(mapper.map(false, (void*)high, 0x1000, PROT_NONE, FCOMMON_FIXED, -1, 0) == (void*)high);
+    unmap_me.push_back({0x50000, 0x1000});
+
+    CATCH_REQUIRE(mapper.remap(false, (void*)high, 0x1000, 0x1000, MREMAP_MAYMOVE | MREMAP_FIXED, (void*)0x60000) == (void*)0x60000);
+    unmap_me.push_back({0x60000, 0x1000});
+
+    verifyRegions(mapper, {{(u32)mmap_min_addr(), 0x4ffff}, {0x51000, 0x5ffff}, {0x61000, UINT32_MAX}});
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("FreelistTopOfAddressSpace", "[mmap32]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = true;
+
+    MMAP_AT(0xffffe000, 0x1000, PROT_NONE, 0);
+    verifyRegions(mapper, {{(u32)mmap_min_addr(), 0xffffdfff}, {0xfffff000, UINT32_MAX}});
+
+    MMAP_AT(0xffffc000, 0x4000, PROT_NONE, 0);
+    verifyRegions(mapper, {{(u32)mmap_min_addr(), 0xffffbfff}});
+
+    UNMAP_AT(0xffffc000, 0x4000);
+    verifyRegions(mapper, {{(u32)mmap_min_addr(), UINT32_MAX}});
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MremapGrowInPlaceExtendsRegion", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    char path[] = "/tmp/felix86_mmap_testXXXXXX";
+    int fd = mkstemp(path);
+    CATCH_REQUIRE(fd != -1);
+    CATCH_REQUIRE(ftruncate(fd, 0x10000) == 0);
+    unlink(path);
+
+    int flags = MAP_PRIVATE | MAP_FIXED;
+    CATCH_REQUIRE(mapper.map(g_mode32, (void*)0x30000, 0x1000, PROT_READ, flags, fd, 0x1000) == (void*)0x30000);
+    CATCH_REQUIRE(mapper.remap(g_mode32, (void*)0x30000, 0x1000, 0x2000, 0, (void*)0x30000) == (void*)0x30000);
+    unmap_me.push_back({0x30000, 0x2000});
+
+    auto regions = mapper.get_guest_regions();
+    CATCH_REQUIRE(regions.size() == 1);
+    CATCH_REQUIRE(regions[0].start == 0x30000);
+    CATCH_REQUIRE(regions[0].end == 0x32000);
+    CATCH_REQUIRE(regions[0].offset == 0x1000);
+
+    close(fd);
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MremapGrowKeepsOwnIdentity", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    char path[] = "/tmp/felix86_mmap_testXXXXXX";
+    int fd = mkstemp(path);
+    CATCH_REQUIRE(fd != -1);
+    CATCH_REQUIRE(ftruncate(fd, 0x10000) == 0);
+    unlink(path);
+
+    CATCH_REQUIRE(mapper.map(g_mode32, (void*)0x30000, 0x1000, PROT_READ, MAP_PRIVATE | MAP_FIXED, fd, 0x1000) == (void*)0x30000);
+    unmap_me.push_back({0x30000, 0x1000});
+    MMAP_AT(0x50000, 0x1000, PROT_READ, 0);
+
+    CATCH_REQUIRE(mapper.remap(g_mode32, (void*)0x50000, 0x1000, 0x2000, 0, (void*)0x50000) == (void*)0x50000);
+    unmap_me.push_back({0x50000, 0x2000});
+
+    auto regions = mapper.get_guest_regions();
+    CATCH_REQUIRE(regions.size() == 2);
+    CATCH_REQUIRE(regions[1].start == 0x50000);
+    CATCH_REQUIRE(regions[1].end == 0x52000);
+    CATCH_REQUIRE(regions[1].ino == 0);
+    CATCH_REQUIRE(regions[1].offset == 0);
+
+    close(fd);
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MProtectSplitKeepsFileOffset", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    char path[] = "/tmp/felix86_mmap_testXXXXXX";
+    int fd = mkstemp(path);
+    CATCH_REQUIRE(fd != -1);
+    CATCH_REQUIRE(ftruncate(fd, 0x10000) == 0);
+    unlink(path);
+
+    CATCH_REQUIRE(mapper.map(g_mode32, (void*)0x30000, 0x2000, PROT_READ, MAP_PRIVATE | MAP_FIXED, fd, 0x1000) == (void*)0x30000);
+    unmap_me.push_back({0x30000, 0x2000});
+
+    CATCH_REQUIRE(mapper.protect((void*)0x30000, 0x1000, PROT_NONE) == 0);
+
+    auto regions = mapper.get_guest_regions();
+    CATCH_REQUIRE(regions.size() == 2);
+    CATCH_REQUIRE(regions[0].prot == PROT_NONE);
+    CATCH_REQUIRE(regions[0].offset == 0x1000);
+    CATCH_REQUIRE(regions[1].prot == PROT_READ);
+    CATCH_REQUIRE(regions[1].offset == 0x2000);
+
+    close(fd);
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MProtectSameProtDoesNotSplit", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = true;
+
+    MMAP_AT(0x20000, 0x30000, PROT_NONE, 0);
+
+    CATCH_REQUIRE(mapper.protect((void*)0x30000, 0x10000, PROT_NONE) == 0);
+
+    verifyGuestRegions(mapper, {
+        {0x20000, 0x30000, PROT_NONE},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MremapSameSizeInPlaceDoesNotSplit", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = true;
+
+    MMAP_AT(0x20000, 0x30000, PROT_NONE, 0);
+
+    CATCH_REQUIRE(mapper.remap(g_mode32, (void*)0x30000, 0x10000, 0x10000, 0, (void*)0x30000) == (void*)0x30000);
+
+    verifyGuestRegions(mapper, {
+        {0x20000, 0x30000, PROT_NONE},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MProtectPastEndAppliesPrefix", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = true;
+
+    MMAP_AT(0x20000, 0x1000, PROT_NONE, 0);
+
+    CATCH_REQUIRE(mapper.protect((void*)0x20000, 0x2000, PROT_READ) != 0);
+
+    verifyGuestRegions(mapper, {
+        {0x20000, 0x1000, PROT_READ},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("SharedAnonymousMappingsDoNotMerge", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    int flags = MAP_ANONYMOUS | MAP_SHARED | MAP_FIXED;
+    CATCH_REQUIRE(mapper.map(g_mode32, (void*)0x30000, 0x1000, PROT_READ, flags, -1, 0) == (void*)0x30000);
+    CATCH_REQUIRE(mapper.map(g_mode32, (void*)0x31000, 0x1000, PROT_READ, flags, -1, 0) == (void*)0x31000);
+    unmap_me.push_back({0x30000, 0x2000});
+
+    auto regions = mapper.get_guest_regions();
+    CATCH_REQUIRE(regions.size() == 2);
+    CATCH_REQUIRE(regions[0].end == 0x31000);
+    CATCH_REQUIRE(regions[1].start == 0x31000);
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("SharedAnonymousMappingMergesWithItself", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    int flags = MAP_ANONYMOUS | MAP_SHARED | MAP_FIXED;
+    CATCH_REQUIRE(mapper.map(g_mode32, (void*)0x30000, 0x2000, PROT_READ, flags, -1, 0) == (void*)0x30000);
+    unmap_me.push_back({0x30000, 0x2000});
+
+    CATCH_REQUIRE(mapper.protect((void*)0x30000, 0x1000, PROT_NONE) == 0);
+    CATCH_REQUIRE(mapper.get_guest_regions().size() == 2);
+
+    CATCH_REQUIRE(mapper.protect((void*)0x30000, 0x1000, PROT_READ) == 0);
+
+    auto regions = mapper.get_guest_regions();
+    CATCH_REQUIRE(regions.size() == 1);
+    CATCH_REQUIRE(regions[0].start == 0x30000);
+    CATCH_REQUIRE(regions[0].end == 0x32000);
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}

--- a/tests/Unit/mmap.cpp
+++ b/tests/Unit/mmap.cpp
@@ -678,6 +678,38 @@ CATCH_TEST_CASE("MremapUnmappedSourceReturnsError", "[mmap32]") {
     SUCCESS_MESSAGE();
 }
 
+CATCH_TEST_CASE("FreelistTopOfAddressSpace", "[mmap32]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = true;
+
+    MMAP_AT(0xffffe000, 0x1000, PROT_NONE, 0);
+    verifyRegions(mapper, {{(u32)mmap_min_addr(), 0xffffdfff}, {0xfffff000, UINT32_MAX}});
+
+    MMAP_AT(0xffffc000, 0x4000, PROT_NONE, 0);
+    verifyRegions(mapper, {{(u32)mmap_min_addr(), 0xffffbfff}});
+
+    UNMAP_AT(0xffffc000, 0x4000);
+    verifyRegions(mapper, {{(u32)mmap_min_addr(), UINT32_MAX}});
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("FreelistFullThenUnmap", "[mmap32]") {
+    Mapper mapper;
+    g_mode32 = true;
+
+    u64 min = mmap_min_addr();
+    CATCH_REQUIRE(mapper.allocate(min, (u64)UINT32_MAX + 1 - min) == (void*)min);
+    verifyRegions(mapper, {});
+
+    CATCH_REQUIRE(mapper.unmap(true, (void*)0x100000, 0x1000) == 0);
+    verifyRegions(mapper, {{0x100000, 0x100fff}});
+
+    SUCCESS_MESSAGE();
+}
+
 CATCH_TEST_CASE("Simple1", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
@@ -1775,36 +1807,6 @@ CATCH_TEST_CASE("MremapGrowFromInsideRegion", "[mmap]") {
     SUCCESS_MESSAGE();
 }
 
-CATCH_TEST_CASE("HintlessAllocWithBlockAtZero", "[mmap32]") {
-    Mapper mapper;
-    g_mode32 = true;
-
-    CATCH_REQUIRE(mapper.allocate(0x200000, (u64)UINT32_MAX + 1 - 0x200000) == (void*)0x200000);
-    CATCH_REQUIRE(mapper.unmap(true, (void*)0, 0x10000) == 0);
-
-    verifyRegions(mapper, {{(u32)mmap_min_addr(), 0x1fffff}});
-
-    void* address = mapper.allocate(0, 0x1000);
-    CATCH_REQUIRE((i64)address > 0);
-    CATCH_REQUIRE((u64)address >= mmap_min_addr());
-
-    SUCCESS_MESSAGE();
-}
-
-CATCH_TEST_CASE("FreelistFullThenUnmap", "[mmap32]") {
-    Mapper mapper;
-    g_mode32 = true;
-
-    u64 min = mmap_min_addr();
-    CATCH_REQUIRE(mapper.allocate(min, (u64)UINT32_MAX + 1 - min) == (void*)min);
-    verifyRegions(mapper, {});
-
-    CATCH_REQUIRE(mapper.unmap(true, (void*)0x100000, 0x1000) == 0);
-    verifyRegions(mapper, {{0x100000, 0x100fff}});
-
-    SUCCESS_MESSAGE();
-}
-
 CATCH_TEST_CASE("Map64DoesNotReserveLowMemory", "[mmap]") {
     Mapper mapper;
     g_mode32 = false;
@@ -1852,28 +1854,12 @@ CATCH_TEST_CASE("Remap64IntoLowDoesNotFreeUnrelated", "[mmap]") {
     CATCH_REQUIRE(mapper.map(false, (void*)high, 0x1000, PROT_NONE, FCOMMON_FIXED, -1, 0) == (void*)high);
     unmap_me.push_back({0x50000, 0x1000});
 
+    verifyRegions(mapper, {{(u32)mmap_min_addr(), 0x4ffff}, {0x51000, UINT32_MAX}});
+
     CATCH_REQUIRE(mapper.remap(false, (void*)high, 0x1000, 0x1000, MREMAP_MAYMOVE | MREMAP_FIXED, (void*)0x60000) == (void*)0x60000);
     unmap_me.push_back({0x60000, 0x1000});
 
     verifyRegions(mapper, {{(u32)mmap_min_addr(), 0x4ffff}, {0x51000, 0x5ffff}, {0x61000, UINT32_MAX}});
-
-    MUNMAP_ALL();
-    SUCCESS_MESSAGE();
-}
-
-CATCH_TEST_CASE("FreelistTopOfAddressSpace", "[mmap32]") {
-    std::vector<std::pair<u32, u32>> unmap_me;
-    Mapper mapper;
-    g_mode32 = true;
-
-    MMAP_AT(0xffffe000, 0x1000, PROT_NONE, 0);
-    verifyRegions(mapper, {{(u32)mmap_min_addr(), 0xffffdfff}, {0xfffff000, UINT32_MAX}});
-
-    MMAP_AT(0xffffc000, 0x4000, PROT_NONE, 0);
-    verifyRegions(mapper, {{(u32)mmap_min_addr(), 0xffffbfff}});
-
-    UNMAP_AT(0xffffc000, 0x4000);
-    verifyRegions(mapper, {{(u32)mmap_min_addr(), UINT32_MAX}});
 
     MUNMAP_ALL();
     SUCCESS_MESSAGE();
@@ -1921,6 +1907,9 @@ CATCH_TEST_CASE("MremapGrowKeepsOwnIdentity", "[mmap]") {
     unmap_me.push_back({0x30000, 0x1000});
     MMAP_AT(0x50000, 0x1000, PROT_READ, 0);
 
+    auto old_regions = mapper.get_guest_regions();
+    ino_t ino = old_regions[1].ino;
+
     CATCH_REQUIRE(mapper.remap(g_mode32, (void*)0x50000, 0x1000, 0x2000, 0, (void*)0x50000) == (void*)0x50000);
     unmap_me.push_back({0x50000, 0x2000});
 
@@ -1928,7 +1917,7 @@ CATCH_TEST_CASE("MremapGrowKeepsOwnIdentity", "[mmap]") {
     CATCH_REQUIRE(regions.size() == 2);
     CATCH_REQUIRE(regions[1].start == 0x50000);
     CATCH_REQUIRE(regions[1].end == 0x52000);
-    CATCH_REQUIRE(regions[1].ino == 0);
+    CATCH_REQUIRE(regions[1].ino == ino);
     CATCH_REQUIRE(regions[1].offset == 0);
 
     close(fd);
@@ -1992,23 +1981,6 @@ CATCH_TEST_CASE("MremapSameSizeInPlaceDoesNotSplit", "[mmap]") {
 
     verifyGuestRegions(mapper, {
         {0x20000, 0x30000, PROT_NONE},
-    });
-
-    MUNMAP_ALL();
-    SUCCESS_MESSAGE();
-}
-
-CATCH_TEST_CASE("MProtectPastEndAppliesPrefix", "[mmap]") {
-    std::vector<std::pair<u32, u32>> unmap_me;
-    Mapper mapper;
-    g_mode32 = true;
-
-    MMAP_AT(0x20000, 0x1000, PROT_NONE, 0);
-
-    CATCH_REQUIRE(mapper.protect((void*)0x20000, 0x2000, PROT_READ) != 0);
-
-    verifyGuestRegions(mapper, {
-        {0x20000, 0x1000, PROT_READ},
     });
 
     MUNMAP_ALL();

--- a/tests/Unit/mmap.cpp
+++ b/tests/Unit/mmap.cpp
@@ -44,7 +44,7 @@ static const int FCOMMON_FIXED = FCOMMON | MAP_FIXED;
 #define MREMAP(old_addr, old_size, new_size, flags) \
     do {\
         void* address = mapper.remap(g_mode32, (void*)old_addr, old_size, new_size, flags, 0); \
-        CATCH_REQUIRE(address != (void*)-1); \
+        CATCH_REQUIRE(address == (void*)old_addr); \
         unmap_me.push_back({(u64)address, new_size}); \
     } while(0)
 
@@ -80,6 +80,9 @@ struct GuestRegionExpected {
 static void verifyGuestRegions(Mapper& mapper, const std::vector<GuestRegionExpected>& expected_regions) {
     auto guest_regions = mapper.get_guest_regions();
     int found_regions = 0;
+    for (auto& region : guest_regions) {
+        printf("[%lx, %lx], %lx, %lx, %b\n", region.start, region.end, region.prot, region.flags, region.shmem);
+    }
     for (const auto region : expected_regions) {
         for (const auto guest_region : guest_regions) {
             bool yes = true;
@@ -967,6 +970,7 @@ CATCH_TEST_CASE("MremapMoveDoNotUnmap", "[mmap]") {
     MREMAP_AT(0x13000, 0x10000, 0x40000, 0x10000, MREMAP_FIXED | MREMAP_MAYMOVE | MREMAP_DONTUNMAP);
 
     verifyGuestRegions(mapper, { 
+        {0x13000, 0x10000, PROT_NONE, FCOMMON_FIXED},
         {0x40000, 0x10000, PROT_NONE, FCOMMON_FIXED},
     });
 
@@ -1127,7 +1131,7 @@ CATCH_TEST_CASE("MremapMoveGrowMiddle", "[mmap]") {
     SUCCESS_MESSAGE();
 }
 
-CATCH_TEST_CASE("MremapDeleteMiddle", "[mmap]") {
+CATCH_TEST_CASE("MremapShrinkMiddle", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
     g_mode32 = false;
@@ -1149,7 +1153,7 @@ CATCH_TEST_CASE("MremapDeleteMiddle", "[mmap]") {
     SUCCESS_MESSAGE();
 }
 
-CATCH_TEST_CASE("MremapOverwriteDelete", "[mmap]") {
+CATCH_TEST_CASE("MremapShrinkDifferentPriv", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
     g_mode32 = false;

--- a/tests/Unit/mmap.cpp
+++ b/tests/Unit/mmap.cpp
@@ -1774,3 +1774,52 @@ CATCH_TEST_CASE("MremapGrowFromInsideRegion", "[mmap]") {
     MUNMAP_ALL();
     SUCCESS_MESSAGE();
 }
+
+CATCH_TEST_CASE("HintlessAllocWithBlockAtZero", "[mmap32]") {
+    Mapper mapper;
+    g_mode32 = true;
+
+    CATCH_REQUIRE(mapper.allocate(0x200000, (u64)UINT32_MAX + 1 - 0x200000) == (void*)0x200000);
+    CATCH_REQUIRE(mapper.unmap(true, (void*)0, 0x10000) == 0);
+
+    verifyRegions(mapper, {{(u32)mmap_min_addr(), 0x1fffff}});
+
+    void* address = mapper.allocate(0, 0x1000);
+    CATCH_REQUIRE((i64)address > 0);
+    CATCH_REQUIRE((u64)address >= mmap_min_addr());
+
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("FreelistFullThenUnmap", "[mmap32]") {
+    Mapper mapper;
+    g_mode32 = true;
+
+    u64 min = mmap_min_addr();
+    CATCH_REQUIRE(mapper.allocate(min, (u64)UINT32_MAX + 1 - min) == (void*)min);
+    verifyRegions(mapper, {});
+
+    CATCH_REQUIRE(mapper.unmap(true, (void*)0x100000, 0x1000) == 0);
+    verifyRegions(mapper, {{0x100000, 0x100fff}});
+
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("Map64DoesNotReserveLowMemory", "[mmap]") {
+    Mapper mapper;
+    g_mode32 = false;
+
+    void* high = mapper.map(false, nullptr, 0x5000, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
+    CATCH_REQUIRE(high != MAP_FAILED);
+    CATCH_REQUIRE((u64)high > UINT32_MAX);
+
+    u64 min = mmap_min_addr();
+    void* low = mapper.map(true, (void*)min, 0x1000, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED_NOREPLACE, -1, 0);
+    CATCH_REQUIRE(low == (void*)min);
+
+    verifyRegions(mapper, {{(u32)min + 0x1000, UINT32_MAX}});
+
+    munmap(high, 0x5000);
+    munmap(low, 0x1000);
+    SUCCESS_MESSAGE();
+}

--- a/tests/Unit/mmap.cpp
+++ b/tests/Unit/mmap.cpp
@@ -1,5 +1,5 @@
 // clang-format off
-// Test our 32-bit mmap implementation
+// Test our mmap implementation
 #include <catch2/catch_test_macros.hpp>
 #include <sys/mman.h>
 #include "felix86/common/global.hpp"
@@ -24,9 +24,9 @@ namespace Catch {
 
 #define SUCCESS_MESSAGE() SUCCESS("Test passed: %s", Catch::getResultCapture().getCurrentTestName().c_str())
 
-#define MMAP_AT(addr, size) \
+#define MMAP_AT(addr, size, prot, flags) \
     do { \
-        void* address = mapper.map(g_mode32, (void*)(addr), size, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, -1, 0); \
+        void* address = mapper.map(g_mode32, (void*)(addr), size, prot, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED | flags, -1, 0); \
         CATCH_REQUIRE(address == (void*)(u64)(addr)); \
         unmap_me.push_back({(u64)(addr), size}); \
     } while (0)
@@ -38,9 +38,9 @@ namespace Catch {
         unmap_me.push_back({(u64)(new_addr), new_size}); \
     } while(0)
 
-#define MMAP_AT_R(size) \
+#define MMAP_AT_R(address, size, prot, flags) \
     do { \
-        void* address = mapper.map(g_mode32, (void*)(0), size, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE, -1, 0); \
+        address = mapper.map(g_mode32, (void*)(0), size, prot, MAP_ANONYMOUS | MAP_PRIVATE | flags, -1, 0); \
         unmap_me.push_back({(u64)(address), size}); \
     } while (0)
 
@@ -59,6 +59,34 @@ namespace Catch {
         } \
     } while (0)
 
+struct GuestRegionExpected {
+    u64 start;
+    u64 len;
+    int flags;
+    int prot;
+};
+
+void verifyGuestRegions(Mapper& mapper, const std::vector<GuestRegionExpected>& expected_regions) {
+    auto guest_regions = mapper.get_guest_regions();
+    int found_regions = 0;
+    for (const auto region : expected_regions) {
+        for (const auto guest_region : guest_regions) {
+            bool yes = true;
+            yes &= region.start == guest_region.start;
+            yes &= region.start + region.len == guest_region.end;
+            // Include the implicit flags here
+            yes &= (region.flags | MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED) == guest_region.flags;
+            yes &= region.prot == guest_region.prot;
+            yes &= !guest_region.shmem;
+            if (yes) {
+                found_regions += 1;
+                break;
+            };
+        }
+    }
+    CATCH_REQUIRE(found_regions == expected_regions.size());    
+}
+
 void verifyRegions(Mapper& mapper, const std::vector<std::pair<u32, u32>>& expected_regions) {
     auto actual_regions = mapper.getRegions();
     CATCH_REQUIRE(expected_regions == actual_regions);
@@ -69,11 +97,15 @@ CATCH_TEST_CASE("Simple1", "[mmap32]") {
     Mapper mapper;
     g_mode32 = true;
 
-    MMAP_AT(0x20000, 0x10000);
+    MMAP_AT(0x20000, 0x10000, PROT_NONE, 0);
 
     verifyRegions(mapper, {
         {mmap_min_addr(), 0x20000 - 1},
         {0x20000 + 0x10000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x10000, PROT_NONE, 0},
     });
 
     MUNMAP_ALL();
@@ -85,12 +117,16 @@ CATCH_TEST_CASE("Simple2", "[mmap32]") {
     Mapper mapper;
     g_mode32 = true;
 
-    MMAP_AT(0x20000, 0x10000);
-    MMAP_AT(0x30000, 0x10000);
+    MMAP_AT(0x20000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
 
     verifyRegions(mapper, {
         {mmap_min_addr(), 0x20000 - 1},
         {0x20000 + 0x10000 + 0x10000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x20000, PROT_NONE, 0},
     });
 
     MUNMAP_ALL();
@@ -102,13 +138,17 @@ CATCH_TEST_CASE("Simple3", "[mmap32]") {
     Mapper mapper;
     g_mode32 = true;
 
-    MMAP_AT(0x20000, 0x10000);
-    MMAP_AT(0x30000, 0x10000);
-    MMAP_AT(0x40000, 0x10000);
+    MMAP_AT(0x20000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x40000, 0x10000, PROT_NONE, 0);
 
     verifyRegions(mapper, {
         {mmap_min_addr(), 0x20000 - 1},
         {0x20000 + 0x10000 + 0x10000 + 0x10000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x30000, PROT_NONE, 0},
     });
 
     MUNMAP_ALL();
@@ -120,10 +160,14 @@ CATCH_TEST_CASE("FirstPages", "[mmap32]") {
     Mapper mapper;
     g_mode32 = true;
 
-    MMAP_AT(mmap_min_addr(), 0x10000);
+    MMAP_AT(mmap_min_addr(), 0x10000, PROT_NONE, 0);
 
     verifyRegions(mapper, {
         {mmap_min_addr() + 0x10000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {mmap_min_addr(), 0x10000, PROT_NONE, 0}
     });
 
     MUNMAP_ALL();
@@ -135,10 +179,14 @@ CATCH_TEST_CASE("FirstPagesUnmap", "[mmap32]") {
     Mapper mapper;
     g_mode32 = true;
 
-    MMAP_AT(mmap_min_addr(), 0x10000);
+    MMAP_AT(mmap_min_addr(), 0x10000, PROT_NONE, 0);
 
     verifyRegions(mapper, {
         {mmap_min_addr() + 0x10000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {mmap_min_addr(), 0x10000, PROT_NONE, 0}
     });
 
     UNMAP_AT(mmap_min_addr(), 0x10000);
@@ -146,6 +194,8 @@ CATCH_TEST_CASE("FirstPagesUnmap", "[mmap32]") {
     verifyRegions(mapper, {
         {mmap_min_addr(), (u64)UINT32_MAX},
     });
+
+    verifyGuestRegions(mapper, {});
 
     MUNMAP_ALL();
     SUCCESS_MESSAGE();
@@ -158,10 +208,14 @@ CATCH_TEST_CASE("LastPages", "[mmap32]") {
 
     u64 end = (u64)UINT32_MAX + 1;
 
-    MMAP_AT(end - 0x10000, 0x10000);
+    MMAP_AT(end - 0x10000, 0x10000, PROT_NONE, 0);
 
     verifyRegions(mapper, {
         {mmap_min_addr(), end - 0x10000 - 1},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {end - 0x10000, 0x10000, PROT_NONE, 0}
     });
 
     MUNMAP_ALL();
@@ -173,13 +227,18 @@ CATCH_TEST_CASE("Split2", "[mmap32]") {
     Mapper mapper;
     g_mode32 = true;
 
-    MMAP_AT(0x30000, 0x10000);
-    MMAP_AT(0x50000, 0x10000);
+    MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x50000, 0x10000, PROT_NONE, 0);
 
     verifyRegions(mapper, {
         {mmap_min_addr(), 0x30000 - 1},
         {0x30000 + 0x10000, 0x50000 - 1},
         {0x50000 + 0x10000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {0x30000, 0x10000, PROT_NONE, 0},
+        {0x50000, 0x10000, PROT_NONE, 0},
     });
 
     MUNMAP_ALL();
@@ -191,15 +250,19 @@ CATCH_TEST_CASE("Split2Pick1", "[mmap32]") {
     Mapper mapper;
     g_mode32 = true;
 
-    MMAP_AT(0x30000, 0x10000);
-    MMAP_AT(0x50000, 0x10000);
+    MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x50000, 0x10000, PROT_NONE, 0);
 
     // Mmap exactly in the middle of the two previous ones
-    MMAP_AT(0x40000, 0x10000);
+    MMAP_AT(0x40000, 0x10000, PROT_NONE, 0);
 
     verifyRegions(mapper, {
         {mmap_min_addr(), 0x30000 - 1},
         {0x50000 + 0x10000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {0x30000, 0x30000, PROT_NONE, 0},
     });
 
     MUNMAP_ALL();
@@ -211,12 +274,16 @@ CATCH_TEST_CASE("Overlapping1", "[mmap32]") {
     Mapper mapper;
     g_mode32 = true;
 
-    MMAP_AT(0x30000, 0x10000);
-    MMAP_AT(0x20000, 0x100000); // this mapping consumes the first
+    MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x20000, 0x100000, PROT_NONE, 0); // this mapping consumes the first
 
     verifyRegions(mapper, {
         {mmap_min_addr(), 0x20000 - 1},
         {0x20000 + 0x100000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x100000, PROT_NONE, 0},
     });
 
     MUNMAP_ALL();
@@ -228,13 +295,17 @@ CATCH_TEST_CASE("Overlapping2", "[mmap32]") {
     Mapper mapper;
     g_mode32 = true;
 
-    MMAP_AT(0x30000, 0x10000);
-    MMAP_AT(0x50000, 0x10000);
-    MMAP_AT(0x20000, 0x100000); // this mapping consumes the other two
+    MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x50000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x20000, 0x100000, PROT_NONE, 0); // this mapping consumes the other two
 
     verifyRegions(mapper, {
         {mmap_min_addr(), 0x20000 - 1},
         {0x20000 + 0x100000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x100000, PROT_NONE, 0},
     });
 
     MUNMAP_ALL();
@@ -246,9 +317,9 @@ CATCH_TEST_CASE("Overlapping2ConsumeLast", "[mmap32]") {
     Mapper mapper;
     g_mode32 = true;
 
-    MMAP_AT(0x30000, 0x10000);
-    MMAP_AT(0x50000, 0x10000);
-    MMAP_AT(0x100000, 0x1000);
+    MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x50000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x100000, 0x1000, PROT_NONE, 0);
 
     verifyRegions(mapper, {
         {mmap_min_addr(), 0x30000 - 1},
@@ -257,11 +328,21 @@ CATCH_TEST_CASE("Overlapping2ConsumeLast", "[mmap32]") {
         {0x101000, (u64)UINT32_MAX},
     });
 
-    MMAP_AT(0x20000, 0x100000 - 0x20000); // this mapping consumes the first two
+    verifyGuestRegions(mapper, { 
+        {0x30000, 0x10000, PROT_NONE, 0},
+        {0x50000, 0x10000, PROT_NONE, 0},
+        {0x100000, 0x1000, PROT_NONE, 0},
+    });
+
+    MMAP_AT(0x20000, 0x100000 - 0x20000, PROT_NONE, 0); // this mapping consumes the first two
 
     verifyRegions(mapper, {
         {mmap_min_addr(), 0x20000 - 1},
         {0x101000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x100000 - 0x20000, PROT_NONE, 0},
     });
 
     MUNMAP_ALL();
@@ -273,11 +354,15 @@ CATCH_TEST_CASE("UnmapPerfect", "[mmap32]") {
     Mapper mapper;
     g_mode32 = true;
 
-    MMAP_AT(0x30000, 0x10000);
+    MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
 
     verifyRegions(mapper, {
         {mmap_min_addr(), 0x30000 - 1},
         {0x40000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {0x30000, 0x10000, PROT_NONE, 0},
     });
 
     UNMAP_AT(0x30000, 0x10000);
@@ -286,31 +371,7 @@ CATCH_TEST_CASE("UnmapPerfect", "[mmap32]") {
         {mmap_min_addr(), (u64)UINT32_MAX},
     });
 
-    MUNMAP_ALL();
-    SUCCESS_MESSAGE();
-}
-
-CATCH_TEST_CASE("UnmapPerfect2", "[mmap32]") {
-    std::vector<std::pair<u32, u32>> unmap_me;
-    Mapper mapper;
-    g_mode32 = true;
-
-    MMAP_AT(0x20000, 0x10000);
-    MMAP_AT(0x30000, 0x10000);
-    MMAP_AT(0x40000, 0x10000);
-    
-    verifyRegions(mapper, {
-        {mmap_min_addr(), 0x20000 - 1},
-        {0x50000, (u64)UINT32_MAX},
-    });
-
-    UNMAP_AT(0x30000, 0x10000);
-
-    verifyRegions(mapper, {
-        {mmap_min_addr(), 0x20000 - 1},
-        {0x30000, 0x40000 - 1},
-        {0x50000, (u64)UINT32_MAX},
-    });
+    verifyGuestRegions(mapper, {});
 
     MUNMAP_ALL();
     SUCCESS_MESSAGE();
@@ -321,13 +382,17 @@ CATCH_TEST_CASE("UnmapMiddle", "[mmap32]") {
     Mapper mapper;
     g_mode32 = true;
 
-    MMAP_AT(0x20000, 0x10000);
-    MMAP_AT(0x30000, 0x10000);
-    MMAP_AT(0x40000, 0x10000);
+    MMAP_AT(0x20000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x40000, 0x10000, PROT_NONE, 0);
 
     verifyRegions(mapper, {
         {mmap_min_addr(), 0x20000 - 1},
         {0x50000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x30000, PROT_NONE, 0},
     });
 
     UNMAP_AT(0x30000, 0x10000);
@@ -336,6 +401,11 @@ CATCH_TEST_CASE("UnmapMiddle", "[mmap32]") {
         {mmap_min_addr(), 0x20000 - 1},
         {0x30000, 0x40000 - 1},
         {0x50000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x10000, PROT_NONE, 0},
+        {0x40000, 0x10000, PROT_NONE, 0},
     });
 
     MUNMAP_ALL();
@@ -347,11 +417,15 @@ CATCH_TEST_CASE("UnmapGreedyMin", "[mmap32]") {
     Mapper mapper;
     g_mode32 = true;
 
-    MMAP_AT(0x20000, 0x100000);
+    MMAP_AT(0x20000, 0x100000, PROT_NONE, 0);
 
     verifyRegions(mapper, {
         {mmap_min_addr(), 0x20000 - 1},
         {0x120000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x100000, PROT_NONE, 0},
     });
 
     // Unmap more pages than we mapped, this is allowed
@@ -360,6 +434,10 @@ CATCH_TEST_CASE("UnmapGreedyMin", "[mmap32]") {
     verifyRegions(mapper, {
         {mmap_min_addr(), 0x2F000 - 1},
         {0x120000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {0x2F000, 0x100000 - 0x0F000, PROT_NONE, 0},
     });
 
     MUNMAP_ALL();
@@ -371,11 +449,15 @@ CATCH_TEST_CASE("UnmapGreedyMax", "[mmap32]") {
     Mapper mapper;
     g_mode32 = true;
 
-    MMAP_AT(0x20000, 0x100000);
+    MMAP_AT(0x20000, 0x100000, PROT_NONE, 0);
 
     verifyRegions(mapper, {
         {mmap_min_addr(), 0x20000 - 1},
         {0x120000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x100000, PROT_NONE, 0},
     });
 
     // Unmap more pages than we mapped, this is allowed
@@ -384,6 +466,10 @@ CATCH_TEST_CASE("UnmapGreedyMax", "[mmap32]") {
     verifyRegions(mapper, {
         {mmap_min_addr(), 0x20000 - 1},
         {0x115000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x100000 - 0x5000, PROT_NONE, 0},
     });
 
     MUNMAP_ALL();
@@ -395,11 +481,16 @@ CATCH_TEST_CASE("MapRandom", "[mmap32]") {
     Mapper mapper;
     g_mode32 = true;
 
-    MMAP_AT_R(0x100000);
+    void* address = 0;
+    MMAP_AT_R(address, 0x100000, PROT_NONE, 0);
 
     // Random mmaps always pick from first page if possible
     verifyRegions(mapper, {
         {mmap_min_addr() + 0x100000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {(u64)address, 0x100000, PROT_NONE, 0},
     });
 
     MUNMAP_ALL();
@@ -411,12 +502,17 @@ CATCH_TEST_CASE("OverwriteFixed", "[mmap32]") {
     Mapper mapper;
     g_mode32 = true;
 
-    MMAP_AT(0x10000, 0x200c);
-    MMAP_AT(0x13000, 0x34a18);
-    MMAP_AT(0x13000, 0x60000);
+    MMAP_AT(0x10000, 0x200c, PROT_NONE, 0);
+    MMAP_AT(0x13000, 0x34a18, PROT_NONE, 0);
+    MMAP_AT(0x13000, 0x60000, PROT_NONE, 0);
 
     verifyRegions(mapper, {
         {mmap_min_addr() + 0x63000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x200c, PROT_NONE, 0},
+        {0x13000, 0x60000, PROT_NONE, 0},
     });
 
     MUNMAP_ALL();
@@ -428,12 +524,16 @@ CATCH_TEST_CASE("OverwriteFixed2", "[mmap32]") {
     Mapper mapper;
     g_mode32 = true;
 
-    MMAP_AT(0x13000, 0x34a18);
-    MMAP_AT(0x12000, 0x60000);
+    MMAP_AT(0x13000, 0x34a18, PROT_NONE, 0);
+    MMAP_AT(0x12000, 0x60000, PROT_NONE, 0);
 
     verifyRegions(mapper, {
         {mmap_min_addr(), 0x11fff},
         {mmap_min_addr() + 0x62000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {0x12000, 0x60000, PROT_NONE, 0},
     });
 
     MUNMAP_ALL();
@@ -445,12 +545,16 @@ CATCH_TEST_CASE("Mremap", "[mmap32]") {
     Mapper mapper;
     g_mode32 = true;
 
-    MMAP_AT(0x13000, 0x10000);
+    MMAP_AT(0x13000, 0x10000, PROT_NONE, 0);
     MREMAP_AT(0x13000, 0x10000, 0x40000, 0x20000);
 
     verifyRegions(mapper, {
         {mmap_min_addr(), 0x3ffff},
         {0x60000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {0x40000, 0x20000, PROT_NONE, 0},
     });
 
     MUNMAP_ALL();
@@ -462,8 +566,8 @@ CATCH_TEST_CASE("MMap bug", "[mmap32]") {
     Mapper mapper;
     g_mode32 = true;
 
-    MMAP_AT(0x85800000, 0x8d400000-0x85800000);
-    MMAP_AT(0xFFF00000, 0xFFFFFFFF-0xFFF00000);
+    MMAP_AT(0x85800000, 0x8d400000-0x85800000, PROT_NONE, 0);
+    MMAP_AT(0xFFF00000, 0xFFFFFFFF-0xFFF00000, PROT_NONE, 0);
 
     void* address = mapper.map(g_mode32, (void*)0xfff00000, 0x7d000, PROT_READ | PROT_WRITE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, -1, 0);
     ASSERT(address == (void*)0xfff00000);
@@ -471,6 +575,408 @@ CATCH_TEST_CASE("MMap bug", "[mmap32]") {
     verifyRegions(mapper, {
         {mmap_min_addr(), 0x00000000857fffff},
         {0x000000008d400000, (u64)0x00000000ffefffff},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {0x85800000, 0x8d400000-0x85800000, PROT_NONE, 0},
+        {0xFFF00000, 0xFFF7d000-0xFFF00000, PROT_WRITE, 0},
+        {0xFFF7d000, 0xFFFFFFFF-0xFFF7d000, PROT_NONE, 0},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("Simple1", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    MMAP_AT(0x20000, 0x10000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x10000, PROT_NONE, 0},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("Simple2", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    MMAP_AT(0x20000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x20000, PROT_NONE, 0},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("Simple3", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    MMAP_AT(0x20000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x40000, 0x10000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x30000, PROT_NONE, 0},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("FirstPages", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    MMAP_AT(mmap_min_addr(), 0x10000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {mmap_min_addr(), 0x10000, PROT_NONE, 0}
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("FirstPagesUnmap", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    MMAP_AT(mmap_min_addr(), 0x10000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {mmap_min_addr(), 0x10000, PROT_NONE, 0}
+    });
+
+    UNMAP_AT(mmap_min_addr(), 0x10000);
+
+    verifyGuestRegions(mapper, {});
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("LastPages", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    u64 end = (u64)UINT32_MAX + 1;
+
+    MMAP_AT(end - 0x10000, 0x10000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {end - 0x10000, 0x10000, PROT_NONE, 0}
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("Split2", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x50000, 0x10000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x30000, 0x10000, PROT_NONE, 0},
+        {0x50000, 0x10000, PROT_NONE, 0},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("Split2Pick1", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x50000, 0x10000, PROT_NONE, 0);
+
+    // Mmap exactly in the middle of the two previous ones
+    MMAP_AT(0x40000, 0x10000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x30000, 0x30000, PROT_NONE, 0},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("Overlapping1", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x20000, 0x100000, PROT_NONE, 0); // this mapping consumes the first
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x100000, PROT_NONE, 0},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("Overlapping2", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x50000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x20000, 0x100000, PROT_NONE, 0); // this mapping consumes the other two
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x100000, PROT_NONE, 0},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("Overlapping2ConsumeLast", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x50000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x100000, 0x1000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x30000, 0x10000, PROT_NONE, 0},
+        {0x50000, 0x10000, PROT_NONE, 0},
+        {0x100000, 0x1000, PROT_NONE, 0},
+    });
+
+    MMAP_AT(0x20000, 0x100000 - 0x20000, PROT_NONE, 0); // this mapping consumes the first two
+
+    verifyRegions(mapper, {
+        {mmap_min_addr(), 0x20000 - 1},
+        {0x101000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x100000 - 0x20000, PROT_NONE, 0},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("UnmapPerfect", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x30000, 0x10000, PROT_NONE, 0},
+    });
+
+    UNMAP_AT(0x30000, 0x10000);
+
+    verifyGuestRegions(mapper, {});
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("UnmapMiddle", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    MMAP_AT(0x20000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x40000, 0x10000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x30000, PROT_NONE, 0},
+    });
+
+    UNMAP_AT(0x30000, 0x10000);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x10000, PROT_NONE, 0},
+        {0x40000, 0x10000, PROT_NONE, 0},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("UnmapGreedyMin", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    MMAP_AT(0x20000, 0x100000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x100000, PROT_NONE, 0},
+    });
+
+    // Unmap more pages than we mapped, this is allowed
+    UNMAP_AT(0x1F000, 0x10000);
+
+    verifyGuestRegions(mapper, { 
+        {0x2F000, 0x100000 - 0x0F000, PROT_NONE, 0},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("UnmapGreedyMax", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    MMAP_AT(0x20000, 0x100000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x100000, PROT_NONE, 0},
+    });
+
+    // Unmap more pages than we mapped, this is allowed
+    UNMAP_AT(0x115000, 0x10000);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x100000 - 0x5000, PROT_NONE, 0},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MapRandom", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    void* address = 0;
+    MMAP_AT_R(address, 0x100000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {(u64)address, 0x100000, PROT_NONE, 0},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("OverwriteFixed", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    MMAP_AT(0x10000, 0x200c, PROT_NONE, 0);
+    MMAP_AT(0x13000, 0x34a18, PROT_NONE, 0);
+    MMAP_AT(0x13000, 0x60000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x200c, PROT_NONE, 0},
+        {0x13000, 0x60000, PROT_NONE, 0},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("OverwriteFixed2", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    MMAP_AT(0x13000, 0x34a18, PROT_NONE, 0);
+    MMAP_AT(0x12000, 0x60000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x12000, 0x60000, PROT_NONE, 0},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("Mremap", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    MMAP_AT(0x13000, 0x10000, PROT_NONE, 0);
+    MREMAP_AT(0x13000, 0x10000, 0x40000, 0x20000);
+
+    verifyGuestRegions(mapper, { 
+        {0x40000, 0x20000, PROT_NONE, 0},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MremapOverwrite", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    MMAP_AT(0x10000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x20000, 0x10000, PROT_WRITE, 0);
+    MMAP_AT(0x30000, 0x10000, PROT_READ, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x10000, PROT_NONE, 0},
+        {0x20000, 0x10000, PROT_WRITE, 0},
+        {0x30000, 0x10000, PROT_READ, 0},
+    });
+
+    MREMAP_AT(0x10000, 0x10000, 0x10000, 0x30000);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x30000, PROT_NONE, 0},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MremapOverwriteDelete", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    MMAP_AT(0x10000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x20000, 0x10000, PROT_WRITE, 0);
+    MMAP_AT(0x30000, 0x10000, PROT_READ, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x10000, PROT_NONE, 0},
+        {0x20000, 0x10000, PROT_WRITE, 0},
+        {0x30000, 0x10000, PROT_READ, 0},
+    });
+
+    MREMAP_AT(0x10000, 0x30000, 0x10000, 0);
+
+    verifyGuestRegions(mapper, {});
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("DifferentNeighborFlags", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+
+    MMAP_AT(0x10000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x20000, 0x10000, PROT_NONE, MAP_DENYWRITE);
+    MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x10000, PROT_NONE, 0},
+        {0x20000, 0x10000, PROT_NONE, MAP_DENYWRITE},
+        {0x30000, 0x10000, PROT_READ, 0},
     });
 
     MUNMAP_ALL();

--- a/tests/Unit/mmap.cpp
+++ b/tests/Unit/mmap.cpp
@@ -24,23 +24,34 @@ namespace Catch {
 
 #define SUCCESS_MESSAGE() SUCCESS("Test passed: %s", Catch::getResultCapture().getCurrentTestName().c_str())
 
+const int FCOMMON = MAP_ANONYMOUS | MAP_PRIVATE;
+const int FCOMMON_FIXED = FCOMMON | MAP_FIXED;
+
 #define MMAP_AT(addr, size, prot, flags) \
     do { \
-        void* address = mapper.map(g_mode32, (void*)(addr), size, prot, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED | flags, -1, 0); \
+        void* address = mapper.map(g_mode32, (void*)(addr), size, prot, FCOMMON_FIXED | flags, -1, 0); \
         CATCH_REQUIRE(address == (void*)(u64)(addr)); \
         unmap_me.push_back({(u64)(addr), size}); \
     } while (0)
 
-#define MREMAP_AT(old_addr, old_size, new_addr, new_size) \
+#define MREMAP_AT(old_addr, old_size, new_addr, new_size, flags) \
     do {\
-        void* address = mapper.remap(g_mode32, (void*)old_addr, old_size, new_size, MREMAP_FIXED | MREMAP_MAYMOVE, (void*)new_addr); \
+        void* address = mapper.remap(g_mode32, (void*)old_addr, old_size, new_size, flags, (void*)new_addr); \
         CATCH_REQUIRE(address == (void*)(u64)(new_addr)); \
         unmap_me.push_back({(u64)(new_addr), new_size}); \
     } while(0)
 
+#define MREMAP(old_addr, old_size, new_size, flags) \
+    do {\
+        void* address = mapper.remap(g_mode32, (void*)old_addr, old_size, new_size, flags, 0); \
+        CATCH_REQUIRE(address != (void*)-1); \
+        unmap_me.push_back({(u64)address, new_size}); \
+    } while(0)
+
+
 #define MMAP_AT_R(address, size, prot, flags) \
     do { \
-        address = mapper.map(g_mode32, (void*)(0), size, prot, MAP_ANONYMOUS | MAP_PRIVATE | flags, -1, 0); \
+        address = mapper.map(g_mode32, (void*)(0), size, prot, FCOMMON | flags, -1, 0); \
         unmap_me.push_back({(u64)(address), size}); \
     } while (0)
 
@@ -62,8 +73,8 @@ namespace Catch {
 struct GuestRegionExpected {
     u64 start;
     u64 len;
-    int flags;
     int prot;
+    int flags;
 };
 
 void verifyGuestRegions(Mapper& mapper, const std::vector<GuestRegionExpected>& expected_regions) {
@@ -75,7 +86,7 @@ void verifyGuestRegions(Mapper& mapper, const std::vector<GuestRegionExpected>& 
             yes &= region.start == guest_region.start;
             yes &= region.start + region.len == guest_region.end;
             // Include the implicit flags here
-            yes &= (region.flags | MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED) == guest_region.flags;
+            yes &= region.flags == guest_region.flags;
             yes &= region.prot == guest_region.prot;
             yes &= !guest_region.shmem;
             if (yes) {
@@ -85,6 +96,7 @@ void verifyGuestRegions(Mapper& mapper, const std::vector<GuestRegionExpected>& 
         }
     }
     CATCH_REQUIRE(found_regions == expected_regions.size());    
+    CATCH_REQUIRE(guest_regions.size() == expected_regions.size());
 }
 
 void verifyRegions(Mapper& mapper, const std::vector<std::pair<u32, u32>>& expected_regions) {
@@ -105,7 +117,7 @@ CATCH_TEST_CASE("Simple1", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x10000, PROT_NONE, 0},
+        {0x20000, 0x10000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -126,7 +138,7 @@ CATCH_TEST_CASE("Simple2", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x20000, PROT_NONE, 0},
+        {0x20000, 0x20000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -148,7 +160,7 @@ CATCH_TEST_CASE("Simple3", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x30000, PROT_NONE, 0},
+        {0x20000, 0x30000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -167,7 +179,7 @@ CATCH_TEST_CASE("FirstPages", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {mmap_min_addr(), 0x10000, PROT_NONE, 0}
+        {mmap_min_addr(), 0x10000, PROT_NONE, FCOMMON_FIXED}
     });
 
     MUNMAP_ALL();
@@ -186,7 +198,7 @@ CATCH_TEST_CASE("FirstPagesUnmap", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {mmap_min_addr(), 0x10000, PROT_NONE, 0}
+        {mmap_min_addr(), 0x10000, PROT_NONE, FCOMMON_FIXED}
     });
 
     UNMAP_AT(mmap_min_addr(), 0x10000);
@@ -215,7 +227,7 @@ CATCH_TEST_CASE("LastPages", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {end - 0x10000, 0x10000, PROT_NONE, 0}
+        {end - 0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED}
     });
 
     MUNMAP_ALL();
@@ -237,8 +249,8 @@ CATCH_TEST_CASE("Split2", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x30000, 0x10000, PROT_NONE, 0},
-        {0x50000, 0x10000, PROT_NONE, 0},
+        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x50000, 0x10000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -262,7 +274,7 @@ CATCH_TEST_CASE("Split2Pick1", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x30000, 0x30000, PROT_NONE, 0},
+        {0x30000, 0x30000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -283,7 +295,7 @@ CATCH_TEST_CASE("Overlapping1", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x100000, PROT_NONE, 0},
+        {0x20000, 0x100000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -305,7 +317,7 @@ CATCH_TEST_CASE("Overlapping2", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x100000, PROT_NONE, 0},
+        {0x20000, 0x100000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -329,9 +341,9 @@ CATCH_TEST_CASE("Overlapping2ConsumeLast", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x30000, 0x10000, PROT_NONE, 0},
-        {0x50000, 0x10000, PROT_NONE, 0},
-        {0x100000, 0x1000, PROT_NONE, 0},
+        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x50000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x100000, 0x1000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MMAP_AT(0x20000, 0x100000 - 0x20000, PROT_NONE, 0); // this mapping consumes the first two
@@ -342,7 +354,7 @@ CATCH_TEST_CASE("Overlapping2ConsumeLast", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x100000 - 0x20000, PROT_NONE, 0},
+        {0x20000, 0x101000 - 0x20000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -362,7 +374,7 @@ CATCH_TEST_CASE("UnmapPerfect", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x30000, 0x10000, PROT_NONE, 0},
+        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
     });
 
     UNMAP_AT(0x30000, 0x10000);
@@ -392,7 +404,7 @@ CATCH_TEST_CASE("UnmapMiddle", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x30000, PROT_NONE, 0},
+        {0x20000, 0x30000, PROT_NONE, FCOMMON_FIXED},
     });
 
     UNMAP_AT(0x30000, 0x10000);
@@ -404,8 +416,8 @@ CATCH_TEST_CASE("UnmapMiddle", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x10000, PROT_NONE, 0},
-        {0x40000, 0x10000, PROT_NONE, 0},
+        {0x20000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x40000, 0x10000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -425,7 +437,7 @@ CATCH_TEST_CASE("UnmapGreedyMin", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x100000, PROT_NONE, 0},
+        {0x20000, 0x100000, PROT_NONE, FCOMMON_FIXED},
     });
 
     // Unmap more pages than we mapped, this is allowed
@@ -437,7 +449,7 @@ CATCH_TEST_CASE("UnmapGreedyMin", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x2F000, 0x100000 - 0x0F000, PROT_NONE, 0},
+        {0x2F000, 0x120000 - 0x2F000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -457,7 +469,7 @@ CATCH_TEST_CASE("UnmapGreedyMax", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x100000, PROT_NONE, 0},
+        {0x20000, 0x100000, PROT_NONE, FCOMMON_FIXED},
     });
 
     // Unmap more pages than we mapped, this is allowed
@@ -469,7 +481,7 @@ CATCH_TEST_CASE("UnmapGreedyMax", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x100000 - 0x5000, PROT_NONE, 0},
+        {0x20000, 0x115000 - 0x20000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -490,7 +502,7 @@ CATCH_TEST_CASE("MapRandom", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {(u64)address, 0x100000, PROT_NONE, 0},
+        {(u64)address, 0x100000, PROT_NONE, FCOMMON},
     });
 
     MUNMAP_ALL();
@@ -511,8 +523,7 @@ CATCH_TEST_CASE("OverwriteFixed", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x200c, PROT_NONE, 0},
-        {0x13000, 0x60000, PROT_NONE, 0},
+        {0x10000, 0x63000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -533,7 +544,7 @@ CATCH_TEST_CASE("OverwriteFixed2", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x12000, 0x60000, PROT_NONE, 0},
+        {0x12000, 0x60000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -546,7 +557,7 @@ CATCH_TEST_CASE("Mremap", "[mmap32]") {
     g_mode32 = true;
 
     MMAP_AT(0x13000, 0x10000, PROT_NONE, 0);
-    MREMAP_AT(0x13000, 0x10000, 0x40000, 0x20000);
+    MREMAP_AT(0x13000, 0x10000, 0x40000, 0x20000, MREMAP_FIXED | MREMAP_MAYMOVE);
 
     verifyRegions(mapper, {
         {mmap_min_addr(), 0x3ffff},
@@ -554,7 +565,7 @@ CATCH_TEST_CASE("Mremap", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x40000, 0x20000, PROT_NONE, 0},
+        {0x40000, 0x20000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -578,9 +589,9 @@ CATCH_TEST_CASE("MMap bug", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x85800000, 0x8d400000-0x85800000, PROT_NONE, 0},
-        {0xFFF00000, 0xFFF7d000-0xFFF00000, PROT_WRITE, 0},
-        {0xFFF7d000, 0xFFFFFFFF-0xFFF7d000, PROT_NONE, 0},
+        {0x85800000, 0x8d400000-0x85800000, PROT_NONE, FCOMMON_FIXED},
+        {0xFFF00000, 0xFFF7d000-0xFFF00000, PROT_READ | PROT_WRITE, FCOMMON_FIXED},
+        {0xFFF7d000, 0x100000000-0xFFF7d000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -590,11 +601,12 @@ CATCH_TEST_CASE("MMap bug", "[mmap32]") {
 CATCH_TEST_CASE("Simple1", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
+    g_mode32 = false;
 
     MMAP_AT(0x20000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x10000, PROT_NONE, 0},
+        {0x20000, 0x10000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -604,12 +616,13 @@ CATCH_TEST_CASE("Simple1", "[mmap]") {
 CATCH_TEST_CASE("Simple2", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
+    g_mode32 = false;
 
     MMAP_AT(0x20000, 0x10000, PROT_NONE, 0);
     MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x20000, PROT_NONE, 0},
+        {0x20000, 0x20000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -619,13 +632,14 @@ CATCH_TEST_CASE("Simple2", "[mmap]") {
 CATCH_TEST_CASE("Simple3", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
+    g_mode32 = false;
 
     MMAP_AT(0x20000, 0x10000, PROT_NONE, 0);
     MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
     MMAP_AT(0x40000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x30000, PROT_NONE, 0},
+        {0x20000, 0x30000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -639,7 +653,7 @@ CATCH_TEST_CASE("FirstPages", "[mmap]") {
     MMAP_AT(mmap_min_addr(), 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {mmap_min_addr(), 0x10000, PROT_NONE, 0}
+        {mmap_min_addr(), 0x10000, PROT_NONE, FCOMMON_FIXED}
     });
 
     MUNMAP_ALL();
@@ -649,11 +663,12 @@ CATCH_TEST_CASE("FirstPages", "[mmap]") {
 CATCH_TEST_CASE("FirstPagesUnmap", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
+    g_mode32 = false;
 
     MMAP_AT(mmap_min_addr(), 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {mmap_min_addr(), 0x10000, PROT_NONE, 0}
+        {mmap_min_addr(), 0x10000, PROT_NONE, FCOMMON_FIXED}
     });
 
     UNMAP_AT(mmap_min_addr(), 0x10000);
@@ -667,13 +682,14 @@ CATCH_TEST_CASE("FirstPagesUnmap", "[mmap]") {
 CATCH_TEST_CASE("LastPages", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
+    g_mode32 = false;
 
     u64 end = (u64)UINT32_MAX + 1;
 
     MMAP_AT(end - 0x10000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {end - 0x10000, 0x10000, PROT_NONE, 0}
+        {end - 0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED}
     });
 
     MUNMAP_ALL();
@@ -683,13 +699,14 @@ CATCH_TEST_CASE("LastPages", "[mmap]") {
 CATCH_TEST_CASE("Split2", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
+    g_mode32 = false;
 
     MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
     MMAP_AT(0x50000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x30000, 0x10000, PROT_NONE, 0},
-        {0x50000, 0x10000, PROT_NONE, 0},
+        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x50000, 0x10000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -699,6 +716,7 @@ CATCH_TEST_CASE("Split2", "[mmap]") {
 CATCH_TEST_CASE("Split2Pick1", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
+    g_mode32 = false;
 
     MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
     MMAP_AT(0x50000, 0x10000, PROT_NONE, 0);
@@ -707,7 +725,7 @@ CATCH_TEST_CASE("Split2Pick1", "[mmap]") {
     MMAP_AT(0x40000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x30000, 0x30000, PROT_NONE, 0},
+        {0x30000, 0x30000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -717,12 +735,13 @@ CATCH_TEST_CASE("Split2Pick1", "[mmap]") {
 CATCH_TEST_CASE("Overlapping1", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
+    g_mode32 = false;
 
     MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
     MMAP_AT(0x20000, 0x100000, PROT_NONE, 0); // this mapping consumes the first
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x100000, PROT_NONE, 0},
+        {0x20000, 0x100000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -732,13 +751,14 @@ CATCH_TEST_CASE("Overlapping1", "[mmap]") {
 CATCH_TEST_CASE("Overlapping2", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
+    g_mode32 = false;
 
     MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
     MMAP_AT(0x50000, 0x10000, PROT_NONE, 0);
     MMAP_AT(0x20000, 0x100000, PROT_NONE, 0); // this mapping consumes the other two
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x100000, PROT_NONE, 0},
+        {0x20000, 0x100000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -748,26 +768,22 @@ CATCH_TEST_CASE("Overlapping2", "[mmap]") {
 CATCH_TEST_CASE("Overlapping2ConsumeLast", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
+    g_mode32 = false;
 
     MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
     MMAP_AT(0x50000, 0x10000, PROT_NONE, 0);
     MMAP_AT(0x100000, 0x1000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x30000, 0x10000, PROT_NONE, 0},
-        {0x50000, 0x10000, PROT_NONE, 0},
-        {0x100000, 0x1000, PROT_NONE, 0},
+        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x50000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x100000, 0x1000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MMAP_AT(0x20000, 0x100000 - 0x20000, PROT_NONE, 0); // this mapping consumes the first two
 
-    verifyRegions(mapper, {
-        {mmap_min_addr(), 0x20000 - 1},
-        {0x101000, (u64)UINT32_MAX},
-    });
-
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x100000 - 0x20000, PROT_NONE, 0},
+        {0x20000, 0x101000 - 0x20000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -777,11 +793,12 @@ CATCH_TEST_CASE("Overlapping2ConsumeLast", "[mmap]") {
 CATCH_TEST_CASE("UnmapPerfect", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
+    g_mode32 = false;
 
     MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x30000, 0x10000, PROT_NONE, 0},
+        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
     });
 
     UNMAP_AT(0x30000, 0x10000);
@@ -795,20 +812,21 @@ CATCH_TEST_CASE("UnmapPerfect", "[mmap]") {
 CATCH_TEST_CASE("UnmapMiddle", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
+    g_mode32 = false;
 
     MMAP_AT(0x20000, 0x10000, PROT_NONE, 0);
     MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
     MMAP_AT(0x40000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x30000, PROT_NONE, 0},
+        {0x20000, 0x30000, PROT_NONE, FCOMMON_FIXED},
     });
 
     UNMAP_AT(0x30000, 0x10000);
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x10000, PROT_NONE, 0},
-        {0x40000, 0x10000, PROT_NONE, 0},
+        {0x20000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x40000, 0x10000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -818,18 +836,19 @@ CATCH_TEST_CASE("UnmapMiddle", "[mmap]") {
 CATCH_TEST_CASE("UnmapGreedyMin", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
+    g_mode32 = false;
 
     MMAP_AT(0x20000, 0x100000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x100000, PROT_NONE, 0},
+        {0x20000, 0x100000, PROT_NONE, FCOMMON_FIXED},
     });
 
     // Unmap more pages than we mapped, this is allowed
     UNMAP_AT(0x1F000, 0x10000);
 
     verifyGuestRegions(mapper, { 
-        {0x2F000, 0x100000 - 0x0F000, PROT_NONE, 0},
+        {0x2F000, 0x100000 - 0x0F000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -839,18 +858,19 @@ CATCH_TEST_CASE("UnmapGreedyMin", "[mmap]") {
 CATCH_TEST_CASE("UnmapGreedyMax", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
+    g_mode32 = false;
 
     MMAP_AT(0x20000, 0x100000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x100000, PROT_NONE, 0},
+        {0x20000, 0x100000, PROT_NONE, FCOMMON_FIXED},
     });
 
     // Unmap more pages than we mapped, this is allowed
     UNMAP_AT(0x115000, 0x10000);
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x100000 - 0x5000, PROT_NONE, 0},
+        {0x20000, 0x115000 - 0x20000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -860,12 +880,13 @@ CATCH_TEST_CASE("UnmapGreedyMax", "[mmap]") {
 CATCH_TEST_CASE("MapRandom", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
+    g_mode32 = false;
 
     void* address = 0;
     MMAP_AT_R(address, 0x100000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {(u64)address, 0x100000, PROT_NONE, 0},
+        {(u64)address, 0x100000, PROT_NONE, FCOMMON},
     });
 
     MUNMAP_ALL();
@@ -875,14 +896,14 @@ CATCH_TEST_CASE("MapRandom", "[mmap]") {
 CATCH_TEST_CASE("OverwriteFixed", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
+    g_mode32 = false;
 
     MMAP_AT(0x10000, 0x200c, PROT_NONE, 0);
     MMAP_AT(0x13000, 0x34a18, PROT_NONE, 0);
     MMAP_AT(0x13000, 0x60000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x200c, PROT_NONE, 0},
-        {0x13000, 0x60000, PROT_NONE, 0},
+        {0x10000, 0x63000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -892,51 +913,236 @@ CATCH_TEST_CASE("OverwriteFixed", "[mmap]") {
 CATCH_TEST_CASE("OverwriteFixed2", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
+    g_mode32 = false;
 
     MMAP_AT(0x13000, 0x34a18, PROT_NONE, 0);
     MMAP_AT(0x12000, 0x60000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x12000, 0x60000, PROT_NONE, 0},
+        {0x12000, 0x60000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
     SUCCESS_MESSAGE();
 }
 
-CATCH_TEST_CASE("Mremap", "[mmap]") {
+CATCH_TEST_CASE("MremapMove", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
+    g_mode32 = false;
 
     MMAP_AT(0x13000, 0x10000, PROT_NONE, 0);
-    MREMAP_AT(0x13000, 0x10000, 0x40000, 0x20000);
+    MREMAP_AT(0x13000, 0x10000, 0x40000, 0x10000, MREMAP_FIXED | MREMAP_MAYMOVE);
 
     verifyGuestRegions(mapper, { 
-        {0x40000, 0x20000, PROT_NONE, 0},
+        {0x40000, 0x10000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
     SUCCESS_MESSAGE();
 }
 
-CATCH_TEST_CASE("MremapOverwrite", "[mmap]") {
+CATCH_TEST_CASE("MremapMoveKeepsFlagsAndProt", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
+    g_mode32 = false;
 
-    MMAP_AT(0x10000, 0x10000, PROT_NONE, 0);
-    MMAP_AT(0x20000, 0x10000, PROT_WRITE, 0);
-    MMAP_AT(0x30000, 0x10000, PROT_READ, 0);
+    MMAP_AT(0x13000, 0x10000, PROT_READ, MAP_DENYWRITE);
+    MREMAP_AT(0x13000, 0x10000, 0x40000, 0x20000, MREMAP_FIXED | MREMAP_MAYMOVE);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x10000, PROT_NONE, 0},
-        {0x20000, 0x10000, PROT_WRITE, 0},
-        {0x30000, 0x10000, PROT_READ, 0},
+        {0x40000, 0x20000, PROT_READ, FCOMMON_FIXED | MAP_DENYWRITE},
     });
 
-    MREMAP_AT(0x10000, 0x10000, 0x10000, 0x30000);
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MremapMoveDoNotUnmap", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    MMAP_AT(0x13000, 0x10000, PROT_NONE, 0);
+    MREMAP_AT(0x13000, 0x10000, 0x40000, 0x10000, MREMAP_FIXED | MREMAP_MAYMOVE | MREMAP_DONTUNMAP);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x30000, PROT_NONE, 0},
+        {0x40000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MremapGrow", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    MMAP_AT(0x10000, 0x10000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+    });
+
+    MREMAP(0x10000, 0x10000, 0x20000, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x20000, PROT_NONE, FCOMMON_FIXED},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MremapMoveGrow", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    MMAP_AT(0x10000, 0x10000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+    });
+
+    MREMAP_AT(0x10000, 0x10000, 0x40000, 0x20000, MREMAP_FIXED | MREMAP_MAYMOVE);
+
+    verifyGuestRegions(mapper, { 
+        {0x40000, 0x20000, PROT_NONE, FCOMMON_FIXED},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MremapShrink", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    MMAP_AT(0x10000, 0x20000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x20000, PROT_NONE, FCOMMON_FIXED},
+    });
+
+    MREMAP(0x10000, 0x20000, 0x10000, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MremapMoveShrink", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    MMAP_AT(0x10000, 0x20000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x20000, PROT_NONE, FCOMMON_FIXED},
+    });
+
+    MREMAP_AT(0x10000, 0x20000, 0x40000, 0x10000, MREMAP_FIXED | MREMAP_MAYMOVE);
+
+    verifyGuestRegions(mapper, { 
+        {0x40000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MremapMoveMiddle", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    MMAP_AT(0x10000, 0x30000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x30000, PROT_NONE, FCOMMON_FIXED},
+    });
+
+    MREMAP_AT(0x20000, 0x10000, 0x60000, 0x10000, MREMAP_FIXED | MREMAP_MAYMOVE);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x60000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MremapMoveShrinkMiddle", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    MMAP_AT(0x10000, 0x40000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x40000, PROT_NONE, FCOMMON_FIXED},
+    });
+
+    MREMAP_AT(0x20000, 0x20000, 0x60000, 0x10000, MREMAP_FIXED | MREMAP_MAYMOVE);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x40000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x60000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MremapMoveGrowMiddle", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    MMAP_AT(0x10000, 0x30000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x30000, PROT_NONE, FCOMMON_FIXED},
+    });
+
+    MREMAP_AT(0x20000, 0x10000, 0x60000, 0x20000, MREMAP_FIXED | MREMAP_MAYMOVE);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x60000, 0x20000, PROT_NONE, FCOMMON_FIXED},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MremapDeleteMiddle", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    MMAP_AT(0x10000, 0x30000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x30000, PROT_NONE, FCOMMON_FIXED},
+    });
+
+    MREMAP(0x20000, 0x10000, 0x1000, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x11000, PROT_NONE, FCOMMON_FIXED},
+        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();
@@ -946,20 +1152,44 @@ CATCH_TEST_CASE("MremapOverwrite", "[mmap]") {
 CATCH_TEST_CASE("MremapOverwriteDelete", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
+    g_mode32 = false;
 
     MMAP_AT(0x10000, 0x10000, PROT_NONE, 0);
     MMAP_AT(0x20000, 0x10000, PROT_WRITE, 0);
     MMAP_AT(0x30000, 0x10000, PROT_READ, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x10000, PROT_NONE, 0},
-        {0x20000, 0x10000, PROT_WRITE, 0},
-        {0x30000, 0x10000, PROT_READ, 0},
+        {0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x10000, PROT_WRITE, FCOMMON_FIXED},
+        {0x30000, 0x10000, PROT_READ, FCOMMON_FIXED},
     });
 
-    MREMAP_AT(0x10000, 0x30000, 0x10000, 0);
+    MREMAP(0x10000, 0x30000, 0x1000, 0);
 
-    verifyGuestRegions(mapper, {});
+    verifyGuestRegions(mapper, {
+        {0x10000, 0x1000, PROT_NONE, FCOMMON_FIXED},     
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("DifferentNeighborProt", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    MMAP_AT(0x10000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x20000, 0x10000, PROT_WRITE, 0);
+    MMAP_AT(0x30000, 0x10000, PROT_READ, 0);
+    MMAP_AT(0x40000, 0x10000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x10000, PROT_WRITE, FCOMMON_FIXED},
+        {0x30000, 0x10000, PROT_READ, FCOMMON_FIXED},
+        {0x40000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+    });
 
     MUNMAP_ALL();
     SUCCESS_MESSAGE();
@@ -968,15 +1198,41 @@ CATCH_TEST_CASE("MremapOverwriteDelete", "[mmap]") {
 CATCH_TEST_CASE("DifferentNeighborFlags", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
+    g_mode32 = false;
 
     MMAP_AT(0x10000, 0x10000, PROT_NONE, 0);
     MMAP_AT(0x20000, 0x10000, PROT_NONE, MAP_DENYWRITE);
     MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x10000, PROT_NONE, 0},
-        {0x20000, 0x10000, PROT_NONE, MAP_DENYWRITE},
-        {0x30000, 0x10000, PROT_READ, 0},
+        {0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x10000, PROT_NONE, FCOMMON_FIXED | MAP_DENYWRITE},
+        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MergeChain", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    MMAP_AT(0x10000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x50000, 0x10000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x50000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+    });
+
+    MMAP_AT(0x20000, 0x30000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x10000, 0x50000, PROT_NONE, FCOMMON_FIXED},
     });
 
     MUNMAP_ALL();

--- a/tests/Unit/mmap.cpp
+++ b/tests/Unit/mmap.cpp
@@ -2028,3 +2028,49 @@ CATCH_TEST_CASE("SharedAnonymousMappingMergesWithItself", "[mmap]") {
     MUNMAP_ALL();
     SUCCESS_MESSAGE();
 }
+
+CATCH_TEST_CASE("Remap64OntoUsedLowMemory", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    const u64 high = 0x200060000ull;
+    CATCH_REQUIRE(mapper.map(true, (void*)0x50000, 0x2000, PROT_NONE, FCOMMON_FIXED, -1, 0) == (void*)0x50000);
+    CATCH_REQUIRE(mapper.map(false, (void*)high, 0x1000, PROT_NONE, FCOMMON_FIXED, -1, 0) == (void*)high);
+    unmap_me.push_back({0x50000, 0x2000});
+
+    CATCH_REQUIRE(mapper.remap(false, (void*)high, 0x1000, 0x3000, MREMAP_MAYMOVE | MREMAP_FIXED, (void*)0x51000) == (void*)0x51000);
+    unmap_me.push_back({0x51000, 0x3000});
+
+    verifyRegions(mapper, {{(u32)mmap_min_addr(), 0x4ffff}, {0x54000, UINT32_MAX}});
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MProtectAcrossRegionsKeepsFileOffsets", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    char path[] = "/tmp/felix86_mmap_testXXXXXX";
+    int fd = mkstemp(path);
+    CATCH_REQUIRE(fd != -1);
+    CATCH_REQUIRE(ftruncate(fd, 0x10000) == 0);
+    unlink(path);
+    int flags = MAP_PRIVATE | MAP_FIXED;
+    CATCH_REQUIRE(mapper.map(g_mode32, (void*)0x30000, 0x1000, PROT_READ, flags, fd, 0x1000) == (void*)0x30000);
+    CATCH_REQUIRE(mapper.map(g_mode32, (void*)0x31000, 0x1000, PROT_NONE, flags, fd, 0x5000) == (void*)0x31000);
+    unmap_me.push_back({0x30000, 0x2000});
+    CATCH_REQUIRE(mapper.get_guest_regions().size() == 2);
+    CATCH_REQUIRE(mapper.protect((void*)0x30000, 0x2000, PROT_READ) == 0);
+
+    auto regions = mapper.get_guest_regions();
+    CATCH_REQUIRE(regions.size() == 2);
+    CATCH_REQUIRE(regions[0].offset == 0x1000);
+    CATCH_REQUIRE(regions[1].offset == 0x5000);
+
+    close(fd);
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}

--- a/tests/Unit/mmap.cpp
+++ b/tests/Unit/mmap.cpp
@@ -76,22 +76,17 @@ struct GuestRegionExpected {
     u64 start;
     u64 len;
     int prot;
-    int flags;
 };
 
 static void verifyGuestRegions(Mapper& mapper, const std::vector<GuestRegionExpected>& expected_regions) {
     auto guest_regions = mapper.get_guest_regions();
     int found_regions = 0;
-    for (auto& region : guest_regions) {
-        printf("[%lx, %lx], %lx, %lx, %b\n", region.start, region.end, region.prot, region.flags, region.shmem);
-    }
     for (const auto region : expected_regions) {
         for (const auto guest_region : guest_regions) {
             bool yes = true;
             yes &= region.start == guest_region.start;
             yes &= region.start + region.len == guest_region.end;
             // Include the implicit flags here
-            yes &= region.flags == guest_region.flags;
             yes &= region.prot == guest_region.prot;
             yes &= !guest_region.shmem;
             if (yes) {
@@ -122,7 +117,7 @@ CATCH_TEST_CASE("Simple1", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x10000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -143,7 +138,7 @@ CATCH_TEST_CASE("Simple2", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x20000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x20000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -165,7 +160,7 @@ CATCH_TEST_CASE("Simple3", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x30000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x30000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -184,7 +179,7 @@ CATCH_TEST_CASE("FirstPages", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {mmap_min_addr(), 0x10000, PROT_NONE, FCOMMON_FIXED}
+        {mmap_min_addr(), 0x10000, PROT_NONE}
     });
 
     MUNMAP_ALL();
@@ -203,7 +198,7 @@ CATCH_TEST_CASE("FirstPagesUnmap", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {mmap_min_addr(), 0x10000, PROT_NONE, FCOMMON_FIXED}
+        {mmap_min_addr(), 0x10000, PROT_NONE}
     });
 
     UNMAP_AT(mmap_min_addr(), 0x10000);
@@ -232,7 +227,7 @@ CATCH_TEST_CASE("LastPages", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {end - 0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED}
+        {end - 0x10000, 0x10000, PROT_NONE}
     });
 
     MUNMAP_ALL();
@@ -254,8 +249,8 @@ CATCH_TEST_CASE("Split2", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
-        {0x50000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x30000, 0x10000, PROT_NONE},
+        {0x50000, 0x10000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -279,7 +274,7 @@ CATCH_TEST_CASE("Split2Pick1", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x30000, 0x30000, PROT_NONE, FCOMMON_FIXED},
+        {0x30000, 0x30000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -300,7 +295,7 @@ CATCH_TEST_CASE("Overlapping1", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x100000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x100000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -322,7 +317,7 @@ CATCH_TEST_CASE("Overlapping2", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x100000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x100000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -346,9 +341,9 @@ CATCH_TEST_CASE("Overlapping2ConsumeLast", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
-        {0x50000, 0x10000, PROT_NONE, FCOMMON_FIXED},
-        {0x100000, 0x1000, PROT_NONE, FCOMMON_FIXED},
+        {0x30000, 0x10000, PROT_NONE},
+        {0x50000, 0x10000, PROT_NONE},
+        {0x100000, 0x1000, PROT_NONE},
     });
 
     MMAP_AT(0x20000, 0x100000 - 0x20000, PROT_NONE, 0); // this mapping consumes the first two
@@ -359,7 +354,7 @@ CATCH_TEST_CASE("Overlapping2ConsumeLast", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x101000 - 0x20000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x101000 - 0x20000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -379,7 +374,7 @@ CATCH_TEST_CASE("UnmapPerfect", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x30000, 0x10000, PROT_NONE},
     });
 
     UNMAP_AT(0x30000, 0x10000);
@@ -409,7 +404,7 @@ CATCH_TEST_CASE("UnmapMiddle", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x30000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x30000, PROT_NONE},
     });
 
     UNMAP_AT(0x30000, 0x10000);
@@ -421,8 +416,8 @@ CATCH_TEST_CASE("UnmapMiddle", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x10000, PROT_NONE, FCOMMON_FIXED},
-        {0x40000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x10000, PROT_NONE},
+        {0x40000, 0x10000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -442,7 +437,7 @@ CATCH_TEST_CASE("UnmapGreedyMin", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x100000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x100000, PROT_NONE},
     });
 
     // Unmap more pages than we mapped, this is allowed
@@ -454,7 +449,7 @@ CATCH_TEST_CASE("UnmapGreedyMin", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x2F000, 0x120000 - 0x2F000, PROT_NONE, FCOMMON_FIXED},
+        {0x2F000, 0x120000 - 0x2F000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -474,7 +469,7 @@ CATCH_TEST_CASE("UnmapGreedyMax", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x100000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x100000, PROT_NONE},
     });
 
     // Unmap more pages than we mapped, this is allowed
@@ -486,7 +481,7 @@ CATCH_TEST_CASE("UnmapGreedyMax", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x115000 - 0x20000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x115000 - 0x20000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -507,7 +502,7 @@ CATCH_TEST_CASE("MapRandom", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {(u64)address, 0x100000, PROT_NONE, FCOMMON},
+        {(u64)address, 0x100000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -528,7 +523,7 @@ CATCH_TEST_CASE("OverwriteFixed", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x63000, PROT_NONE, FCOMMON_FIXED},
+        {0x10000, 0x63000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -549,7 +544,7 @@ CATCH_TEST_CASE("OverwriteFixed2", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x12000, 0x60000, PROT_NONE, FCOMMON_FIXED},
+        {0x12000, 0x60000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -570,7 +565,7 @@ CATCH_TEST_CASE("Mremap", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x40000, 0x20000, PROT_NONE, FCOMMON_FIXED},
+        {0x40000, 0x20000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -594,9 +589,9 @@ CATCH_TEST_CASE("MMap bug", "[mmap32]") {
     });
 
     verifyGuestRegions(mapper, { 
-        {0x85800000, 0x8d400000-0x85800000, PROT_NONE, FCOMMON_FIXED},
-        {0xFFF00000, 0xFFF7d000-0xFFF00000, PROT_READ | PROT_WRITE, FCOMMON_FIXED},
-        {0xFFF7d000, 0x100000000-0xFFF7d000, PROT_NONE, FCOMMON_FIXED},
+        {0x85800000, 0x8d400000-0x85800000, PROT_NONE},
+        {0xFFF00000, 0xFFF7d000-0xFFF00000, PROT_READ | PROT_WRITE},
+        {0xFFF7d000, 0x100000000-0xFFF7d000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -611,7 +606,7 @@ CATCH_TEST_CASE("Simple1", "[mmap]") {
     MMAP_AT(0x20000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x10000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -627,7 +622,7 @@ CATCH_TEST_CASE("Simple2", "[mmap]") {
     MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x20000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x20000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -644,7 +639,7 @@ CATCH_TEST_CASE("Simple3", "[mmap]") {
     MMAP_AT(0x40000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x30000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x30000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -658,7 +653,7 @@ CATCH_TEST_CASE("FirstPages", "[mmap]") {
     MMAP_AT(mmap_min_addr(), 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {mmap_min_addr(), 0x10000, PROT_NONE, FCOMMON_FIXED}
+        {mmap_min_addr(), 0x10000, PROT_NONE}
     });
 
     MUNMAP_ALL();
@@ -673,7 +668,7 @@ CATCH_TEST_CASE("FirstPagesUnmap", "[mmap]") {
     MMAP_AT(mmap_min_addr(), 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {mmap_min_addr(), 0x10000, PROT_NONE, FCOMMON_FIXED}
+        {mmap_min_addr(), 0x10000, PROT_NONE}
     });
 
     UNMAP_AT(mmap_min_addr(), 0x10000);
@@ -694,7 +689,7 @@ CATCH_TEST_CASE("LastPages", "[mmap]") {
     MMAP_AT(end - 0x10000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {end - 0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED}
+        {end - 0x10000, 0x10000, PROT_NONE}
     });
 
     MUNMAP_ALL();
@@ -710,8 +705,8 @@ CATCH_TEST_CASE("Split2", "[mmap]") {
     MMAP_AT(0x50000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
-        {0x50000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x30000, 0x10000, PROT_NONE},
+        {0x50000, 0x10000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -730,7 +725,7 @@ CATCH_TEST_CASE("Split2Pick1", "[mmap]") {
     MMAP_AT(0x40000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x30000, 0x30000, PROT_NONE, FCOMMON_FIXED},
+        {0x30000, 0x30000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -746,7 +741,7 @@ CATCH_TEST_CASE("Overlapping1", "[mmap]") {
     MMAP_AT(0x20000, 0x100000, PROT_NONE, 0); // this mapping consumes the first
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x100000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x100000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -763,7 +758,7 @@ CATCH_TEST_CASE("Overlapping2", "[mmap]") {
     MMAP_AT(0x20000, 0x100000, PROT_NONE, 0); // this mapping consumes the other two
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x100000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x100000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -780,15 +775,15 @@ CATCH_TEST_CASE("Overlapping2ConsumeLast", "[mmap]") {
     MMAP_AT(0x100000, 0x1000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
-        {0x50000, 0x10000, PROT_NONE, FCOMMON_FIXED},
-        {0x100000, 0x1000, PROT_NONE, FCOMMON_FIXED},
+        {0x30000, 0x10000, PROT_NONE},
+        {0x50000, 0x10000, PROT_NONE},
+        {0x100000, 0x1000, PROT_NONE},
     });
 
     MMAP_AT(0x20000, 0x100000 - 0x20000, PROT_NONE, 0); // this mapping consumes the first two
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x101000 - 0x20000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x101000 - 0x20000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -803,7 +798,7 @@ CATCH_TEST_CASE("UnmapPerfect", "[mmap]") {
     MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x30000, 0x10000, PROT_NONE},
     });
 
     UNMAP_AT(0x30000, 0x10000);
@@ -824,14 +819,14 @@ CATCH_TEST_CASE("UnmapMiddle", "[mmap]") {
     MMAP_AT(0x40000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x30000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x30000, PROT_NONE},
     });
 
     UNMAP_AT(0x30000, 0x10000);
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x10000, PROT_NONE, FCOMMON_FIXED},
-        {0x40000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x10000, PROT_NONE},
+        {0x40000, 0x10000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -846,14 +841,14 @@ CATCH_TEST_CASE("UnmapGreedyMin", "[mmap]") {
     MMAP_AT(0x20000, 0x100000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x100000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x100000, PROT_NONE},
     });
 
     // Unmap more pages than we mapped, this is allowed
     UNMAP_AT(0x1F000, 0x10000);
 
     verifyGuestRegions(mapper, { 
-        {0x2F000, 0x100000 - 0x0F000, PROT_NONE, FCOMMON_FIXED},
+        {0x2F000, 0x100000 - 0x0F000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -868,14 +863,14 @@ CATCH_TEST_CASE("UnmapGreedyMax", "[mmap]") {
     MMAP_AT(0x20000, 0x100000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x100000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x100000, PROT_NONE},
     });
 
     // Unmap more pages than we mapped, this is allowed
     UNMAP_AT(0x115000, 0x10000);
 
     verifyGuestRegions(mapper, { 
-        {0x20000, 0x115000 - 0x20000, PROT_NONE, FCOMMON_FIXED},
+        {0x20000, 0x115000 - 0x20000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -891,7 +886,7 @@ CATCH_TEST_CASE("MapRandom", "[mmap]") {
     MMAP_AT_R(address, 0x100000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {(u64)address, 0x100000, PROT_NONE, FCOMMON},
+        {(u64)address, 0x100000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -908,7 +903,7 @@ CATCH_TEST_CASE("OverwriteFixed", "[mmap]") {
     MMAP_AT(0x13000, 0x60000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x63000, PROT_NONE, FCOMMON_FIXED},
+        {0x10000, 0x63000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -924,7 +919,7 @@ CATCH_TEST_CASE("OverwriteFixed2", "[mmap]") {
     MMAP_AT(0x12000, 0x60000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x12000, 0x60000, PROT_NONE, FCOMMON_FIXED},
+        {0x12000, 0x60000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -940,14 +935,14 @@ CATCH_TEST_CASE("OverwriteFixedNonMergeableNeighbor", "[mmap]") {
     MMAP_AT(0x34000, 0x3000, PROT_READ, 0);
 
     verifyGuestRegions(mapper, {
-        {0x30000, 0x4000, PROT_NONE, FCOMMON_FIXED},
-        {0x34000, 0x3000, PROT_READ, FCOMMON_FIXED},
+        {0x30000, 0x4000, PROT_NONE},
+        {0x34000, 0x3000, PROT_READ},
     });
 
     MMAP_AT(0x34000, 0x6000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, {
-        {0x30000, 0xa000, PROT_NONE, FCOMMON_FIXED},
+        {0x30000, 0xa000, PROT_NONE},
     });
 
     CATCH_REQUIRE(mapper.total_mapped_memory() == 0xa000);
@@ -965,7 +960,7 @@ CATCH_TEST_CASE("MremapMove", "[mmap]") {
     MREMAP_AT(0x13000, 0x10000, 0x40000, 0x10000, MREMAP_FIXED | MREMAP_MAYMOVE);
 
     verifyGuestRegions(mapper, { 
-        {0x40000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x40000, 0x10000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -981,7 +976,7 @@ CATCH_TEST_CASE("MremapMoveKeepsFlagsAndProt", "[mmap]") {
     MREMAP_AT(0x13000, 0x10000, 0x40000, 0x20000, MREMAP_FIXED | MREMAP_MAYMOVE);
 
     verifyGuestRegions(mapper, { 
-        {0x40000, 0x20000, PROT_READ, FCOMMON_FIXED | MAP_DENYWRITE},
+        {0x40000, 0x20000, PROT_READ},
     });
 
     MUNMAP_ALL();
@@ -997,8 +992,8 @@ CATCH_TEST_CASE("MremapMoveDoNotUnmap", "[mmap]") {
     MREMAP_AT(0x13000, 0x10000, 0x40000, 0x10000, MREMAP_FIXED | MREMAP_MAYMOVE | MREMAP_DONTUNMAP);
 
     verifyGuestRegions(mapper, { 
-        {0x13000, 0x10000, PROT_NONE, FCOMMON_FIXED},
-        {0x40000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x13000, 0x10000, PROT_NONE},
+        {0x40000, 0x10000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -1013,13 +1008,13 @@ CATCH_TEST_CASE("MremapGrow", "[mmap]") {
     MMAP_AT(0x10000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x10000, 0x10000, PROT_NONE},
     });
 
     MREMAP(0x10000, 0x10000, 0x20000, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x20000, PROT_NONE, FCOMMON_FIXED},
+        {0x10000, 0x20000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -1034,13 +1029,13 @@ CATCH_TEST_CASE("MremapMoveGrow", "[mmap]") {
     MMAP_AT(0x10000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x10000, 0x10000, PROT_NONE},
     });
 
     MREMAP_AT(0x10000, 0x10000, 0x40000, 0x20000, MREMAP_FIXED | MREMAP_MAYMOVE);
 
     verifyGuestRegions(mapper, { 
-        {0x40000, 0x20000, PROT_NONE, FCOMMON_FIXED},
+        {0x40000, 0x20000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -1055,13 +1050,13 @@ CATCH_TEST_CASE("MremapShrink", "[mmap]") {
     MMAP_AT(0x10000, 0x20000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x20000, PROT_NONE, FCOMMON_FIXED},
+        {0x10000, 0x20000, PROT_NONE},
     });
 
     MREMAP(0x10000, 0x20000, 0x10000, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x10000, 0x10000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -1076,13 +1071,13 @@ CATCH_TEST_CASE("MremapMoveShrink", "[mmap]") {
     MMAP_AT(0x10000, 0x20000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x20000, PROT_NONE, FCOMMON_FIXED},
+        {0x10000, 0x20000, PROT_NONE},
     });
 
     MREMAP_AT(0x10000, 0x20000, 0x40000, 0x10000, MREMAP_FIXED | MREMAP_MAYMOVE);
 
     verifyGuestRegions(mapper, { 
-        {0x40000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x40000, 0x10000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -1097,15 +1092,15 @@ CATCH_TEST_CASE("MremapMoveMiddle", "[mmap]") {
     MMAP_AT(0x10000, 0x30000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x30000, PROT_NONE, FCOMMON_FIXED},
+        {0x10000, 0x30000, PROT_NONE},
     });
 
     MREMAP_AT(0x20000, 0x10000, 0x60000, 0x10000, MREMAP_FIXED | MREMAP_MAYMOVE);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED},
-        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
-        {0x60000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x10000, 0x10000, PROT_NONE},
+        {0x30000, 0x10000, PROT_NONE},
+        {0x60000, 0x10000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -1120,15 +1115,15 @@ CATCH_TEST_CASE("MremapMoveShrinkMiddle", "[mmap]") {
     MMAP_AT(0x10000, 0x40000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x40000, PROT_NONE, FCOMMON_FIXED},
+        {0x10000, 0x40000, PROT_NONE},
     });
 
     MREMAP_AT(0x20000, 0x20000, 0x60000, 0x10000, MREMAP_FIXED | MREMAP_MAYMOVE);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED},
-        {0x40000, 0x10000, PROT_NONE, FCOMMON_FIXED},
-        {0x60000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x10000, 0x10000, PROT_NONE},
+        {0x40000, 0x10000, PROT_NONE},
+        {0x60000, 0x10000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -1143,15 +1138,15 @@ CATCH_TEST_CASE("MremapMoveGrowMiddle", "[mmap]") {
     MMAP_AT(0x10000, 0x30000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x30000, PROT_NONE, FCOMMON_FIXED},
+        {0x10000, 0x30000, PROT_NONE},
     });
 
     MREMAP_AT(0x20000, 0x10000, 0x60000, 0x20000, MREMAP_FIXED | MREMAP_MAYMOVE);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED},
-        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
-        {0x60000, 0x20000, PROT_NONE, FCOMMON_FIXED},
+        {0x10000, 0x10000, PROT_NONE},
+        {0x30000, 0x10000, PROT_NONE},
+        {0x60000, 0x20000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -1166,14 +1161,14 @@ CATCH_TEST_CASE("MremapShrinkMiddle", "[mmap]") {
     MMAP_AT(0x10000, 0x30000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x30000, PROT_NONE, FCOMMON_FIXED},
+        {0x10000, 0x30000, PROT_NONE},
     });
 
     MREMAP(0x20000, 0x10000, 0x1000, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x11000, PROT_NONE, FCOMMON_FIXED},
-        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x10000, 0x11000, PROT_NONE},
+        {0x30000, 0x10000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -1190,15 +1185,15 @@ CATCH_TEST_CASE("MremapShrinkDifferentPriv", "[mmap]") {
     MMAP_AT(0x30000, 0x10000, PROT_READ, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED},
-        {0x20000, 0x10000, PROT_WRITE, FCOMMON_FIXED},
-        {0x30000, 0x10000, PROT_READ, FCOMMON_FIXED},
+        {0x10000, 0x10000, PROT_NONE},
+        {0x20000, 0x10000, PROT_WRITE},
+        {0x30000, 0x10000, PROT_READ},
     });
 
     MREMAP(0x10000, 0x30000, 0x1000, 0);
 
     verifyGuestRegions(mapper, {
-        {0x10000, 0x1000, PROT_NONE, FCOMMON_FIXED},     
+        {0x10000, 0x1000, PROT_NONE},     
     });
 
     MUNMAP_ALL();
@@ -1216,10 +1211,10 @@ CATCH_TEST_CASE("DifferentNeighborProt", "[mmap]") {
     MMAP_AT(0x40000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED},
-        {0x20000, 0x10000, PROT_WRITE, FCOMMON_FIXED},
-        {0x30000, 0x10000, PROT_READ, FCOMMON_FIXED},
-        {0x40000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x10000, 0x10000, PROT_NONE},
+        {0x20000, 0x10000, PROT_WRITE},
+        {0x30000, 0x10000, PROT_READ},
+        {0x40000, 0x10000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -1236,9 +1231,7 @@ CATCH_TEST_CASE("DifferentNeighborFlags", "[mmap]") {
     MMAP_AT(0x30000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED},
-        {0x20000, 0x10000, PROT_NONE, FCOMMON_FIXED | MAP_DENYWRITE},
-        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x10000, 0x30000, PROT_NONE},
     });
 
     MUNMAP_ALL();
@@ -1257,7 +1250,7 @@ CATCH_TEST_CASE("PlacementFlagsDoNotAffectMerging", "[mmap]") {
     unmap_me.push_back({0x40000, 0x10000});
 
     verifyGuestRegions(mapper, {
-        {0x30000, 0x20000, PROT_READ, FCOMMON},
+        {0x30000, 0x20000, PROT_READ},
     });
 
     MUNMAP_ALL();
@@ -1273,7 +1266,7 @@ CATCH_TEST_CASE("PopulateDoesNotAffectMerging", "[mmap]") {
     MMAP_AT(0x40000, 0x10000, PROT_READ, MAP_POPULATE);
 
     verifyGuestRegions(mapper, {
-        {0x30000, 0x20000, PROT_READ, FCOMMON},
+        {0x30000, 0x20000, PROT_READ},
     });
 
     MUNMAP_ALL();
@@ -1347,15 +1340,15 @@ CATCH_TEST_CASE("MergeChain", "[mmap]") {
     MMAP_AT(0x50000, 0x10000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x10000, PROT_NONE, FCOMMON_FIXED},
-        {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
-        {0x50000, 0x10000, PROT_NONE, FCOMMON_FIXED},
+        {0x10000, 0x10000, PROT_NONE},
+        {0x30000, 0x10000, PROT_NONE},
+        {0x50000, 0x10000, PROT_NONE},
     });
 
     MMAP_AT(0x20000, 0x30000, PROT_NONE, 0);
 
     verifyGuestRegions(mapper, { 
-        {0x10000, 0x50000, PROT_NONE, FCOMMON_FIXED},
+        {0x10000, 0x50000, PROT_NONE},
     });
 
     MUNMAP_ALL();

--- a/tests/Unit/mmap.cpp
+++ b/tests/Unit/mmap.cpp
@@ -1,6 +1,8 @@
 // clang-format off
 // Test our mmap implementation
+#include <cstdlib>
 #include <catch2/catch_test_macros.hpp>
+#include <unistd.h>
 #include <sys/mman.h>
 #include "felix86/common/global.hpp"
 #include "felix86/common/log.hpp"
@@ -929,6 +931,31 @@ CATCH_TEST_CASE("OverwriteFixed2", "[mmap]") {
     SUCCESS_MESSAGE();
 }
 
+CATCH_TEST_CASE("OverwriteFixedNonMergeableNeighbor", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    MMAP_AT(0x30000, 0x4000, PROT_NONE, 0);
+    MMAP_AT(0x34000, 0x3000, PROT_READ, 0);
+
+    verifyGuestRegions(mapper, {
+        {0x30000, 0x4000, PROT_NONE, FCOMMON_FIXED},
+        {0x34000, 0x3000, PROT_READ, FCOMMON_FIXED},
+    });
+
+    MMAP_AT(0x34000, 0x6000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, {
+        {0x30000, 0xa000, PROT_NONE, FCOMMON_FIXED},
+    });
+
+    CATCH_REQUIRE(mapper.total_mapped_memory() == 0xa000);
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
 CATCH_TEST_CASE("MremapMove", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;
@@ -1214,6 +1241,98 @@ CATCH_TEST_CASE("DifferentNeighborFlags", "[mmap]") {
         {0x30000, 0x10000, PROT_NONE, FCOMMON_FIXED},
     });
 
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("PlacementFlagsDoNotAffectMerging", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    MMAP_AT(0x30000, 0x10000, PROT_READ, 0);
+
+    void* second = mapper.map(g_mode32, (void*)0x40000, 0x10000, PROT_READ, FCOMMON | MAP_FIXED_NOREPLACE, -1, 0);
+    CATCH_REQUIRE(second == (void*)0x40000);
+    unmap_me.push_back({0x40000, 0x10000});
+
+    verifyGuestRegions(mapper, {
+        {0x30000, 0x20000, PROT_READ, FCOMMON},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("PopulateDoesNotAffectMerging", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    MMAP_AT(0x30000, 0x10000, PROT_READ, 0);
+    MMAP_AT(0x40000, 0x10000, PROT_READ, MAP_POPULATE);
+
+    verifyGuestRegions(mapper, {
+        {0x30000, 0x20000, PROT_READ, FCOMMON},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("FileOffsetAffectsMerging", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    char path[] = "/tmp/felix86_mmap_testXXXXXX";
+    int fd = mkstemp(path);
+    CATCH_REQUIRE(fd != -1);
+    CATCH_REQUIRE(ftruncate(fd, 0x10000) == 0);
+    unlink(path);
+
+    int flags = MAP_PRIVATE | MAP_FIXED;
+    CATCH_REQUIRE(mapper.map(g_mode32, (void*)0x30000, 0x1000, PROT_READ, flags, fd, 0) == (void*)0x30000);
+    CATCH_REQUIRE(mapper.map(g_mode32, (void*)0x31000, 0x1000, PROT_READ, flags, fd, 0xF000) == (void*)0x31000);
+    unmap_me.push_back({0x30000, 0x2000});
+
+    auto regions = mapper.get_guest_regions();
+    CATCH_REQUIRE(regions.size() == 2);
+    CATCH_REQUIRE(regions[0].start == 0x30000);
+    CATCH_REQUIRE(regions[0].end == 0x31000);
+    CATCH_REQUIRE(regions[1].start == 0x31000);
+    CATCH_REQUIRE(regions[1].end == 0x32000);
+
+    close(fd);
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("SameFileThroughDifferentFdsMerges", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    char path[] = "/tmp/felix86_mmap_testXXXXXX";
+    int fd = mkstemp(path);
+    CATCH_REQUIRE(fd != -1);
+    CATCH_REQUIRE(ftruncate(fd, 0x10000) == 0);
+    int other_fd = dup(fd);
+    CATCH_REQUIRE(other_fd != -1);
+    unlink(path);
+
+    int flags = MAP_PRIVATE | MAP_FIXED;
+    CATCH_REQUIRE(mapper.map(g_mode32, (void*)0x30000, 0x1000, PROT_READ, flags, fd, 0) == (void*)0x30000);
+    CATCH_REQUIRE(mapper.map(g_mode32, (void*)0x31000, 0x1000, PROT_READ, flags, other_fd, 0x1000) == (void*)0x31000);
+    unmap_me.push_back({0x30000, 0x2000});
+
+    auto regions = mapper.get_guest_regions();
+    CATCH_REQUIRE(regions.size() == 1);
+    CATCH_REQUIRE(regions[0].start == 0x30000);
+    CATCH_REQUIRE(regions[0].end == 0x32000);
+
+    close(fd);
+    close(other_fd);
     MUNMAP_ALL();
     SUCCESS_MESSAGE();
 }

--- a/tests/Unit/mmap.cpp
+++ b/tests/Unit/mmap.cpp
@@ -1752,3 +1752,25 @@ CATCH_TEST_CASE("MProtectMiddle", "[mmap]") {
     MUNMAP_ALL();
     SUCCESS_MESSAGE();
 }
+
+CATCH_TEST_CASE("MremapGrowFromInsideRegion", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = true;
+
+    MMAP_AT(0x20000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x50000, 0x1000, PROT_NONE, 0);
+
+    CATCH_REQUIRE(mapper.remap(g_mode32, (void*)0x21000, 0x1000, 0x2000, MREMAP_MAYMOVE | MREMAP_FIXED, (void*)0x60000) == (void*)0x60000);
+    unmap_me.push_back({0x60000, 0x2000});
+
+    verifyGuestRegions(mapper, {
+        {0x20000, 0x1000, PROT_NONE},
+        {0x22000, 0xe000, PROT_NONE},
+        {0x50000, 0x1000, PROT_NONE},
+        {0x60000, 0x2000, PROT_NONE},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}

--- a/tests/Unit/mmap.cpp
+++ b/tests/Unit/mmap.cpp
@@ -1,5 +1,6 @@
 // clang-format off
 // Test our mmap implementation
+#include <cstdio>
 #include <cstdlib>
 #include <catch2/catch_test_macros.hpp>
 #include <unistd.h>
@@ -595,6 +596,85 @@ CATCH_TEST_CASE("MMap bug", "[mmap32]") {
     });
 
     MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MremapFixedOntoExistingMapping", "[mmap32]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = true;
+
+    MMAP_AT(0x13000, 0x10000, PROT_NONE, 0);
+    MMAP_AT(0x40000, 0x10000, PROT_NONE, 0);
+    MREMAP_AT(0x13000, 0x10000, 0x40000, 0x10000, MREMAP_FIXED | MREMAP_MAYMOVE);
+
+    verifyRegions(mapper, {
+        {mmap_min_addr(), 0x3ffff},
+        {0x50000, (u64)UINT32_MAX},
+    });
+
+    verifyGuestRegions(mapper, {
+        {0x40000, 0x10000, PROT_NONE},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MremapMayMoveInPlaceIn32BitSpace", "[mmap32]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = true;
+
+    MMAP_AT(0x40000, 0x2000, PROT_NONE, 0);
+
+    void* moved = mapper.remap(false, (void*)0x40000, 0x2000, 0x2000, MREMAP_MAYMOVE, nullptr);
+    CATCH_REQUIRE(moved == (void*)0x40000);
+
+    verifyGuestRegions(mapper, {
+        {0x40000, 0x2000, PROT_NONE},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MremapOutOf32BitSpaceFreesTheFreelist", "[mmap32]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = true;
+
+    void* high = mmap(nullptr, 0x2000, PROT_NONE, MAP_PRIVATE | MAP_ANONYMOUS | MAP_NORESERVE, -1, 0);
+    CATCH_REQUIRE(high != MAP_FAILED);
+    CATCH_REQUIRE((u64)high > UINT32_MAX);
+    CATCH_REQUIRE(munmap(high, 0x2000) == 0);
+
+    MMAP_AT(0x40000, 0x2000, PROT_NONE, 0);
+
+    verifyRegions(mapper, {
+        {mmap_min_addr(), 0x3ffff},
+        {0x42000, (u64)UINT32_MAX},
+    });
+
+    void* moved = mapper.remap(false, (void*)0x40000, 0x2000, 0x2000, MREMAP_FIXED | MREMAP_MAYMOVE, high);
+    CATCH_REQUIRE(moved == high);
+
+    verifyRegions(mapper, {
+        {mmap_min_addr(), (u64)UINT32_MAX},
+    });
+
+    munmap(high, 0x2000);
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MremapUnmappedSourceReturnsError", "[mmap32]") {
+    Mapper mapper;
+    g_mode32 = true;
+
+    void* result = mapper.remap(g_mode32, (void*)0x40000, 0x1000, 0x2000, MREMAP_MAYMOVE, nullptr);
+    CATCH_REQUIRE(result == MAP_FAILED);
+
     SUCCESS_MESSAGE();
 }
 
@@ -1349,6 +1429,324 @@ CATCH_TEST_CASE("MergeChain", "[mmap]") {
 
     verifyGuestRegions(mapper, { 
         {0x10000, 0x50000, PROT_NONE},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MremapDoNotUnmapMiddle", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    MMAP_AT(0x10000, 0x30000, PROT_NONE, 0);
+    MREMAP_AT(0x20000, 0x10000, 0x60000, 0x10000, MREMAP_FIXED | MREMAP_MAYMOVE | MREMAP_DONTUNMAP);
+
+    verifyGuestRegions(mapper, {
+        {0x10000, 0x30000, PROT_NONE},
+        {0x60000, 0x10000, PROT_NONE},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("SplitFileMappingAdjustsOffset", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    char path[] = "/tmp/felix86_mmap_testXXXXXX";
+    int fd = mkstemp(path);
+    CATCH_REQUIRE(fd != -1);
+    CATCH_REQUIRE(ftruncate(fd, 0x10000) == 0);
+    unlink(path);
+
+    int flags = MAP_PRIVATE | MAP_FIXED;
+    CATCH_REQUIRE(mapper.map(g_mode32, (void*)0x30000, 0x3000, PROT_READ, flags, fd, 0) == (void*)0x30000);
+    CATCH_REQUIRE(mapper.map(g_mode32, (void*)0x31000, 0x1000, PROT_READ, FCOMMON_FIXED, -1, 0) == (void*)0x31000);
+    unmap_me.push_back({0x30000, 0x3000});
+
+    auto regions = mapper.get_guest_regions();
+    CATCH_REQUIRE(regions.size() == 3);
+    CATCH_REQUIRE(regions[0].start == 0x30000);
+    CATCH_REQUIRE(regions[0].offset == 0);
+    CATCH_REQUIRE(regions[2].start == 0x32000);
+    CATCH_REQUIRE(regions[2].offset == 0x2000);
+
+    close(fd);
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("TrimFileMappingStartAdjustsOffset", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    char path[] = "/tmp/felix86_mmap_testXXXXXX";
+    int fd = mkstemp(path);
+    CATCH_REQUIRE(fd != -1);
+    CATCH_REQUIRE(ftruncate(fd, 0x10000) == 0);
+    unlink(path);
+
+    int flags = MAP_PRIVATE | MAP_FIXED;
+    CATCH_REQUIRE(mapper.map(g_mode32, (void*)0x31000, 0x2000, PROT_READ, flags, fd, 0x1000) == (void*)0x31000);
+    unmap_me.push_back({0x31000, 0x2000});
+
+    UNMAP_AT(0x30000, 0x2000);
+
+    auto regions = mapper.get_guest_regions();
+    CATCH_REQUIRE(regions.size() == 1);
+    CATCH_REQUIRE(regions[0].start == 0x32000);
+    CATCH_REQUIRE(regions[0].end == 0x33000);
+    CATCH_REQUIRE(regions[0].offset == 0x2000);
+
+    close(fd);
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MremapMoveMiddleOfFileMapping", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    char path[] = "/tmp/felix86_mmap_testXXXXXX";
+    int fd = mkstemp(path);
+    CATCH_REQUIRE(fd != -1);
+    CATCH_REQUIRE(ftruncate(fd, 0x10000) == 0);
+    unlink(path);
+
+    int flags = MAP_PRIVATE | MAP_FIXED;
+    CATCH_REQUIRE(mapper.map(g_mode32, (void*)0x30000, 0x3000, PROT_READ, flags, fd, 0) == (void*)0x30000);
+    unmap_me.push_back({0x30000, 0x3000});
+
+    MREMAP_AT(0x31000, 0x1000, 0x50000, 0x1000, MREMAP_FIXED | MREMAP_MAYMOVE);
+
+    auto regions = mapper.get_guest_regions();
+    CATCH_REQUIRE(regions.size() == 3);
+    CATCH_REQUIRE(regions[1].start == 0x32000);
+    CATCH_REQUIRE(regions[1].offset == 0x2000);
+    CATCH_REQUIRE(regions[2].start == 0x50000);
+    CATCH_REQUIRE(regions[2].offset == 0x1000);
+
+    close(fd);
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("FileOffsetMergeDirection", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    char path[] = "/tmp/felix86_mmap_testXXXXXX";
+    int fd = mkstemp(path);
+    CATCH_REQUIRE(fd != -1);
+    CATCH_REQUIRE(ftruncate(fd, 0x10000) == 0);
+    unlink(path);
+
+    int flags = MAP_PRIVATE | MAP_FIXED;
+    CATCH_REQUIRE(mapper.map(g_mode32, (void*)0x31000, 0x1000, PROT_READ, flags, fd, 0x1000) == (void*)0x31000);
+    CATCH_REQUIRE(mapper.map(g_mode32, (void*)0x30000, 0x1000, PROT_READ, flags, fd, 0x2000) == (void*)0x30000);
+    unmap_me.push_back({0x30000, 0x2000});
+
+    auto regions = mapper.get_guest_regions();
+    CATCH_REQUIRE(regions.size() == 2);
+    CATCH_REQUIRE(regions[0].offset == 0x2000);
+    CATCH_REQUIRE(regions[1].offset == 0x1000);
+
+    close(fd);
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MergeLeadingFileMappingKeepsOffset", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = false;
+
+    char path[] = "/tmp/felix86_mmap_testXXXXXX";
+    int fd = mkstemp(path);
+    CATCH_REQUIRE(fd != -1);
+    CATCH_REQUIRE(ftruncate(fd, 0x10000) == 0);
+    unlink(path);
+
+    int flags = MAP_PRIVATE | MAP_FIXED;
+    CATCH_REQUIRE(mapper.map(g_mode32, (void*)0x31000, 0x1000, PROT_READ, flags, fd, 0x1000) == (void*)0x31000);
+    CATCH_REQUIRE(mapper.map(g_mode32, (void*)0x30000, 0x1000, PROT_READ, flags, fd, 0) == (void*)0x30000);
+    unmap_me.push_back({0x30000, 0x2000});
+
+    auto regions = mapper.get_guest_regions();
+    CATCH_REQUIRE(regions.size() == 1);
+    CATCH_REQUIRE(regions[0].start == 0x30000);
+    CATCH_REQUIRE(regions[0].end == 0x32000);
+    CATCH_REQUIRE(regions[0].offset == 0);
+
+    close(fd);
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MProtect1", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = true;
+
+    MMAP_AT(0x20000, 0x10000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x10000, PROT_NONE},
+    });
+
+    mapper.protect((void*)0x20000, 0x10000, PROT_WRITE);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x10000, PROT_WRITE},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MProtectLeft", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = true;
+
+    MMAP_AT(0x20000, 0x20000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x20000, PROT_NONE},
+    });
+
+    mapper.protect((void*)0x20000, 0x10000, PROT_WRITE);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x10000, PROT_WRITE},
+        {0x30000, 0x10000, PROT_NONE},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MProtectRight", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = true;
+
+    MMAP_AT(0x20000, 0x20000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x20000, PROT_NONE},
+    });
+
+    mapper.protect((void*)0x30000, 0x10000, PROT_WRITE);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x10000, PROT_NONE},
+        {0x30000, 0x10000, PROT_WRITE},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+
+CATCH_TEST_CASE("MProtectLeftRight", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = true;
+
+    MMAP_AT(0x20000, 0x20000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x20000, PROT_NONE},
+    });
+
+    mapper.protect((void*)0x20000, 0x10000, PROT_WRITE);
+    mapper.protect((void*)0x30000, 0x10000, PROT_READ);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x10000, PROT_WRITE},
+        {0x30000, 0x10000, PROT_READ},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MProtectLeftRightMerge", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = true;
+
+    MMAP_AT(0x20000, 0x20000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x20000, PROT_NONE},
+    });
+
+    mapper.protect((void*)0x20000, 0x10000, PROT_WRITE);
+    mapper.protect((void*)0x30000, 0x10000, PROT_WRITE);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x20000, PROT_WRITE},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MProtectLeftRightThenMerge", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = true;
+
+    MMAP_AT(0x20000, 0x20000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x20000, PROT_NONE},
+    });
+
+    mapper.protect((void*)0x20000, 0x10000, PROT_WRITE);
+    mapper.protect((void*)0x30000, 0x10000, PROT_READ);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x10000, PROT_WRITE},
+        {0x30000, 0x10000, PROT_READ},
+    });
+
+    mapper.protect((void*)0x20000, 0x20000, PROT_WRITE);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x20000, PROT_WRITE},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("MProtectMiddle", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = true;
+
+    MMAP_AT(0x20000, 0x30000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x30000, PROT_NONE},
+    });
+
+    mapper.protect((void*)0x30000, 0x10000, PROT_WRITE);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x10000, PROT_NONE},
+        {0x30000, 0x10000, PROT_WRITE},
+        {0x40000, 0x10000, PROT_NONE},
     });
 
     MUNMAP_ALL();

--- a/tests/Unit/mmap.cpp
+++ b/tests/Unit/mmap.cpp
@@ -24,8 +24,8 @@ namespace Catch {
 
 #define SUCCESS_MESSAGE() SUCCESS("Test passed: %s", Catch::getResultCapture().getCurrentTestName().c_str())
 
-const int FCOMMON = MAP_ANONYMOUS | MAP_PRIVATE;
-const int FCOMMON_FIXED = FCOMMON | MAP_FIXED;
+static const int FCOMMON = MAP_ANONYMOUS | MAP_PRIVATE;
+static const int FCOMMON_FIXED = FCOMMON | MAP_FIXED;
 
 #define MMAP_AT(addr, size, prot, flags) \
     do { \
@@ -77,7 +77,7 @@ struct GuestRegionExpected {
     int flags;
 };
 
-void verifyGuestRegions(Mapper& mapper, const std::vector<GuestRegionExpected>& expected_regions) {
+static void verifyGuestRegions(Mapper& mapper, const std::vector<GuestRegionExpected>& expected_regions) {
     auto guest_regions = mapper.get_guest_regions();
     int found_regions = 0;
     for (const auto region : expected_regions) {

--- a/tests/Unit/mmap.cpp
+++ b/tests/Unit/mmap.cpp
@@ -1643,6 +1643,28 @@ CATCH_TEST_CASE("MProtect1", "[mmap]") {
     SUCCESS_MESSAGE();
 }
 
+CATCH_TEST_CASE("MProtect2", "[mmap]") {
+    std::vector<std::pair<u32, u32>> unmap_me;
+    Mapper mapper;
+    g_mode32 = true;
+
+    MMAP_AT(0x20000, 0x20000, PROT_NONE, 0);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x20000, PROT_NONE},
+    });
+
+    mapper.protect((void*)0x30000, 0x10000, PROT_WRITE);
+
+    verifyGuestRegions(mapper, { 
+        {0x20000, 0x10000, PROT_NONE},
+        {0x30000, 0x10000, PROT_WRITE},
+    });
+
+    MUNMAP_ALL();
+    SUCCESS_MESSAGE();
+}
+
 CATCH_TEST_CASE("MProtectLeft", "[mmap]") {
     std::vector<std::pair<u32, u32>> unmap_me;
     Mapper mapper;

--- a/tests/Unit/shmat.cpp
+++ b/tests/Unit/shmat.cpp
@@ -1,6 +1,7 @@
 // clang-format off
 // Test our shmat implementation
 #include <catch2/catch_test_macros.hpp>
+#include <sys/mman.h>
 #include <sys/shm.h>
 #include <sys/types.h>
 #include "felix86/common/log.hpp"
@@ -24,7 +25,6 @@ struct GuestRegionExpected {
     u64 start;
     u64 len;
     int prot;
-    int flags;
 };
 
 static void verifyGuestRegions(Mapper& mapper, const std::vector<GuestRegionExpected>& expected_regions) {
@@ -35,7 +35,6 @@ static void verifyGuestRegions(Mapper& mapper, const std::vector<GuestRegionExpe
             bool yes = true;
             yes &= region.start == guest_region.start;
             yes &= region.start + region.len == guest_region.end;
-            yes &= region.flags == guest_region.flags;
             yes &= region.prot == guest_region.prot;
             yes &= guest_region.shmem;
             if (yes) {
@@ -60,7 +59,30 @@ CATCH_TEST_CASE("Simple1", "[shmat32]") {
     CATCH_REQUIRE(result == 0x50000);
 
     verifyGuestRegions(mapper, { 
-        {result, 0x1000, 0, 0},
+        {result, 0x1000, PROT_READ | PROT_WRITE},
+    });
+
+    CATCH_REQUIRE(mapper.shmdt(true, (void*)result) == 0);
+
+    verifyGuestRegions(mapper, {});
+
+    CATCH_REQUIRE(shmctl(shmid, IPC_RMID, 0) == 0);
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("Simple2", "[shmat32]") {
+    Mapper mapper;
+
+    key_t key;
+    int shmid = shmget(IPC_PRIVATE, 0x1000, 0777 | IPC_CREAT);
+    CATCH_REQUIRE(shmid != -1);
+
+    u64 result = 0;
+    CATCH_REQUIRE(mapper.shmat(true, shmid, (void*)0x50000, SHM_EXEC | SHM_RDONLY, &result) == 0);
+    CATCH_REQUIRE(result == 0x50000);
+
+    verifyGuestRegions(mapper, { 
+        {result, 0x1000, PROT_READ | PROT_EXEC},
     });
 
     CATCH_REQUIRE(mapper.shmdt(true, (void*)result) == 0);
@@ -83,7 +105,30 @@ CATCH_TEST_CASE("Simple1", "[shmat]") {
     CATCH_REQUIRE(result == 0x50000);
 
     verifyGuestRegions(mapper, { 
-        {result, 0x1000, 0, 0},
+        {result, 0x1000, PROT_READ | PROT_WRITE},
+    });
+
+    CATCH_REQUIRE(mapper.shmdt(false, (void*)result) == 0);
+
+    verifyGuestRegions(mapper, {});
+
+    CATCH_REQUIRE(shmctl(shmid, IPC_RMID, 0) == 0);
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("Simple2", "[shmat]") {
+    Mapper mapper;
+
+    key_t key;
+    int shmid = shmget(IPC_PRIVATE, 0x1000, 0777 | IPC_CREAT);
+    CATCH_REQUIRE(shmid != -1);
+
+    u64 result = 0;
+    CATCH_REQUIRE(mapper.shmat(false, shmid, (void*)0x50000, SHM_EXEC | SHM_RDONLY, &result) == 0);
+    CATCH_REQUIRE(result == 0x50000);
+
+    verifyGuestRegions(mapper, { 
+        {result, 0x1000, PROT_READ | PROT_EXEC},
     });
 
     CATCH_REQUIRE(mapper.shmdt(false, (void*)result) == 0);
@@ -108,14 +153,14 @@ CATCH_TEST_CASE("DistinctSegments", "[shmat]") {
     CATCH_REQUIRE(mapper.shmat(false, second_shmid, (void*)0x200005000ull, 0, &second) == 0);
 
     verifyGuestRegions(mapper, { 
-        {first, 0x1000, 0, 0},
-        {second, 0x2000, 0, 0},
+        {first, 0x1000, PROT_READ | PROT_WRITE},
+        {second, 0x2000, PROT_READ | PROT_WRITE},
     });
 
     CATCH_REQUIRE(mapper.shmdt(false, (void*)first) == 0);
  
     verifyGuestRegions(mapper, { 
-       {second, 0x2000, 0, 0},
+       {second, 0x2000, PROT_READ | PROT_WRITE},
     });
  
     CATCH_REQUIRE(mapper.shmdt(false, (void*)second) == 0);

--- a/tests/Unit/shmat.cpp
+++ b/tests/Unit/shmat.cpp
@@ -5,6 +5,7 @@
 #include <sys/shm.h>
 #include <sys/types.h>
 #include "felix86/common/log.hpp"
+#include "felix86/common/utility.hpp"
 #include "felix86/hle/mmap.hpp"
 
 namespace Catch {
@@ -221,6 +222,144 @@ CATCH_TEST_CASE("ShmdtKeepsUnrelatedMappingInWindow", "[shmat]") {
     CATCH_REQUIRE(regions[0].start == base + 0x1000);
     CATCH_REQUIRE(regions[0].end == base + 0x2000);
     CATCH_REQUIRE(!regions[0].shmem);
+
+    munmap(neighbour, 0x1000);
+    CATCH_REQUIRE(shmctl(shmid, IPC_RMID, nullptr) == 0);
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("ShmatPastEndOf32BitSpace", "[shmat32]") {
+    Mapper mapper;
+
+    int shmid = shmget(IPC_PRIVATE, 0x2000, 0644 | IPC_CREAT);
+    CATCH_REQUIRE(shmid != -1);
+
+    u64 result = 0;
+    CATCH_REQUIRE(mapper.shmat(true, shmid, (void*)0xfffff000ull, 0, &result) < 0);
+
+    CATCH_REQUIRE(mapper.shmat(true, shmid, (void*)0xffffe000ull, 0, &result) == 0);
+    CATCH_REQUIRE(result == 0xffffe000ull);
+    CATCH_REQUIRE(mapper.shmdt(true, (void*)result) == 0);
+
+    CATCH_REQUIRE(shmctl(shmid, IPC_RMID, nullptr) == 0);
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("ShmatWhenFreelistPickIsTaken", "[shmat32]") {
+    Mapper mapper;
+
+    int shmid = shmget(IPC_PRIVATE, 0x2000, 0644 | IPC_CREAT);
+    CATCH_REQUIRE(shmid != -1);
+
+    const u64 window = 0x60000;
+    u64 min = mmap_min_addr();
+    CATCH_REQUIRE(mapper.allocate(min, window - min) == (void*)min);
+    CATCH_REQUIRE(mapper.allocate(window + 0x2000, (u64)UINT32_MAX + 1 - (window + 0x2000)) == (void*)(window + 0x2000));
+
+    void* taken = mmap((void*)window, 0x2000, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, -1, 0);
+    CATCH_REQUIRE(taken == (void*)window);
+
+    u64 result = 0;
+    CATCH_REQUIRE(mapper.shmat(true, shmid, nullptr, 0, &result) < 0);
+    CATCH_REQUIRE(mapper.get_guest_regions().empty());
+
+    munmap(taken, 0x2000);
+    CATCH_REQUIRE(shmctl(shmid, IPC_RMID, nullptr) == 0);
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("ShmdtOneOfTwoAdjacentAttachments", "[shmat]") {
+    Mapper mapper;
+
+    int shmid = shmget(IPC_PRIVATE, 0x2000, 0644 | IPC_CREAT);
+    CATCH_REQUIRE(shmid != -1);
+
+    const u64 first_address = 0x100005000ull;
+    const u64 second_address = first_address + 0x2000;
+    u64 first = 0;
+    u64 second = 0;
+    CATCH_REQUIRE(mapper.shmat(false, shmid, (void*)first_address, 0, &first) == 0);
+    CATCH_REQUIRE(mapper.shmat(false, shmid, (void*)second_address, 0, &second) == 0);
+
+    CATCH_CHECK(mapper.get_guest_regions().size() == 2);
+
+    CATCH_REQUIRE(mapper.shmdt(false, (void*)second) == 0);
+
+    auto regions = mapper.get_guest_regions();
+    CATCH_REQUIRE(regions.size() == 1);
+    CATCH_REQUIRE(regions[0].start == first_address);
+    CATCH_REQUIRE(regions[0].end == first_address + 0x2000);
+
+    CATCH_REQUIRE(mapper.shmdt(false, (void*)first) == 0);
+    CATCH_REQUIRE(mapper.get_guest_regions().empty());
+
+    CATCH_REQUIRE(shmctl(shmid, IPC_RMID, nullptr) == 0);
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("AdjacentAttachmentsOfSameSegment", "[shmat]") {
+    Mapper mapper;
+
+    int shmid = shmget(IPC_PRIVATE, 0x1000, 0644 | IPC_CREAT);
+    CATCH_REQUIRE(shmid != -1);
+
+    u64 first = 0;
+    u64 second = 0;
+    CATCH_REQUIRE(mapper.shmat(false, shmid, (void*)0x100005000ull, 0, &first) == 0);
+    CATCH_REQUIRE(mapper.shmat(false, shmid, (void*)0x100006000ull, 0, &second) == 0);
+
+    verifyGuestRegions(mapper, {
+        {first, 0x1000, PROT_READ | PROT_WRITE},
+        {second, 0x1000, PROT_READ | PROT_WRITE},
+    });
+
+    CATCH_REQUIRE(mapper.shmdt(false, (void*)first) == 0);
+    CATCH_REQUIRE(mapper.shmdt(false, (void*)second) == 0);
+
+    CATCH_REQUIRE(shmctl(shmid, IPC_RMID, nullptr) == 0);
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("ShmdtRemovesGrownAttachment", "[shmat]") {
+    Mapper mapper;
+
+    int shmid = shmget(IPC_PRIVATE, 0x2000, 0644 | IPC_CREAT);
+    CATCH_REQUIRE(shmid != -1);
+
+    u64 address = 0;
+    CATCH_REQUIRE(mapper.shmat(false, shmid, (void*)0x100005000ull, 0, &address) == 0);
+    CATCH_REQUIRE(mapper.remap(false, (void*)address, 0x2000, 0x3000, 0, (void*)address) == (void*)address);
+
+    verifyGuestRegions(mapper, {
+        {address, 0x3000, PROT_READ | PROT_WRITE},
+    });
+
+    CATCH_REQUIRE(mapper.shmdt(false, (void*)address) == 0);
+    verifyGuestRegions(mapper, {});
+
+    CATCH_REQUIRE(shmctl(shmid, IPC_RMID, nullptr) == 0);
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("ShmdtKeepsNeighbouringMapping", "[shmat]") {
+    Mapper mapper;
+
+    int shmid = shmget(IPC_PRIVATE, 0x2000, 0644 | IPC_CREAT);
+    CATCH_REQUIRE(shmid != -1);
+
+    u64 address = 0;
+    CATCH_REQUIRE(mapper.shmat(false, shmid, (void*)0x100005000ull, 0, &address) == 0);
+    CATCH_REQUIRE(mapper.unmap(false, (void*)0x100006000ull, 0x1000) == 0);
+
+    void* neighbour = mapper.map(false, (void*)0x100006000ull, 0x1000, PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, -1, 0);
+    CATCH_REQUIRE(neighbour == (void*)0x100006000ull);
+
+    CATCH_REQUIRE(mapper.shmdt(false, (void*)address) == 0);
+
+    auto regions = mapper.get_guest_regions();
+    CATCH_REQUIRE(regions.size() == 1);
+    CATCH_REQUIRE(regions[0].start == 0x100006000ull);
+    CATCH_REQUIRE(regions[0].end == 0x100007000ull);
 
     munmap(neighbour, 0x1000);
     CATCH_REQUIRE(shmctl(shmid, IPC_RMID, nullptr) == 0);

--- a/tests/Unit/shmat.cpp
+++ b/tests/Unit/shmat.cpp
@@ -1,0 +1,80 @@
+// clang-format off
+// Test our shmat implementation
+#include <catch2/catch_test_macros.hpp>
+#include <sys/shm.h>
+#include <sys/types.h>
+#include "felix86/common/log.hpp"
+#include "felix86/hle/mmap.hpp"
+
+#define SUCCESS_MESSAGE() SUCCESS("Test passed: %s", Catch::getResultCapture().getCurrentTestName().c_str())
+
+struct GuestRegionExpected {
+    u64 start;
+    u64 len;
+    int flags;
+    int prot;
+};
+
+void verifyGuestRegions(Mapper& mapper, const std::vector<GuestRegionExpected>& expected_regions) {
+    auto guest_regions = mapper.get_guest_regions();
+    int found_regions = 0;
+    for (const auto region : expected_regions) {
+        for (const auto guest_region : guest_regions) {
+            bool yes = true;
+            yes &= region.start == guest_region.start;
+            yes &= region.start + region.len == guest_region.end;
+            // Include the implicit flags here
+            yes &= region.flags == guest_region.flags;
+            yes &= region.prot == guest_region.prot;
+            yes &= guest_region.shmem;
+            if (yes) {
+                found_regions += 1;
+                break;
+            };
+        }
+    }
+    CATCH_REQUIRE(found_regions == expected_regions.size());    
+}
+
+CATCH_TEST_CASE("Simple1", "[shmat32]") {
+    Mapper mapper;
+
+    key_t key;
+    int shmid = shmget(key, 1024, 0644 | IPC_CREAT);
+    ASSERT(shmid != -1);
+
+    u64 result = 0;
+    mapper.shmat(false, shmid, (void*)0x50000, 0, &result);
+    ASSERT(result = 0x50000);
+
+    verifyGuestRegions(mapper, { 
+        {result, 1024, 0, 0644 | IPC_CREAT},
+    });
+
+    mapper.shmdt(false, (void*)result);
+
+    verifyGuestRegions(mapper, {});
+
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("Simple1", "[shmat]") {
+    Mapper mapper;
+
+    key_t key;
+    int shmid = shmget(key, 1024, 0644 | IPC_CREAT);
+    ASSERT(shmid != -1);
+
+    u64 result = 0;
+    mapper.shmat(false, shmid, 0, 0, &result);
+
+    verifyGuestRegions(mapper, { 
+        {result, 1024, 0, 0644 | IPC_CREAT},
+    });
+
+    mapper.shmdt(false, (void*)result);
+
+    verifyGuestRegions(mapper, {});
+
+    SUCCESS_MESSAGE();
+}

--- a/tests/Unit/shmat.cpp
+++ b/tests/Unit/shmat.cpp
@@ -342,3 +342,47 @@ CATCH_TEST_CASE("ShmdtKeepsNeighbouringMapping", "[shmat]") {
     CATCH_REQUIRE(shmctl(shmid, IPC_RMID, nullptr) == 0);
     SUCCESS_MESSAGE();
 }
+
+CATCH_TEST_CASE("ShmdtRemovesEveryAttachmentPiece", "[shmat]") {
+    Mapper mapper;
+
+    int shmid = shmget(IPC_PRIVATE, 0x3000, 0644 | IPC_CREAT);
+    CATCH_REQUIRE(shmid != -1);
+
+    const u64 base = 0x100040000ull;
+    u64 address = 0;
+    CATCH_REQUIRE(mapper.shmat(false, shmid, (void*)base, 0, &address) == 0);
+
+    CATCH_REQUIRE(mapper.unmap(false, (void*)(base + 0x1000), 0x1000) == 0);
+    CATCH_REQUIRE(mapper.get_guest_regions().size() == 2);
+
+    CATCH_REQUIRE(mapper.shmdt(false, (void*)base) == 0);
+    CATCH_REQUIRE(mapper.get_guest_regions().empty());
+
+    CATCH_REQUIRE(shmctl(shmid, IPC_RMID, nullptr) == 0);
+    munmap((void*)base, 0x8000);
+    SUCCESS_MESSAGE();
+}
+
+CATCH_TEST_CASE("ShmdtRemovesAttachmentAfterFirstPageMoved", "[shmat]") {
+    Mapper mapper;
+
+    int shmid = shmget(IPC_PRIVATE, 0x2000, 0644 | IPC_CREAT);
+    CATCH_REQUIRE(shmid != -1);
+
+    const u64 base = 0x100050000ull;
+    const u64 moved = base + 0x4000;
+    u64 address = 0;
+    CATCH_REQUIRE(mapper.shmat(false, shmid, (void*)base, 0, &address) == 0);
+    CATCH_REQUIRE(mapper.remap(false, (void*)base, 0x1000, 0x1000, MREMAP_MAYMOVE | MREMAP_FIXED, (void*)moved) == (void*)moved);
+    CATCH_REQUIRE(mapper.shmdt(false, (void*)base) == 0);
+
+    auto regions = mapper.get_guest_regions();
+    CATCH_REQUIRE(regions.size() == 1);
+    CATCH_REQUIRE(regions[0].start == moved);
+
+    munmap((void*)moved, 0x1000);
+    CATCH_REQUIRE(shmctl(shmid, IPC_RMID, nullptr) == 0);
+    munmap((void*)base, 0x8000);
+    SUCCESS_MESSAGE();
+}

--- a/tests/Unit/shmat.cpp
+++ b/tests/Unit/shmat.cpp
@@ -6,18 +6,33 @@
 #include "felix86/common/log.hpp"
 #include "felix86/hle/mmap.hpp"
 
+namespace Catch {
+    template <>
+    struct StringMaker<std::pair<uint32_t, uint32_t>> {
+        static std::string convert(const std::pair<uint32_t, uint32_t>& range) {
+            std::ostringstream oss;
+            oss << "0x" << std::hex << std::setw(16) << std::setfill('0') << range.first
+                << " - 0x" << std::hex << std::setw(16) << std::setfill('0') << range.second;
+            return oss.str();
+        }
+    };
+}
+
 #define SUCCESS_MESSAGE() SUCCESS("Test passed: %s", Catch::getResultCapture().getCurrentTestName().c_str())
 
 struct GuestRegionExpected {
     u64 start;
     u64 len;
-    int flags;
     int prot;
+    int flags;
 };
 
-void verifyGuestRegions(Mapper& mapper, const std::vector<GuestRegionExpected>& expected_regions) {
+static void verifyGuestRegions(Mapper& mapper, const std::vector<GuestRegionExpected>& expected_regions) {
     auto guest_regions = mapper.get_guest_regions();
     int found_regions = 0;
+    for (auto& region : guest_regions) {
+        printf("[%lx, %lx], %lx, %lx, %b\n", region.start, region.end, region.prot, region.flags, region.shmem);
+    }
     for (const auto region : expected_regions) {
         for (const auto guest_region : guest_regions) {
             bool yes = true;
@@ -40,21 +55,22 @@ CATCH_TEST_CASE("Simple1", "[shmat32]") {
     Mapper mapper;
 
     key_t key;
-    int shmid = shmget(key, 1024, 0644 | IPC_CREAT);
-    ASSERT(shmid != -1);
+    int shmid = shmget(IPC_PRIVATE, 0x1000, 0644 | IPC_CREAT);
+    CATCH_REQUIRE(shmid != -1);
 
     u64 result = 0;
-    mapper.shmat(false, shmid, (void*)0x50000, 0, &result);
-    ASSERT(result = 0x50000);
+    CATCH_REQUIRE(mapper.shmat(true, shmid, (void*)0x50000, 0, &result) == 0);
+    CATCH_REQUIRE(result == 0x50000);
 
     verifyGuestRegions(mapper, { 
-        {result, 1024, 0, 0644 | IPC_CREAT},
+        {result, 0x1000, 0, 0},
     });
 
-    mapper.shmdt(false, (void*)result);
+    CATCH_REQUIRE(mapper.shmdt(true, (void*)result) == 0);
 
     verifyGuestRegions(mapper, {});
 
+    CATCH_REQUIRE(shmctl(shmid, IPC_RMID, 0) == 0);
     SUCCESS_MESSAGE();
 }
 
@@ -62,19 +78,54 @@ CATCH_TEST_CASE("Simple1", "[shmat]") {
     Mapper mapper;
 
     key_t key;
-    int shmid = shmget(key, 1024, 0644 | IPC_CREAT);
-    ASSERT(shmid != -1);
+    int shmid = shmget(IPC_PRIVATE, 0x1000, 0644 | IPC_CREAT);
+    CATCH_REQUIRE(shmid != -1);
 
     u64 result = 0;
-    mapper.shmat(false, shmid, 0, 0, &result);
+    CATCH_REQUIRE(mapper.shmat(false, shmid, (void*)0x50000, 0, &result) == 0);
+    CATCH_REQUIRE(result == 0x50000);
 
     verifyGuestRegions(mapper, { 
-        {result, 1024, 0, 0644 | IPC_CREAT},
+        {result, 0x1000, 0, 0},
     });
 
-    mapper.shmdt(false, (void*)result);
+    CATCH_REQUIRE(mapper.shmdt(false, (void*)result) == 0);
 
     verifyGuestRegions(mapper, {});
 
+    CATCH_REQUIRE(shmctl(shmid, IPC_RMID, 0) == 0);
     SUCCESS_MESSAGE();
 }
+
+CATCH_TEST_CASE("DistinctSegments", "[shmat]") {
+    Mapper mapper;
+
+    int first_shmid = shmget(IPC_PRIVATE, 0x1000, 0644 | IPC_CREAT);
+    int second_shmid = shmget(IPC_PRIVATE, 0x2000, 0644 | IPC_CREAT);
+    CATCH_REQUIRE(first_shmid != -1);
+    CATCH_REQUIRE(second_shmid != -1);
+
+    u64 first = 0;
+    u64 second = 0;
+    CATCH_REQUIRE(mapper.shmat(false, first_shmid, (void*)0x100005000ull, 0, &first) == 0);
+    CATCH_REQUIRE(mapper.shmat(false, second_shmid, (void*)0x200005000ull, 0, &second) == 0);
+
+    verifyGuestRegions(mapper, { 
+        {first, 0x1000, 0, 0},
+        {second, 0x2000, 0, 0},
+    });
+
+    CATCH_REQUIRE(mapper.shmdt(false, (void*)first) == 0);
+ 
+    verifyGuestRegions(mapper, { 
+       {second, 0x2000, 0, 0},
+    });
+ 
+    CATCH_REQUIRE(mapper.shmdt(false, (void*)second) == 0);
+ 
+    verifyGuestRegions(mapper, {});
+ 
+    CATCH_REQUIRE(shmctl(first_shmid, IPC_RMID, nullptr) == 0);
+    CATCH_REQUIRE(shmctl(second_shmid, IPC_RMID, nullptr) == 0);
+    SUCCESS_MESSAGE();
+ }

--- a/tests/Unit/shmat.cpp
+++ b/tests/Unit/shmat.cpp
@@ -30,9 +30,6 @@ struct GuestRegionExpected {
 static void verifyGuestRegions(Mapper& mapper, const std::vector<GuestRegionExpected>& expected_regions) {
     auto guest_regions = mapper.get_guest_regions();
     int found_regions = 0;
-    for (auto& region : guest_regions) {
-        printf("[%lx, %lx], %lx, %lx, %b\n", region.start, region.end, region.prot, region.flags, region.shmem);
-    }
     for (const auto region : expected_regions) {
         for (const auto guest_region : guest_regions) {
             bool yes = true;
@@ -128,4 +125,4 @@ CATCH_TEST_CASE("DistinctSegments", "[shmat]") {
     CATCH_REQUIRE(shmctl(first_shmid, IPC_RMID, nullptr) == 0);
     CATCH_REQUIRE(shmctl(second_shmid, IPC_RMID, nullptr) == 0);
     SUCCESS_MESSAGE();
- }
+}

--- a/tests/Unit/shmat.cpp
+++ b/tests/Unit/shmat.cpp
@@ -94,6 +94,46 @@ CATCH_TEST_CASE("Simple2", "[shmat32]") {
     SUCCESS_MESSAGE();
 }
 
+// CATCH_TEST_CASE("ShmatPastEndOf32BitSpace", "[shmat32]") {
+//     Mapper mapper;
+
+//     int shmid = shmget(IPC_PRIVATE, 0x2000, 0644 | IPC_CREAT);
+//     CATCH_REQUIRE(shmid != -1);
+
+//     u64 result = 0;
+//     CATCH_REQUIRE(mapper.shmat(true, shmid, (void*)0xfffff000ull, 0, &result) < 0);
+
+//     CATCH_REQUIRE(mapper.shmat(true, shmid, (void*)0xffffe000ull, 0, &result) == 0);
+//     CATCH_REQUIRE(result == 0xffffe000ull);
+//     CATCH_REQUIRE(mapper.shmdt(true, (void*)result) == 0);
+
+//     CATCH_REQUIRE(shmctl(shmid, IPC_RMID, nullptr) == 0);
+//     SUCCESS_MESSAGE();
+// }
+
+CATCH_TEST_CASE("ShmatWhenFreelistPickIsTaken", "[shmat32]") {
+    Mapper mapper;
+
+    int shmid = shmget(IPC_PRIVATE, 0x2000, 0644 | IPC_CREAT);
+    CATCH_REQUIRE(shmid != -1);
+
+    const u64 window = 0x60000;
+    u64 min = mmap_min_addr();
+    CATCH_REQUIRE(mapper.allocate(min, window - min) == (void*)min);
+    CATCH_REQUIRE(mapper.allocate(window + 0x2000, (u64)UINT32_MAX + 1 - (window + 0x2000)) == (void*)(window + 0x2000));
+
+    void* taken = mmap((void*)window, 0x2000, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, -1, 0);
+    CATCH_REQUIRE(taken == (void*)window);
+
+    u64 result = 0;
+    CATCH_REQUIRE(mapper.shmat(true, shmid, nullptr, 0, &result) < 0);
+    CATCH_REQUIRE(mapper.get_guest_regions().empty());
+
+    munmap(taken, 0x2000);
+    CATCH_REQUIRE(shmctl(shmid, IPC_RMID, nullptr) == 0);
+    SUCCESS_MESSAGE();
+}
+
 CATCH_TEST_CASE("Simple1", "[shmat]") {
     Mapper mapper;
 
@@ -224,46 +264,6 @@ CATCH_TEST_CASE("ShmdtKeepsUnrelatedMappingInWindow", "[shmat]") {
     CATCH_REQUIRE(!regions[0].shmem);
 
     munmap(neighbour, 0x1000);
-    CATCH_REQUIRE(shmctl(shmid, IPC_RMID, nullptr) == 0);
-    SUCCESS_MESSAGE();
-}
-
-CATCH_TEST_CASE("ShmatPastEndOf32BitSpace", "[shmat32]") {
-    Mapper mapper;
-
-    int shmid = shmget(IPC_PRIVATE, 0x2000, 0644 | IPC_CREAT);
-    CATCH_REQUIRE(shmid != -1);
-
-    u64 result = 0;
-    CATCH_REQUIRE(mapper.shmat(true, shmid, (void*)0xfffff000ull, 0, &result) < 0);
-
-    CATCH_REQUIRE(mapper.shmat(true, shmid, (void*)0xffffe000ull, 0, &result) == 0);
-    CATCH_REQUIRE(result == 0xffffe000ull);
-    CATCH_REQUIRE(mapper.shmdt(true, (void*)result) == 0);
-
-    CATCH_REQUIRE(shmctl(shmid, IPC_RMID, nullptr) == 0);
-    SUCCESS_MESSAGE();
-}
-
-CATCH_TEST_CASE("ShmatWhenFreelistPickIsTaken", "[shmat32]") {
-    Mapper mapper;
-
-    int shmid = shmget(IPC_PRIVATE, 0x2000, 0644 | IPC_CREAT);
-    CATCH_REQUIRE(shmid != -1);
-
-    const u64 window = 0x60000;
-    u64 min = mmap_min_addr();
-    CATCH_REQUIRE(mapper.allocate(min, window - min) == (void*)min);
-    CATCH_REQUIRE(mapper.allocate(window + 0x2000, (u64)UINT32_MAX + 1 - (window + 0x2000)) == (void*)(window + 0x2000));
-
-    void* taken = mmap((void*)window, 0x2000, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, -1, 0);
-    CATCH_REQUIRE(taken == (void*)window);
-
-    u64 result = 0;
-    CATCH_REQUIRE(mapper.shmat(true, shmid, nullptr, 0, &result) < 0);
-    CATCH_REQUIRE(mapper.get_guest_regions().empty());
-
-    munmap(taken, 0x2000);
     CATCH_REQUIRE(shmctl(shmid, IPC_RMID, nullptr) == 0);
     SUCCESS_MESSAGE();
 }

--- a/tests/Unit/shmat.cpp
+++ b/tests/Unit/shmat.cpp
@@ -197,3 +197,32 @@ CATCH_TEST_CASE("AdjacentDistinctSegments", "[shmat]") {
     CATCH_REQUIRE(shmctl(second_shmid, IPC_RMID, nullptr) == 0);
     SUCCESS_MESSAGE();
 }
+
+CATCH_TEST_CASE("ShmdtKeepsUnrelatedMappingInWindow", "[shmat]") {
+    Mapper mapper;
+
+    int shmid = shmget(IPC_PRIVATE, 0x3000, 0644 | IPC_CREAT);
+    CATCH_REQUIRE(shmid != -1);
+
+    const u64 base = 0x100005000ull;
+    u64 address = 0;
+    CATCH_REQUIRE(mapper.shmat(false, shmid, (void*)base, 0, &address) == 0);
+    CATCH_REQUIRE(address == base);
+
+    CATCH_REQUIRE(mapper.unmap(false, (void*)(base + 0x1000), 0x2000) == 0);
+
+    void* neighbour = mapper.map(false, (void*)(base + 0x1000), 0x1000, PROT_READ, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, -1, 0);
+    CATCH_REQUIRE(neighbour == (void*)(base + 0x1000));
+
+    CATCH_REQUIRE(mapper.shmdt(false, (void*)base) == 0);
+
+    auto regions = mapper.get_guest_regions();
+    CATCH_REQUIRE(regions.size() == 1);
+    CATCH_REQUIRE(regions[0].start == base + 0x1000);
+    CATCH_REQUIRE(regions[0].end == base + 0x2000);
+    CATCH_REQUIRE(!regions[0].shmem);
+
+    munmap(neighbour, 0x1000);
+    CATCH_REQUIRE(shmctl(shmid, IPC_RMID, nullptr) == 0);
+    SUCCESS_MESSAGE();
+}

--- a/tests/Unit/shmat.cpp
+++ b/tests/Unit/shmat.cpp
@@ -171,3 +171,29 @@ CATCH_TEST_CASE("DistinctSegments", "[shmat]") {
     CATCH_REQUIRE(shmctl(second_shmid, IPC_RMID, nullptr) == 0);
     SUCCESS_MESSAGE();
 }
+
+CATCH_TEST_CASE("AdjacentDistinctSegments", "[shmat]") {
+    Mapper mapper;
+
+    int first_shmid = shmget(IPC_PRIVATE, 0x1000, 0644 | IPC_CREAT);
+    int second_shmid = shmget(IPC_PRIVATE, 0x1000, 0644 | IPC_CREAT);
+    CATCH_REQUIRE(first_shmid != -1);
+    CATCH_REQUIRE(second_shmid != -1);
+
+    u64 first = 0;
+    u64 second = 0;
+    CATCH_REQUIRE(mapper.shmat(false, first_shmid, (void*)0x100005000ull, 0, &first) == 0);
+    CATCH_REQUIRE(mapper.shmat(false, second_shmid, (void*)0x100006000ull, 0, &second) == 0);
+
+    verifyGuestRegions(mapper, {
+        {first, 0x1000, PROT_READ | PROT_WRITE},
+        {second, 0x1000, PROT_READ | PROT_WRITE},
+    });
+
+    CATCH_REQUIRE(mapper.shmdt(false, (void*)first) == 0);
+    CATCH_REQUIRE(mapper.shmdt(false, (void*)second) == 0);
+
+    CATCH_REQUIRE(shmctl(first_shmid, IPC_RMID, nullptr) == 0);
+    CATCH_REQUIRE(shmctl(second_shmid, IPC_RMID, nullptr) == 0);
+    SUCCESS_MESSAGE();
+}

--- a/tests/Unit/shmat.cpp
+++ b/tests/Unit/shmat.cpp
@@ -23,7 +23,6 @@ void verifyGuestRegions(Mapper& mapper, const std::vector<GuestRegionExpected>& 
             bool yes = true;
             yes &= region.start == guest_region.start;
             yes &= region.start + region.len == guest_region.end;
-            // Include the implicit flags here
             yes &= region.flags == guest_region.flags;
             yes &= region.prot == guest_region.prot;
             yes &= guest_region.shmem;
@@ -34,6 +33,7 @@ void verifyGuestRegions(Mapper& mapper, const std::vector<GuestRegionExpected>& 
         }
     }
     CATCH_REQUIRE(found_regions == expected_regions.size());    
+    CATCH_REQUIRE(guest_regions.size() == expected_regions.size());
 }
 
 CATCH_TEST_CASE("Simple1", "[shmat32]") {

--- a/tests/Unit/shmat.cpp
+++ b/tests/Unit/shmat.cpp
@@ -94,42 +94,19 @@ CATCH_TEST_CASE("Simple2", "[shmat32]") {
     SUCCESS_MESSAGE();
 }
 
-// CATCH_TEST_CASE("ShmatPastEndOf32BitSpace", "[shmat32]") {
-//     Mapper mapper;
-
-//     int shmid = shmget(IPC_PRIVATE, 0x2000, 0644 | IPC_CREAT);
-//     CATCH_REQUIRE(shmid != -1);
-
-//     u64 result = 0;
-//     CATCH_REQUIRE(mapper.shmat(true, shmid, (void*)0xfffff000ull, 0, &result) < 0);
-
-//     CATCH_REQUIRE(mapper.shmat(true, shmid, (void*)0xffffe000ull, 0, &result) == 0);
-//     CATCH_REQUIRE(result == 0xffffe000ull);
-//     CATCH_REQUIRE(mapper.shmdt(true, (void*)result) == 0);
-
-//     CATCH_REQUIRE(shmctl(shmid, IPC_RMID, nullptr) == 0);
-//     SUCCESS_MESSAGE();
-// }
-
-CATCH_TEST_CASE("ShmatWhenFreelistPickIsTaken", "[shmat32]") {
+CATCH_TEST_CASE("ShmatPastEndOf32BitSpace", "[shmat32]") {
     Mapper mapper;
 
     int shmid = shmget(IPC_PRIVATE, 0x2000, 0644 | IPC_CREAT);
     CATCH_REQUIRE(shmid != -1);
 
-    const u64 window = 0x60000;
-    u64 min = mmap_min_addr();
-    CATCH_REQUIRE(mapper.allocate(min, window - min) == (void*)min);
-    CATCH_REQUIRE(mapper.allocate(window + 0x2000, (u64)UINT32_MAX + 1 - (window + 0x2000)) == (void*)(window + 0x2000));
-
-    void* taken = mmap((void*)window, 0x2000, PROT_NONE, MAP_ANONYMOUS | MAP_PRIVATE | MAP_FIXED, -1, 0);
-    CATCH_REQUIRE(taken == (void*)window);
-
     u64 result = 0;
-    CATCH_REQUIRE(mapper.shmat(true, shmid, nullptr, 0, &result) < 0);
-    CATCH_REQUIRE(mapper.get_guest_regions().empty());
+    CATCH_REQUIRE(mapper.shmat(true, shmid, (void*)0xfffff000ull, 0, &result) < 0);
 
-    munmap(taken, 0x2000);
+    CATCH_REQUIRE(mapper.shmat(true, shmid, (void*)0xffffe000ull, 0, &result) == 0);
+    CATCH_REQUIRE(result == 0xffffe000ull);
+    CATCH_REQUIRE(mapper.shmdt(true, (void*)result) == 0);
+
     CATCH_REQUIRE(shmctl(shmid, IPC_RMID, nullptr) == 0);
     SUCCESS_MESSAGE();
 }

--- a/tests/common.cpp
+++ b/tests/common.cpp
@@ -18,6 +18,7 @@ public:
         Config new_config{};
         new_config.rootfs_path = g_config.rootfs_path;
         new_config.protect_pages = false;
+        new_config.guest_memory_tracking_enabled = true;
         g_config = new_config;
     }
 };


### PR DESCRIPTION
adds memory tracking to invocations of mmap/munmap and shmat32/shmdt32. shmat and shmdt for 64-bits is not supported in this PR because it would involve adding an entire new function for handling shmat/shmdt logic (although, it could likely be 1:1 copy pasted from shmat32/shmdt32?).

The idea is to be able to query the memory usage of the guest at any time so it can be used to be subtracted towards total memory use and therefore get emulator memory usage, and also to intercept guest segmentation faults or any other use case that involves determining if a memory access is done on the guest side or host side. Although this is not entirely a solved problem because an access to completely unmapped memory can happen both from the guest or the host emulator.

Memory allocations are pooled into a linked list for quick insertions and reasonably fast iterations. It probably stands things can still be improved performance wise, but from my testing things still run plenty fast, but it will depend on the amount of mmap/munmap invocations a program does and maybe this should be further probed if it is an issue?