### PR TITLE
Recompiler: Check for indefinites in CVT(T)PS2PI

### DIFF
--- a/external/berkeley-softfloat-3/source/RISCV/specialize.h
+++ b/external/berkeley-softfloat-3/source/RISCV/specialize.h
@@ -209,7 +209,7 @@ uint_fast64_t
 /*----------------------------------------------------------------------------
 | The bit pattern for a default generated 80-bit extended floating-point NaN.
 *----------------------------------------------------------------------------*/
-#define defaultNaNExtF80UI64 0x7FFF
+#define defaultNaNExtF80UI64 0xFFFF
 #define defaultNaNExtF80UI0  UINT64_C( 0xC000000000000000 )
 
 /*----------------------------------------------------------------------------

--- a/src/felix86/common/x87.cpp
+++ b/src/felix86/common/x87.cpp
@@ -380,34 +380,40 @@ void felix86_x87_FLD1(ThreadState* state) {
     push(state, &value);
 }
 
+static void push_rounded_constant(ThreadState* state, const float128_t* value) {
+    extFloat80_t rounded;
+    f128M_to_extF80M(value, &rounded);
+    push(state, &rounded);
+}
+
 void felix86_x87_FLDL2T(ThreadState* state) {
     FELIX86_PROFILE_INSTANT_INCREMENT(state->thread_stats, AccumulatedFloatFallbackCount, 1);
-    extFloat80_t value = {0xD49A'784B'CD1B'8AFEULL, 0x4000};
-    push(state, &value);
+    static const float128_t value = {{0x15FC9257EDFE9B60ull, 0x4000A934F0979A37ull}};
+    push_rounded_constant(state, &value);
 }
 
 void felix86_x87_FLDL2E(ThreadState* state) {
     FELIX86_PROFILE_INSTANT_INCREMENT(state->thread_stats, AccumulatedFloatFallbackCount, 1);
-    extFloat80_t value = {0xB8AA'3B29'5C17'F0BCULL, 0x3FFF};
-    push(state, &value);
+    static const float128_t value = {{0xE1777D0FFDA0D23Aull, 0x3FFF71547652B82Full}};
+    push_rounded_constant(state, &value);
 }
 
 void felix86_x87_FLDPI(ThreadState* state) {
     FELIX86_PROFILE_INSTANT_INCREMENT(state->thread_stats, AccumulatedFloatFallbackCount, 1);
-    extFloat80_t value = {0xC90F'DAA2'2168'C235ULL, 0x4000};
-    push(state, &value);
+    static const float128_t value = {{0x8469898CC51701B8ull, 0x4000921FB54442D1ull}};
+    push_rounded_constant(state, &value);
 }
 
 void felix86_x87_FLDLG2(ThreadState* state) {
     FELIX86_PROFILE_INSTANT_INCREMENT(state->thread_stats, AccumulatedFloatFallbackCount, 1);
-    extFloat80_t value = {0x9A20'9A84'FBCF'F799ULL, 0x3FFD};
-    push(state, &value);
+    static const float128_t value = {{0xEF311F12B35816F9ull, 0x3FFD34413509F79Full}};
+    push_rounded_constant(state, &value);
 }
 
 void felix86_x87_FLDLN2(ThreadState* state) {
     FELIX86_PROFILE_INSTANT_INCREMENT(state->thread_stats, AccumulatedFloatFallbackCount, 1);
-    extFloat80_t value = {0xB172'17F7'D1CF'79ACULL, 0x3FFE};
-    push(state, &value);
+    static const float128_t value = {{0xF35793C7673007E6ull, 0x3FFE62E42FEFA39Eull}};
+    push_rounded_constant(state, &value);
 }
 
 void felix86_x87_FABS(ThreadState* state) {

--- a/src/felix86/v2/handlers.cpp
+++ b/src/felix86/v2/handlers.cpp
@@ -8955,6 +8955,7 @@ FAST_HANDLE(EMMS) {
     // Set FPU tag word to empty
     // Since our internal tag word is abridged, we use zeroes for empty
     as.SB(x0, offsetof(ThreadState, ctx.fpu_tw), rec.threadStatePointer());
+    rec.setTOP(x0);
     rec.switchToX87();
 }
 
@@ -9343,21 +9344,59 @@ FAST_HANDLE(CVTPI2PS) {
 }
 
 FAST_HANDLE(CVTPS2PI) {
+    biscuit::Vec result = rec.scratchVec();
+    biscuit::GPR mask = rec.scratch();
+    biscuit::GPR indefinite = rec.scratch();
+    biscuit::GPR largest_int = rec.scratch();
+    biscuit::FPR limit = rec.scratchFPR();
+    biscuit::Vec class_bits = rec.scratchVec();
+    biscuit::Vec bigger_bits = rec.scratchVec();
     biscuit::Vec dst = rec.getVec(&operands[0]);
     biscuit::Vec src = rec.getVec(&operands[1]);
 
+    as.LI(indefinite, 0x8000'0000);
+    as.LI(mask, 0b1110000001);
+    as.ADDI(largest_int, indefinite, -1);
+    as.FCVT_S_W(limit, largest_int);
+
     rec.setVectorState(SEW::E32, 2);
-    as.VFCVT_X_F(dst, src);
+    as.VFCLASS(class_bits, src);
+    as.VAND(class_bits, class_bits, mask);
+    as.VMFGE(bigger_bits, src, limit);
+    as.VMSNE(class_bits, class_bits, x0);
+    as.VFCVT_X_F(result, src);
+    as.VMOR(v0, class_bits, bigger_bits);
+    rec.v0Modified();
+    as.VMERGE(dst, result, indefinite);
 
     rec.setVec(&operands[0], dst);
 }
 
 FAST_HANDLE(CVTTPS2PI) {
+    biscuit::Vec result = rec.scratchVec();
+    biscuit::GPR mask = rec.scratch();
+    biscuit::GPR indefinite = rec.scratch();
+    biscuit::GPR largest_int = rec.scratch();
+    biscuit::FPR limit = rec.scratchFPR();
+    biscuit::Vec class_bits = rec.scratchVec();
+    biscuit::Vec bigger_bits = rec.scratchVec();
     biscuit::Vec dst = rec.getVec(&operands[0]);
     biscuit::Vec src = rec.getVec(&operands[1]);
 
+    as.LI(indefinite, 0x8000'0000);
+    as.LI(mask, 0b1110000001);
+    as.ADDI(largest_int, indefinite, -1);
+    as.FCVT_S_W(limit, largest_int);
+
     rec.setVectorState(SEW::E32, 2);
-    as.VFCVT_RTZ_X_F(dst, src);
+    as.VFCLASS(class_bits, src);
+    as.VAND(class_bits, class_bits, mask);
+    as.VMFGE(bigger_bits, src, limit);
+    as.VMSNE(class_bits, class_bits, x0);
+    as.VFCVT_RTZ_X_F(result, src);
+    as.VMOR(v0, class_bits, bigger_bits);
+    rec.v0Modified();
+    as.VMERGE(dst, result, indefinite);
 
     rec.setVec(&operands[0], dst);
 }


### PR DESCRIPTION
Also fix default f80 NaN and EMMS not previously
zeroing top as all MMX instructions do
Also fix silly load constant instructions using rounding modes