### PR TITLE
Recompiler: Don't link loop to self

### DIFF
--- a/counts/HotBlocks.json
+++ b/counts/HotBlocks.json
@@ -45,9 +45,8 @@
         ]
     },
     "crysis2": {
-        "instruction_count": 72,
+        "instruction_count": 71,
         "expected_asm": [
-            "ADDI            zero, zero, 0x0(0)",
             "SD              zero, gp, 0xfffffff8(-8)",
             "LUI             t1, 0xd8(216)",
             "ADDIW           t1, t1, 0x42f(1071)",
@@ -122,7 +121,7 @@
         ]
     },
     "crysis3": {
-        "instruction_count": 325,
+        "instruction_count": 322,
         "expected_asm": [
             "SD              zero, gp, 0xfffffff8(-8)",
             "ADDI            ra, s2, 0xfffffff0(-16)",
@@ -439,12 +438,9 @@
             "XOR             s9, s9, t3",
             "ADDI            a0, ra, 0x0(0)",
             "XORI            ra, s7, 0x1(1)",
-            "BNE             zero, ra, 0x18(24)",
+            "ADDI            t5, zero, 0x0(0)",
+            "BNE             zero, ra, 0xfffffb10(-1264)",
             "ADDI            s11, s11, 0x1d2(466)",
-            "AUIPC           t5, 0x0(0)",
-            "LD              t6, gp, 0x398(920)",
-            "LD              t6, t6, 0x90(144)",
-            "JALR            zero, t6, 0x0(0)",
             "AUIPC           t5, 0x0(0)",
             "LD              t6, gp, 0x398(920)",
             "LD              t6, t6, 0x90(144)",

--- a/src/felix86/common/utility.hpp
+++ b/src/felix86/common/utility.hpp
@@ -11,6 +11,10 @@
 #include "felix86/common/types.hpp"
 #include "felix86/common/xsave.hpp"
 
+[[nodiscard]] constexpr bool IsValidBTypeImm(ptrdiff_t value) {
+    return value >= -4096 && value <= 4095;
+}
+
 [[nodiscard]] constexpr bool IsValidJTypeImm(ptrdiff_t value) {
     return value >= -0x80000 && value <= 0x7FFFF;
 }

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -571,27 +571,6 @@ u64 Recompiler::compileSequence(bool mode32, u64 rip) {
         VERBOSE("Jumped to address %lx which has a sequence of zeroes -- probably a bad jump?", rip);
     }
 
-    // When invalidating from other threads we need to do it in a single atomic instruction, thus block starts
-    // need to be aligned to 8 bytes as we exchange two instructions
-    switch ((u64)as.GetCursorPointer() & 0x7) {
-    case 0: {
-        break;
-    }
-    case 4: {
-        as.NOP();
-        break;
-    }
-    case 2: {
-        as.C_NOP();
-        as.NOP();
-        break;
-    }
-    case 6: {
-        as.C_NOP();
-        break;
-    }
-    }
-
     ASSERT(((u64)as.GetCursorPointer() & 0x7) == 0);
 
     current_mode32 = mode32;

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -2688,12 +2688,20 @@ void Recompiler::jumpAndLinkConditional(biscuit::GPR condition, u64 rip_true, u6
     i64 host_offset = current_block_metadata->host_address - (here + 4);
     // Check if it is branch to self
     if (IsValidBTypeImm(host_offset) && rip_true == current_block_metadata->guest_address) {
+        biscuit::GPR ripreg = allocatedGPR(X86_REF_RIP);
         as.MV(t5, x0);
         ASSERT(condition != t5);
+        if (getCurrentRipregValue() != rip_true) { // ripreg might've changed during the block, set it back to the start if so
+            u64 rip_true_offset = rip_true - getCurrentRipregValue();
+            addi(ripreg, ripreg, rip_true_offset);
+            if (current_mode32) {
+                zext(ripreg, ripreg, X86_SIZE_DWORD);
+                rip_true = (u32)rip_true;
+            }
+        }
         as.BNEZ(condition, host_offset);
         ASSERT((u64)as.GetCursorPointer() == here + 8);
 
-        biscuit::GPR ripreg = allocatedGPR(X86_REF_RIP);
         u64 rip_false_offset = rip_false - getCurrentRipregValue();
         addi(ripreg, ripreg, rip_false_offset);
         if (current_mode32) {

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -2695,12 +2695,12 @@ void Recompiler::jumpAndLinkConditional(biscuit::GPR condition, u64 rip_true, u6
         if (getCurrentRipregValue() != rip_true) { // ripreg might've changed during the block, set it back to the start if so
             ASSERT(getCurrentRipregValue() > rip_true);
             u64 rip_true_offset = getCurrentRipregValue() - rip_true;
-            addi(ripreg, ripreg, rip_true_offset);
-            setCurrentRipregValue(rip_true);
+            addi(ripreg, ripreg, -rip_true_offset);
             if (current_mode32) {
                 zext(ripreg, ripreg, X86_SIZE_DWORD);
                 rip_true = (u32)rip_true;
             }
+            setCurrentRipregValue(rip_true);
         }
         i64 host_offset = current_block_metadata->host_address - here;
         ASSERT(IsValidBTypeImm(host_offset)); // max_instr_space should guarantee it

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -2694,7 +2694,7 @@ void Recompiler::jumpAndLink(u64 rip) {
 void Recompiler::jumpAndLinkConditional(biscuit::GPR condition, u64 rip_true, u64 rip_false) {
     OptimizationGuard guard(as, optimization_guard_counter);
     u64 here = (u64)as.GetCursorPointer();
-    i64 host_offset = here - current_block_metadata->host_address;
+    i64 host_offset = (here + 4) - current_block_metadata->host_address;
     if (IsValidBTypeImm(host_offset) && rip_true == current_block_metadata->guest_address) {
         as.MV(t5, x0);
         as.BNEZ(condition, host_offset);

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -571,6 +571,20 @@ u64 Recompiler::compileSequence(bool mode32, u64 rip) {
         VERBOSE("Jumped to address %lx which has a sequence of zeroes -- probably a bad jump?", rip);
     }
 
+    // When invalidating from other threads we need to do it in a single atomic instruction, thus block starts
+    // need to be aligned to 4 bytes
+    switch ((u64)as.GetCursorPointer() & 0x3) {
+    case 0: {
+        break;
+    }
+    case 2: {
+        as.C_NOP();
+        break;
+    }
+    }
+
+    ASSERT(((u64)as.GetCursorPointer() & 0x2) == 0);
+
     current_mode32 = mode32;
     current_decoder_initialized = false; // TODO: don't invalidate if same mode32 as before
     scanAhead(rip);
@@ -3313,7 +3327,7 @@ void Recompiler::invalidateBlock(BlockMetadata* block) {
     // so we use C.LDSP here
     tas.C_LDSP(t4, offsetof(felix86_frame, invalidate_caller_thunk_ptr));
     tas.C_JALR(t4); // ra is used in invalidate_caller_thunk
-    ASSERT(((u64)address & 0x4) == 0);
+    ASSERT(((u64)address & 0x3) == 0);
     __atomic_exchange_n(address, storage, __ATOMIC_SEQ_CST);
 }
 

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -2696,6 +2696,7 @@ void Recompiler::jumpAndLinkConditional(biscuit::GPR condition, u64 rip_true, u6
             ASSERT(getCurrentRipregValue() > rip_true);
             u64 rip_true_offset = getCurrentRipregValue() - rip_true;
             addi(ripreg, ripreg, rip_true_offset);
+            setCurrentRipregValue(rip_true);
             if (current_mode32) {
                 zext(ripreg, ripreg, X86_SIZE_DWORD);
                 rip_true = (u32)rip_true;

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -2685,8 +2685,7 @@ void Recompiler::jumpAndLink(u64 rip) {
 void Recompiler::jumpAndLinkConditional(biscuit::GPR condition, u64 rip_true, u64 rip_false) {
     OptimizationGuard guard(as, optimization_guard_counter);
     constexpr u64 max_instr_space = 80;
-    u64 here = (u64)as.GetCursorPointer();
-    i64 host_offset = current_block_metadata->host_address - here;
+    i64 host_offset = current_block_metadata->host_address - (u64)as.GetCursorPointer();
     // Check if it is branch to self
     if (rip_true == current_block_metadata->guest_address && host_offset > -4096 + max_instr_space) {
         biscuit::GPR ripreg = allocatedGPR(X86_REF_RIP);
@@ -2702,7 +2701,7 @@ void Recompiler::jumpAndLinkConditional(biscuit::GPR condition, u64 rip_true, u6
             }
             setCurrentRipregValue(rip_true);
         }
-        i64 host_offset = current_block_metadata->host_address - here;
+        i64 host_offset = current_block_metadata->host_address - (u64)as.GetCursorPointer();
         ASSERT(IsValidBTypeImm(host_offset)); // max_instr_space should guarantee it
         as.BNEZ(condition, host_offset);
 

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -2694,10 +2694,12 @@ void Recompiler::jumpAndLink(u64 rip) {
 void Recompiler::jumpAndLinkConditional(biscuit::GPR condition, u64 rip_true, u64 rip_false) {
     OptimizationGuard guard(as, optimization_guard_counter);
     u64 here = (u64)as.GetCursorPointer();
-    i64 host_offset = current_block_metadata->host_address - (here + 8);
+    i64 host_offset = current_block_metadata->host_address - (here + 4);
+    // Check if it is branch to self
     if (IsValidBTypeImm(host_offset) && rip_true == current_block_metadata->guest_address) {
         as.MV(t5, x0);
         as.BNEZ(condition, host_offset);
+        ASSERT((u64)as.GetCursorPointer() == here + 8);
 
         biscuit::GPR ripreg = allocatedGPR(X86_REF_RIP);
         u64 rip_false_offset = rip_false - getCurrentRipregValue();

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -571,8 +571,6 @@ u64 Recompiler::compileSequence(bool mode32, u64 rip) {
         VERBOSE("Jumped to address %lx which has a sequence of zeroes -- probably a bad jump?", rip);
     }
 
-    ASSERT(((u64)as.GetCursorPointer() & 0x7) == 0);
-
     current_mode32 = mode32;
     current_decoder_initialized = false; // TODO: don't invalidate if same mode32 as before
     scanAhead(rip);

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -2693,7 +2693,8 @@ void Recompiler::jumpAndLinkConditional(biscuit::GPR condition, u64 rip_true, u6
         as.MV(t5, x0);
         ASSERT(condition != t5);
         if (getCurrentRipregValue() != rip_true) { // ripreg might've changed during the block, set it back to the start if so
-            u64 rip_true_offset = rip_true - getCurrentRipregValue();
+            ASSERT(getCurrentRipregValue() > rip_true);
+            u64 rip_true_offset = getCurrentRipregValue() - rip_true;
             addi(ripreg, ripreg, rip_true_offset);
             if (current_mode32) {
                 zext(ripreg, ripreg, X86_SIZE_DWORD);

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -2693,6 +2693,25 @@ void Recompiler::jumpAndLink(u64 rip) {
 
 void Recompiler::jumpAndLinkConditional(biscuit::GPR condition, u64 rip_true, u64 rip_false) {
     OptimizationGuard guard(as, optimization_guard_counter);
+    u64 here = (u64)as.GetCursorPointer();
+    i64 host_offset = here - current_block_metadata->host_address;
+    if (IsValidBTypeImm(host_offset) && rip_true == current_block_metadata->guest_address) {
+        as.MV(t5, x0);
+        as.BNEZ(condition, host_offset);
+
+        biscuit::GPR ripreg = allocatedGPR(X86_REF_RIP);
+        u64 rip_false_offset = rip_false - getCurrentRipregValue();
+        addi(ripreg, ripreg, rip_false_offset);
+        if (current_mode32) {
+            zext(ripreg, ripreg, X86_SIZE_DWORD);
+            rip_false = (u32)rip_false;
+        }
+
+        as.AUIPC(t5, 0); // <- must be before link point, see invalidate_caller_thunk
+        jumpAndLink(rip_false);
+        return;
+    }
+
     Label true_label;
     as.BNEZ(condition, &true_label);
 

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -2694,8 +2694,8 @@ void Recompiler::jumpAndLinkConditional(biscuit::GPR condition, u64 rip_true, u6
         ASSERT(condition != t5);
         if (getCurrentRipregValue() != rip_true) { // ripreg might've changed during the block, set it back to the start if so
             ASSERT(getCurrentRipregValue() > rip_true);
-            u64 rip_true_offset = getCurrentRipregValue() - rip_true;
-            addi(ripreg, ripreg, -rip_true_offset);
+            u64 rip_true_offset = rip_true - getCurrentRipregValue();
+            addi(ripreg, ripreg, rip_true_offset);
             if (current_mode32) {
                 zext(ripreg, ripreg, X86_SIZE_DWORD);
                 rip_true = (u32)rip_true;

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -2689,6 +2689,7 @@ void Recompiler::jumpAndLinkConditional(biscuit::GPR condition, u64 rip_true, u6
     // Check if it is branch to self
     if (IsValidBTypeImm(host_offset) && rip_true == current_block_metadata->guest_address) {
         as.MV(t5, x0);
+        ASSERT(condition != t5);
         as.BNEZ(condition, host_offset);
         ASSERT((u64)as.GetCursorPointer() == here + 8);
 

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -2694,7 +2694,7 @@ void Recompiler::jumpAndLink(u64 rip) {
 void Recompiler::jumpAndLinkConditional(biscuit::GPR condition, u64 rip_true, u64 rip_false) {
     OptimizationGuard guard(as, optimization_guard_counter);
     u64 here = (u64)as.GetCursorPointer();
-    i64 host_offset = (here + 4) - current_block_metadata->host_address;
+    i64 host_offset = (here + 8) - current_block_metadata->host_address;
     if (IsValidBTypeImm(host_offset) && rip_true == current_block_metadata->guest_address) {
         as.MV(t5, x0);
         as.BNEZ(condition, host_offset);

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -2684,10 +2684,11 @@ void Recompiler::jumpAndLink(u64 rip) {
 
 void Recompiler::jumpAndLinkConditional(biscuit::GPR condition, u64 rip_true, u64 rip_false) {
     OptimizationGuard guard(as, optimization_guard_counter);
+    constexpr u64 max_instr_space = 80;
     u64 here = (u64)as.GetCursorPointer();
-    i64 host_offset = current_block_metadata->host_address - (here + 4);
+    i64 host_offset = current_block_metadata->host_address - here;
     // Check if it is branch to self
-    if (IsValidBTypeImm(host_offset) && rip_true == current_block_metadata->guest_address) {
+    if (rip_true == current_block_metadata->guest_address && host_offset > -4096 + max_instr_space) {
         biscuit::GPR ripreg = allocatedGPR(X86_REF_RIP);
         as.MV(t5, x0);
         ASSERT(condition != t5);
@@ -2699,8 +2700,9 @@ void Recompiler::jumpAndLinkConditional(biscuit::GPR condition, u64 rip_true, u6
                 rip_true = (u32)rip_true;
             }
         }
+        i64 host_offset = current_block_metadata->host_address - here;
+        ASSERT(IsValidBTypeImm(host_offset)); // max_instr_space should guarantee it
         as.BNEZ(condition, host_offset);
-        ASSERT((u64)as.GetCursorPointer() == here + 8);
 
         u64 rip_false_offset = rip_false - getCurrentRipregValue();
         addi(ripreg, ripreg, rip_false_offset);

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -2694,7 +2694,7 @@ void Recompiler::jumpAndLink(u64 rip) {
 void Recompiler::jumpAndLinkConditional(biscuit::GPR condition, u64 rip_true, u64 rip_false) {
     OptimizationGuard guard(as, optimization_guard_counter);
     u64 here = (u64)as.GetCursorPointer();
-    i64 host_offset = (here + 8) - current_block_metadata->host_address;
+    i64 host_offset = current_block_metadata->host_address - (here + 8);
     if (IsValidBTypeImm(host_offset) && rip_true == current_block_metadata->guest_address) {
         as.MV(t5, x0);
         as.BNEZ(condition, host_offset);


### PR DESCRIPTION
Backwards branch to self is easy to optimize as the target being invalidated means we don't need to invalidate the link as it will no longer be run.

Improves performance in 7z benchmark by 1% in compression and 3% in decompression.