### PR TITLE
Recompiler: Optimize TSO emulation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,7 @@ set(FELIX86_COMMON_SOURCES
     src/felix86/common/binfmt.cpp
     src/felix86/common/x87.cpp
     src/felix86/common/xsave.cpp
+    src/felix86/common/decoder.c
 )
 
 set(FELIX86_HLE_SOURCES

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,7 @@ set(FELIX86_HLE_SOURCES
 set(FELIX86_V2_SOURCES
     src/felix86/v2/recompiler.cpp
     src/felix86/v2/handlers.cpp
+    src/felix86/v2/optimizer.cpp
 )
 
 set(FELIX86_CORE_SOURCES

--- a/src/felix86/common/global.cpp
+++ b/src/felix86/common/global.cpp
@@ -50,6 +50,7 @@ std::filesystem::path g_mounts_path{};
 std::vector<FakeMountNode> g_fake_mounts{};
 bool g_testing = false;
 bool g_emit_stats = false;
+bool g_is_single_thread = true;
 
 // g_output_fd should be replaced upon connecting to the server, however if an error occurs before then we should at least log it
 int g_output_fd = STDERR_FILENO;

--- a/src/felix86/common/global.hpp
+++ b/src/felix86/common/global.hpp
@@ -93,6 +93,7 @@ extern std::filesystem::path g_executable_path_guest_override;
 extern std::filesystem::path g_mounts_path;
 extern bool g_testing;
 extern bool g_emit_stats;
+extern bool g_is_single_thread;
 
 struct FakeMountNode {
     std::filesystem::path src_path;

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -328,6 +328,11 @@ static Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 a
         break;
     }
     case felix86_riscv64_shmat: {
+        if (g_is_single_thread) {
+            // Similar to mmap with MAP_SHARED
+            g_is_single_thread = false;
+            Recompiler::invalidateRangeGlobal(0, UINT64_MAX & ~0xFFFull, "shmat happened");
+        }
         result = SYSCALL(shmat, arg1, arg2, arg3);
         if (result >= 0 && ((u64)result) > mmap_min_addr() && result < UINT32_MAX) {
             WARN("shmat in 32-bit address space, this could cause problems with MAP_32BIT");
@@ -855,6 +860,12 @@ static Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 a
 #define MAP_32BIT 0x40
 #endif
         u64 flags = arg4;
+        if (g_is_single_thread && (flags & MAP_TYPE) != MAP_PRIVATE) {
+            // If a MAP_SHARED happens we can no longer do single threaded optimizations like not emitting TSO fences
+            g_is_single_thread = false;
+            Recompiler::invalidateRangeGlobal(0, UINT64_MAX & ~0xFFFull, "MAP_SHARED happened");
+        }
+
         bool is_fixed = (flags & MAP_FIXED) || (flags & MAP_FIXED_NOREPLACE);
         if ((flags & MAP_32BIT) || (is_fixed && arg1 < UINT32_MAX) || mode32) {
             // The MAP_32BIT flag is x86 only so we need to emulate it
@@ -2610,6 +2621,12 @@ void felix86_syscall32(felix86_frame* frame, u32 rip_next) {
                 break;
             }
 
+            if (g_is_single_thread && (mmap_args->flags & MAP_TYPE) != MAP_PRIVATE) {
+                // If a MAP_SHARED happens we can no longer do single threaded optimizations like not emitting TSO fences
+                g_is_single_thread = false;
+                Recompiler::invalidateRangeGlobal(0, UINT64_MAX & ~0xFFFull, "MAP_SHARED happened");
+            }
+
             u64 size = mmap_args->len;
             int fd = mmap_args->fd;
             result = (ssize_t)g_mapper->map(mode32, (void*)(u64)mmap_args->addr, size, mmap_args->prot, mmap_args->flags, fd, offset);
@@ -2625,6 +2642,13 @@ void felix86_syscall32(felix86_frame* frame, u32 rip_next) {
         case felix86_x86_32_mmap_pgoff: {
             // mmap2 is like mmap but file offset is in pages (4096 bytes) to help with the lack of big enough integers in x86-32
             u64 offset = arg6 * 4096;
+
+            if (g_is_single_thread && (arg4 & MAP_TYPE) != MAP_PRIVATE) {
+                // If a MAP_SHARED happens we can no longer do single threaded optimizations like not emitting TSO fences
+                g_is_single_thread = false;
+                Recompiler::invalidateRangeGlobal(0, UINT64_MAX & ~0xFFFull, "MAP_SHARED happened");
+            }
+
             result = (ssize_t)g_mapper->map(mode32, (void*)arg1, arg2, arg3, arg4, arg5, offset);
             if (result > 0) {
                 Recompiler::invalidateRangeGlobal(result, result + arg2, "mmap_pgoff");
@@ -2688,6 +2712,11 @@ void felix86_syscall32(felix86_frame* frame, u32 rip_next) {
             break;
         }
         case felix86_x86_32_shmat: {
+            if (g_is_single_thread) {
+                // Similar to mmap with MAP_SHARED
+                g_is_single_thread = false;
+                Recompiler::invalidateRangeGlobal(0, UINT64_MAX & ~0xFFFull, "shmat happened");
+            }
             u32 result_address = 0;
             result = g_mapper->shmat32((int)arg1, (void*)arg2, (int)arg3, &result_address);
             if (result == 0) {

--- a/src/felix86/hle/thread.cpp
+++ b/src/felix86/hle/thread.cpp
@@ -10,6 +10,7 @@
 #include <sys/resource.h>
 #include <sys/syscall.h>
 #include "felix86/common/exit.hpp"
+#include "felix86/common/global.hpp"
 #include "felix86/common/log.hpp"
 #include "felix86/common/state.hpp"
 #include "felix86/common/types.hpp"
@@ -481,6 +482,12 @@ long Threads::Clone(ThreadState* current_state, CloneArgs* args) {
 
     bool clone_fs = args->guest_flags & CLONE_FS;
     bool clone_vm = args->guest_flags & CLONE_VM;
+    if (g_is_single_thread && clone_vm) {
+        // No longer single threaded, start emitting fences
+        g_is_single_thread = false;
+        Recompiler::invalidateRangeGlobal(0, UINT64_MAX & ~0xFFFull, "clone with CLONE_VM happened");
+    }
+
     if (clone_fs && !clone_vm) {
         // This would be quite cursed, because we'd have to use IPC to communicate any FS changes to the processes
         // that share the FS info. Hopefully we won't reach this ever but add a warning here

--- a/src/felix86/v2/optimizer.cpp
+++ b/src/felix86/v2/optimizer.cpp
@@ -1,0 +1,246 @@
+#include "biscuit/assembler.hpp"
+#include "felix86/common/decoder.h"
+#include "felix86/v2/optimizer.hpp"
+
+using namespace biscuit;
+
+static bool is_compressed(u32 instr) {
+    return (instr & 0x3) != 0x3;
+}
+
+static int instr_size(u32 instr) {
+    return is_compressed(instr) ? 2 : 4;
+}
+
+static bool is_branch(RiscvMnemonic m) {
+    switch (m) {
+    case RISCV_BEQ:
+    case RISCV_BNE:
+    case RISCV_BLT:
+    case RISCV_BGE:
+    case RISCV_BLTU:
+    case RISCV_BGEU:
+    case RISCV_BEQI:
+    case RISCV_BNEI:
+    case RISCV_JAL:
+    case RISCV_JALR:
+    case RISCV_C_J:
+    case RISCV_C_JAL:
+    case RISCV_C_JR:
+    case RISCV_C_JALR:
+    case RISCV_C_BEQZ:
+    case RISCV_C_BNEZ:
+        return true;
+    default:
+        return false;
+    }
+}
+
+static bool is_memory_access(RiscvMnemonic m) {
+    switch (m) {
+    case RISCV_LB:
+    case RISCV_LBU:
+    case RISCV_LB_AQ:
+    case RISCV_LH:
+    case RISCV_LHU:
+    case RISCV_LH_AQ:
+    case RISCV_LW:
+    case RISCV_LWU:
+    case RISCV_LW_AQ:
+    case RISCV_LD:
+    case RISCV_LD_AQ:
+    case RISCV_SB:
+    case RISCV_SB_RL:
+    case RISCV_SH:
+    case RISCV_SH_RL:
+    case RISCV_SW:
+    case RISCV_SW_RL:
+    case RISCV_SD:
+    case RISCV_SD_RL:
+    case RISCV_C_LW:
+    case RISCV_C_LWSP:
+    case RISCV_C_LD:
+    case RISCV_C_LDSP:
+    case RISCV_C_LBU:
+    case RISCV_C_LH:
+    case RISCV_C_LHU:
+    case RISCV_C_SW:
+    case RISCV_C_SWSP:
+    case RISCV_C_SD:
+    case RISCV_C_SDSP:
+    case RISCV_C_SB:
+    case RISCV_C_SH:
+    case RISCV_C_FLD:
+    case RISCV_C_FLDSP:
+    case RISCV_C_FLW:
+    case RISCV_C_FLWSP:
+    case RISCV_C_FSD:
+    case RISCV_C_FSDSP:
+    case RISCV_C_FSW:
+    case RISCV_C_FSWSP:
+    case RISCV_FLW:
+    case RISCV_FLD:
+    case RISCV_FLH:
+    case RISCV_FLQ:
+    case RISCV_FSW:
+    case RISCV_FSD:
+    case RISCV_FSH:
+    case RISCV_FSQ:
+    case RISCV_LR_B:
+    case RISCV_LR_H:
+    case RISCV_LR_W:
+    case RISCV_LR_D:
+    case RISCV_SC_B:
+    case RISCV_SC_H:
+    case RISCV_SC_W:
+    case RISCV_SC_D:
+    case RISCV_AMOADD_B:
+    case RISCV_AMOADD_H:
+    case RISCV_AMOADD_W:
+    case RISCV_AMOADD_D:
+    case RISCV_AMOSWAP_B:
+    case RISCV_AMOSWAP_H:
+    case RISCV_AMOSWAP_W:
+    case RISCV_AMOSWAP_D:
+    case RISCV_AMOOR_B:
+    case RISCV_AMOOR_H:
+    case RISCV_AMOOR_W:
+    case RISCV_AMOOR_D:
+    case RISCV_AMOAND_B:
+    case RISCV_AMOAND_H:
+    case RISCV_AMOAND_W:
+    case RISCV_AMOAND_D:
+    case RISCV_AMOXOR_B:
+    case RISCV_AMOXOR_H:
+    case RISCV_AMOXOR_W:
+    case RISCV_AMOXOR_D:
+    case RISCV_AMOMIN_B:
+    case RISCV_AMOMIN_H:
+    case RISCV_AMOMIN_W:
+    case RISCV_AMOMIN_D:
+    case RISCV_AMOMAX_B:
+    case RISCV_AMOMAX_H:
+    case RISCV_AMOMAX_W:
+    case RISCV_AMOMAX_D:
+    case RISCV_AMOMINU_B:
+    case RISCV_AMOMINU_H:
+    case RISCV_AMOMINU_W:
+    case RISCV_AMOMINU_D:
+    case RISCV_AMOMAXU_B:
+    case RISCV_AMOMAXU_H:
+    case RISCV_AMOMAXU_W:
+    case RISCV_AMOMAXU_D:
+    case RISCV_AMOCAS_B:
+    case RISCV_AMOCAS_H:
+    case RISCV_AMOCAS_W:
+    case RISCV_AMOCAS_D:
+    case RISCV_AMOCAS_Q:
+    case RISCV_VSE8_V:
+    case RISCV_VSE16_V:
+    case RISCV_VSE32_V:
+    case RISCV_VSE64_V:
+    case RISCV_VLE8_V:
+    case RISCV_VLE16_V:
+    case RISCV_VLE32_V:
+    case RISCV_VLE64_V:
+    case RISCV_VLE8FF_V:
+    case RISCV_VLE16FF_V:
+    case RISCV_VLE32FF_V:
+    case RISCV_VLE64FF_V:
+    case RISCV_VLUXEI8_V:
+    case RISCV_VLUXEI16_V:
+    case RISCV_VLUXEI32_V:
+    case RISCV_VLUXEI64_V:
+    case RISCV_VLOXEI8_V:
+    case RISCV_VLOXEI16_V:
+    case RISCV_VLOXEI32_V:
+    case RISCV_VLOXEI64_V:
+    case RISCV_VSUXEI8_V:
+    case RISCV_VSUXEI16_V:
+    case RISCV_VSUXEI32_V:
+    case RISCV_VSUXEI64_V:
+    case RISCV_VSOXEI8_V:
+    case RISCV_VSOXEI16_V:
+    case RISCV_VSOXEI32_V:
+    case RISCV_VSOXEI64_V:
+    case RISCV_VLSE8_V:
+    case RISCV_VLSE16_V:
+    case RISCV_VLSE32_V:
+    case RISCV_VLSE64_V:
+    case RISCV_VSSE8_V:
+    case RISCV_VSSE16_V:
+    case RISCV_VSSE32_V:
+    case RISCV_VSSE64_V:
+    case RISCV_VLM_V:
+    case RISCV_VSM_V:
+    case RISCV_VL1RE8_V:
+    case RISCV_VL1RE16_V:
+    case RISCV_VL1RE32_V:
+    case RISCV_VL1RE64_V:
+    case RISCV_VL2RE8_V:
+    case RISCV_VL2RE16_V:
+    case RISCV_VL2RE32_V:
+    case RISCV_VL2RE64_V:
+    case RISCV_VL4RE8_V:
+    case RISCV_VL4RE16_V:
+    case RISCV_VL4RE32_V:
+    case RISCV_VL4RE64_V:
+    case RISCV_VL8RE8_V:
+    case RISCV_VL8RE16_V:
+    case RISCV_VL8RE32_V:
+    case RISCV_VL8RE64_V:
+    case RISCV_VS1R_V:
+    case RISCV_VS2R_V:
+    case RISCV_VS4R_V:
+    case RISCV_VS8R_V:
+        return true;
+    default:
+        return false;
+    }
+}
+
+void Optimizer::native_pass(u8* start, u64 size) {
+    u32 acq_fence, rel_fence;
+    {
+        Assembler as((u8*)&acq_fence, 4);
+        as.FENCE(FenceOrder::R, FenceOrder::RW);
+    }
+    {
+        Assembler as((u8*)&rel_fence, 4);
+        as.FENCE(FenceOrder::RW, FenceOrder::W);
+    }
+
+    u32* acq_fence_pos = nullptr;
+    u64 i = 0;
+    while (i < size) {
+        u32* pos = (u32*)(start + i);
+        const u32 instr = *pos;
+        RiscvMnemonic mnemonic = riscv_get_mnemonic(instr);
+
+        if (is_branch(mnemonic)) {
+            // We would need to have branch targets invalidate our fence positions, skip for now
+            return;
+        }
+
+        if (mnemonic == RISCV_FENCE) {
+            u32* prior_acq = acq_fence_pos;
+            acq_fence_pos = nullptr;
+            if (instr == acq_fence) {
+                acq_fence_pos = pos;
+            } else if (instr == rel_fence && prior_acq) {
+                {
+                    Assembler as((u8*)prior_acq, 4);
+                    as.NOP();
+                }
+                {
+                    Assembler as((u8*)pos, 4);
+                    as.FENCETSO();
+                }
+            }
+        } else if (is_memory_access(mnemonic)) {
+            acq_fence_pos = nullptr;
+        }
+
+        i += instr_size(instr);
+    }
+}

--- a/src/felix86/v2/optimizer.hpp
+++ b/src/felix86/v2/optimizer.hpp
@@ -1,0 +1,7 @@
+#pragma once
+
+#include "felix86/common/types.hpp"
+
+namespace Optimizer {
+void native_pass(u8* start, u64 size);
+}

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -804,9 +804,8 @@ u64 Recompiler::compileSequence(bool mode32, u64 rip) {
 
     resetScratch();
 
-    if (g_config.always_tso && !Extensions::TSO) {
-        Optimizer::native_pass((u8*)block_meta.host_address,
-                               (u64)as.GetCursorPointer() - block_meta.host_address);
+    if (g_config.always_tso && !g_is_single_thread && !Extensions::TSO) {
+        Optimizer::native_pass((u8*)block_meta.host_address, (u64)as.GetCursorPointer() - block_meta.host_address);
     }
 
     flush_icache(block_meta.host_address, (u64)as.GetCursorPointer());
@@ -2958,7 +2957,8 @@ biscuit::GPR Recompiler::getCond(int cond) {
 }
 
 bool Recompiler::needsTsoFence() const {
-    return g_config.always_tso && !Extensions::TSO && !(g_config.no_tso_stack && current_instruction_on_stack && !g_config.paranoid);
+    return g_config.always_tso && !g_is_single_thread && !Extensions::TSO &&
+           !(g_config.no_tso_stack && current_instruction_on_stack && !g_config.paranoid);
 }
 
 void Recompiler::readMemory(biscuit::GPR dest, biscuit::GPR address, i64 offset, x86_size_e size) {

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -17,6 +17,7 @@
 #include "felix86/hle/ptrace.hpp"
 #include "felix86/hle/syscall.hpp"
 #include "felix86/v2/handlers.hpp"
+#include "felix86/v2/optimizer.hpp"
 #include "felix86/v2/recompiler.hpp"
 #include "fmt/format.h"
 
@@ -802,6 +803,12 @@ u64 Recompiler::compileSequence(bool mode32, u64 rip) {
     }
 
     resetScratch();
+
+    if (g_config.always_tso && !Extensions::TSO) {
+        Optimizer::native_pass((u8*)block_meta.host_address,
+                               (u64)as.GetCursorPointer() - block_meta.host_address);
+    }
+
     flush_icache(block_meta.host_address, (u64)as.GetCursorPointer());
 
     current_block_metadata = nullptr;


### PR DESCRIPTION
Merge acq+rel fences into fence.tso, and only enable TSO on first clone/map_shared/shmat