### PR TITLE
Linux: Passthrough to host xdg-open for URLs

### DIFF
--- a/src/felix86/common/config.inc
+++ b/src/felix86/common/config.inc
@@ -9,6 +9,7 @@ X(General, std::string, host_environment, "", FELIX86_HOST_ENVIRONMENT, "Environ
 X(General, bool, binfmt_misc_installed, false, FELIX86_BINFMT_MISC_INSTALLED, "Whether binfmt_misc is installed, do NOT change this manually unless if you know what you're doing -- install with `felix86 --binfmt-misc` instead")
 X(General, bool, no_rootfs, false, FELIX86_NO_ROOTFS, "Do not use a rootfs, passthrough all filesystem syscalls to the host")
 X(General, bool, mount_home, true, FELIX86_MOUNT_HOME, "Fakemount the host /home directory inside the rootfs")
+X(General, bool, xdg_open_passthrough, true, FELIX86_XDG_OPEN_PASSTHROUGH, "Passthrough xdg-open calls to host xdg-open, allowing running the host browser when opening URLs for example")
 
 X(Logging, bool, verbose, false, FELIX86_VERBOSE, "Enable verbose logging")
 X(Logging, bool, quiet, false, FELIX86_QUIET, "Disable all logging")

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -1531,28 +1531,17 @@ static Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 a
             break;
         }
 
-        FdPath fd_path = Filesystem::resolve((char*)arg1, true);
-
-        if (!fd_path.path() || !std::filesystem::exists(fd_path.full_path())) {
-            WARN("Execve couldn't find path: %s", (char*)arg1);
-            result = -ENOENT;
-            break;
-        }
-
-        std::filesystem::path path = fd_path.full_path();
-        if (!std::filesystem::is_regular_file(path)) {
-            WARN("Not regular file during execve: %s", path.c_str());
-            result = -ENOENT;
-            break;
-        }
-
-        if (g_config.xdg_open_passthrough && path.filename() == "xdg-open") {
+        if (g_config.xdg_open_passthrough && std::filesystem::path((char*)arg1).filename() == "xdg-open") {
             const char* url = nullptr;
             if (arg2) {
-                u64 url_ptr = 0, next_ptr = 0;
-                memcpy(&url_ptr, (u8*)arg2 + (mode32 ? 4 : 8), mode32 ? 4 : 8);
+                size_t ptr_size = mode32 ? 4 : 8;
+                u64 argv0_ptr = 0, url_ptr = 0, next_ptr = 0;
+                memcpy(&argv0_ptr, (u8*)arg2, ptr_size);
+                if (argv0_ptr) {
+                    memcpy(&url_ptr, (u8*)arg2 + ptr_size, ptr_size);
+                }
                 if (url_ptr) {
-                    memcpy(&next_ptr, (u8*)arg2 + (mode32 ? 8 : 16), mode32 ? 4 : 8);
+                    memcpy(&next_ptr, (u8*)arg2 + ptr_size * 2, ptr_size);
                 }
                 if (url_ptr && !next_ptr && is_xdg_open_url((const char*)url_ptr)) {
                     url = (const char*)url_ptr;
@@ -1574,6 +1563,21 @@ static Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 a
 
                 WARN("Couldn't run the host xdg-open with error %s, running the guest xdg-open instead", strerror(errno));
             }
+        }
+
+        FdPath fd_path = Filesystem::resolve((char*)arg1, true);
+
+        if (!fd_path.path() || !std::filesystem::exists(fd_path.full_path())) {
+            WARN("Execve couldn't find path: %s", (char*)arg1);
+            result = -ENOENT;
+            break;
+        }
+
+        std::filesystem::path path = fd_path.full_path();
+        if (!std::filesystem::is_regular_file(path)) {
+            WARN("Not regular file during execve: %s", path.c_str());
+            result = -ENOENT;
+            break;
         }
 
         std::vector<const char*> argv;

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -189,6 +189,11 @@ static bool try_strace_ioctl(int rdi, u64 rsi, u64 rdx, u64 result) {
     return false;
 }
 
+static bool is_xdg_open_url(const char* arg) {
+    std::string_view url = arg;
+    return url.starts_with("https://") || url.starts_with("http://");
+}
+
 static Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 arg1, u64 arg2, u64 arg3, u64 arg4, u64 arg5, u64 arg6) {
     ThreadState* state = frame->state;
     bool mode32 = state->ctx.Mode32();
@@ -1529,7 +1534,7 @@ static Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 a
         FdPath fd_path = Filesystem::resolve((char*)arg1, true);
 
         if (!fd_path.path() || !std::filesystem::exists(fd_path.full_path())) {
-            WARN("Execve couldn't find path: %s", arg1);
+            WARN("Execve couldn't find path: %s", (char*)arg1);
             result = -ENOENT;
             break;
         }
@@ -1539,6 +1544,36 @@ static Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 a
             WARN("Not regular file during execve: %s", path.c_str());
             result = -ENOENT;
             break;
+        }
+
+        if (g_config.xdg_open_passthrough && path.filename() == "xdg-open") {
+            const char* url = nullptr;
+            if (arg2) {
+                u64 url_ptr = 0, next_ptr = 0;
+                memcpy(&url_ptr, (u8*)arg2 + (mode32 ? 4 : 8), mode32 ? 4 : 8);
+                if (url_ptr) {
+                    memcpy(&next_ptr, (u8*)arg2 + (mode32 ? 8 : 16), mode32 ? 4 : 8);
+                }
+                if (url_ptr && !next_ptr && is_xdg_open_url((const char*)url_ptr)) {
+                    url = (const char*)url_ptr;
+                }
+            }
+
+            if (!url) {
+                VERBOSE("xdg-open wasn't called with a URL, using the guest xdg-open instead");
+            } else {
+                const char* xdg_argv[] = {"xdg-open", url, nullptr};
+
+                LOG("Calling host xdg-open: %s", url);
+
+                g_process_globals.shm_manager.unlink();
+
+                ThreadState::Set(nullptr);
+                execvpe("xdg-open", (char* const*)xdg_argv, environ);
+                ThreadState::Set(state);
+
+                WARN("Couldn't run the host xdg-open with error %s, running the guest xdg-open instead", strerror(errno));
+            }
         }
 
         std::vector<const char*> argv;


### PR DESCRIPTION
For #443, tested with Hytale Launcher, opened native browser window and I was able to login and the guest can wait on the host xdg-open to finish just fine.  Enabled by default since its rare someone will want a guest browser running. 