### PR TITLE
Recompiler: Fix rare bug in MULX and CMPXCHG

### DIFF
--- a/counts/Base.json
+++ b/counts/Base.json
@@ -12037,7 +12037,7 @@
         "disassembly": "neg [rdi]"
     },
     "0fb01f": {
-        "instruction_count": 46,
+        "instruction_count": 48,
         "expected_asm": [
             "ADDI            ra, a0, 0x0(0)",
             "ANDI            t1, s0, 0xff(255)",
@@ -12058,6 +12058,8 @@
             "BNE             zero, t6, 0xffffffe4(-28)",
             "SRLW            t4, t4, ra",
             "ANDI            t4, t4, 0xff(255)",
+            "ADDI            s5, zero, 0x0(0)",
+            "ADDI            s7, zero, 0x0(0)",
             "SUB             t2, t3, t4",
             "SLTU            s5, t3, t4",
             "ANDI            t5, t2, 0xff(255)",
@@ -12089,7 +12091,7 @@
         "disassembly": "cmpxchg [rdi], bl"
     },
     "0fb03f": {
-        "instruction_count": 47,
+        "instruction_count": 49,
         "expected_asm": [
             "ADDI            ra, a0, 0x0(0)",
             "SRLI            t1, s0, 0x8(8)",
@@ -12111,6 +12113,8 @@
             "BNE             zero, t6, 0xffffffe4(-28)",
             "SRLW            t4, t4, ra",
             "ANDI            t4, t4, 0xff(255)",
+            "ADDI            s5, zero, 0x0(0)",
+            "ADDI            s7, zero, 0x0(0)",
             "SUB             t2, t3, t4",
             "SLTU            s5, t3, t4",
             "ANDI            t5, t2, 0xff(255)",
@@ -12142,7 +12146,7 @@
         "disassembly": "cmpxchg [rdi], bh"
     },
     "660fb11f": {
-        "instruction_count": 52,
+        "instruction_count": 55,
         "expected_asm": [
             "ADDI            ra, a0, 0x0(0)",
             "ZEXT.H          t1, s0",
@@ -12168,6 +12172,9 @@
             "BNE             zero, t5, 0xffffffe4(-28)",
             "SRLW            t4, t4, ra",
             "AND             t4, t4, t6",
+            "ADDI            s8, zero, 0x0(0)",
+            "ADDI            s5, zero, 0x0(0)",
+            "ADDI            s7, zero, 0x0(0)",
             "SUB             t2, t3, t4",
             "SLTU            s5, t3, t4",
             "ANDI            t5, t2, 0xff(255)",

--- a/counts/Base_NoFlags.json
+++ b/counts/Base_NoFlags.json
@@ -5696,7 +5696,7 @@
         "disassembly": "neg [rdi]"
     },
     "0fb01f": {
-        "instruction_count": 24,
+        "instruction_count": 26,
         "expected_asm": [
             "ADDI            ra, a0, 0x0(0)",
             "ANDI            t1, s0, 0xff(255)",
@@ -5717,6 +5717,8 @@
             "BNE             zero, t6, 0xffffffe4(-28)",
             "SRLW            t4, t4, ra",
             "ANDI            t4, t4, 0xff(255)",
+            "ADDI            s5, zero, 0x0(0)",
+            "ADDI            s7, zero, 0x0(0)",
             "SUB             t2, t3, t4",
             "BEQ             t2, zero, 0x10(16)",
             "ANDI            t5, t4, 0xff(255)",
@@ -5726,7 +5728,7 @@
         "disassembly": "cmpxchg [rdi], bl"
     },
     "0fb03f": {
-        "instruction_count": 25,
+        "instruction_count": 27,
         "expected_asm": [
             "ADDI            ra, a0, 0x0(0)",
             "SRLI            t1, s0, 0x8(8)",
@@ -5748,6 +5750,8 @@
             "BNE             zero, t6, 0xffffffe4(-28)",
             "SRLW            t4, t4, ra",
             "ANDI            t4, t4, 0xff(255)",
+            "ADDI            s5, zero, 0x0(0)",
+            "ADDI            s7, zero, 0x0(0)",
             "SUB             t2, t3, t4",
             "BEQ             t2, zero, 0x10(16)",
             "ANDI            t5, t4, 0xff(255)",
@@ -5757,7 +5761,7 @@
         "disassembly": "cmpxchg [rdi], bh"
     },
     "660fb11f": {
-        "instruction_count": 30,
+        "instruction_count": 33,
         "expected_asm": [
             "ADDI            ra, a0, 0x0(0)",
             "ZEXT.H          t1, s0",
@@ -5783,6 +5787,9 @@
             "BNE             zero, t5, 0xffffffe4(-28)",
             "SRLW            t4, t4, ra",
             "AND             t4, t4, t6",
+            "ADDI            s8, zero, 0x0(0)",
+            "ADDI            s5, zero, 0x0(0)",
+            "ADDI            s7, zero, 0x0(0)",
             "SUB             t2, t3, t4",
             "BEQ             t2, zero, 0x14(20)",
             "ZEXT.H          t5, t4",

--- a/counts/Lock.json
+++ b/counts/Lock.json
@@ -374,7 +374,7 @@
         "disassembly": "lock xchg [rdi], rax"
     },
     "f00fb027": {
-        "instruction_count": 25,
+        "instruction_count": 27,
         "expected_asm": [
             "ADDI            ra, a0, 0x0(0)",
             "SRLI            t1, t0, 0x8(8)",
@@ -396,6 +396,8 @@
             "BNE             zero, t6, 0xffffffe4(-28)",
             "SRLW            t4, t4, ra",
             "ANDI            t4, t4, 0xff(255)",
+            "ADDI            s5, zero, 0x0(0)",
+            "ADDI            s7, zero, 0x0(0)",
             "SUB             t2, t3, t4",
             "BEQ             t2, zero, 0x10(16)",
             "ANDI            t5, t4, 0xff(255)",
@@ -405,7 +407,7 @@
         "disassembly": "lock cmpxchg [rdi], ah"
     },
     "f0660fb107": {
-        "instruction_count": 30,
+        "instruction_count": 33,
         "expected_asm": [
             "ADDI            ra, a0, 0x0(0)",
             "ZEXT.H          t1, t0",
@@ -431,6 +433,9 @@
             "BNE             zero, t5, 0xffffffe4(-28)",
             "SRLW            t4, t4, ra",
             "AND             t4, t4, t6",
+            "ADDI            s8, zero, 0x0(0)",
+            "ADDI            s5, zero, 0x0(0)",
+            "ADDI            s7, zero, 0x0(0)",
             "SUB             t2, t3, t4",
             "BEQ             t2, zero, 0x14(20)",
             "ZEXT.H          t5, t4",

--- a/src/felix86/v2/handlers.cpp
+++ b/src/felix86/v2/handlers.cpp
@@ -7549,11 +7549,15 @@ FAST_HANDLE(RORX) {
 FAST_HANDLE(MULX) {
     biscuit::GPR hi_dst = rec.getGPR(&operands[0], X86_SIZE_QWORD);
     biscuit::GPR lo_dst = rec.getGPR(&operands[1], X86_SIZE_QWORD);
+    bool same_dst = lo_dst == hi_dst;
     if (operands[0].size == 64) {
         biscuit::GPR src = rec.getGPR(&operands[2]);
         biscuit::GPR rdx = rec.getGPR(X86_REF_RDX, X86_SIZE_QWORD);
         if (lo_dst == src || lo_dst == rdx) {
             lo_dst = rec.scratch();
+        }
+        if (same_dst) {
+            hi_dst = rec.scratch();
         }
         as.MUL(lo_dst, src, rdx);
         as.MULHU(hi_dst, src, rdx);
@@ -8681,6 +8685,9 @@ FAST_HANDLE(CMPXCHG_lock) {
             as.SRLW(dst, dst, address);
             as.ANDI(dst, dst, 0xFF);
 
+            as.MV(rax_shifted, x0);
+            as.MV(src_shifted, x0);
+
             rec.popScratch();
             rec.popScratch();
             rec.popScratch();
@@ -8753,6 +8760,10 @@ FAST_HANDLE(CMPXCHG_lock) {
             as.Bind(&not_equal);
             as.SRLW(dst, dst, address);
             as.AND(dst, dst, mask);
+
+            as.MV(mask_shifted, x0);
+            as.MV(rax_shifted, x0);
+            as.MV(src_shifted, x0);
 
             rec.popScratch();
             rec.popScratch();


### PR DESCRIPTION
MULX destinations overlapping with sources or with each other and CMPXCHG needs to zero the flag registers it used as scratch after using them