### PR TITLE
Common: Allow searching for symbols for libraries outside the rootfs

### DIFF
--- a/src/felix86/common/utility.cpp
+++ b/src/felix86/common/utility.cpp
@@ -555,11 +555,6 @@ void update_symbols() {
                 continue;
             }
 
-            if (std::string(buffer).find(g_config.rootfs_path.string()) != 0) {
-                // It's our emulator or its libraries, skip
-                continue;
-            }
-
             if (it == regions.end()) {
                 regions[buffer] = {UINT64_MAX, 0};
             }


### PR DESCRIPTION
Since its possible we share the home directory now, some x86 libraries or programs may not be in the rootfs. Also the previous check is sufficient to know if the library is x86 or not.