### PR TITLE
Linux: Allow rootfs to propagate through vfork and hide protected fds in getdents

### DIFF
--- a/src/felix86/common/global.cpp
+++ b/src/felix86/common/global.cpp
@@ -103,6 +103,8 @@ void ProcessGlobals::initialize() {
 
     memset(cas128_locks, 0, sizeof(cas128_locks));
 
+    vfork_rootfs = nullptr;
+
     // HACK: Don't clear as they get shared per mount namespace
     // TODO: proper mount namespacing when we need it
     // mount_paths.clear();

--- a/src/felix86/common/global.hpp
+++ b/src/felix86/common/global.hpp
@@ -56,6 +56,8 @@ struct ProcessGlobals {
     // But we don't care for now
     std::vector<std::filesystem::path> mount_paths;
 
+    char* vfork_rootfs = nullptr;
+
     SHMManager shm_manager;
 };
 

--- a/src/felix86/hle/fd.cpp
+++ b/src/felix86/hle/fd.cpp
@@ -1,8 +1,10 @@
 #include <cstring>
 #include <set>
 #include <fcntl.h>
+#include <sys/syscall.h>
 #include "felix86/common/log.hpp"
 #include "felix86/hle/fd.hpp"
+#include "felix86/hle/guest_types.hpp"
 
 static std::set<int> g_protected_fds{};
 
@@ -37,6 +39,47 @@ int FD::close(int fd) {
     } else {
         return ::close(fd);
     }
+}
+
+static bool is_proc_fd_directory(int fd) {
+    char buffer[4096];
+    std::string link = "/proc/self/fd/" + std::to_string(fd);
+    ssize_t size = ::readlink(link.c_str(), buffer, sizeof(buffer) - 1);
+    if (size <= 0) {
+        return false;
+    }
+    std::string_view path(buffer, size);
+    if (!path.starts_with("/proc/")) {
+        return false;
+    }
+    return path.ends_with("/fd") || path.ends_with("/fdinfo");
+}
+
+long FD::getdents64(int fd, u64 dirp, u32 count) {
+    long result = ::syscall(SYS_getdents64, fd, dirp, count);
+    if (result <= 0) {
+        return result;
+    }
+
+    auto guard = g_process_globals.states_lock.lock();
+    if (g_protected_fds.empty() || !is_proc_fd_directory(fd)) {
+        return result;
+    }
+
+    long out = 0;
+    for (long i = 0; i < result;) {
+        x86_linux_dirent64* current = (x86_linux_dirent64*)(dirp + i);
+        u16 reclen = current->d_reclen;
+        if (!g_protected_fds.contains(atoi(current->d_name))) {
+            if (out != i) {
+                memmove((void*)(dirp + out), (void*)(dirp + i), reclen);
+            }
+            out += reclen;
+        }
+        i += reclen;
+    }
+
+    return out;
 }
 
 int FD::close_range(u32 start, u32 end, int flags) {

--- a/src/felix86/hle/fd.hpp
+++ b/src/felix86/hle/fd.hpp
@@ -20,6 +20,8 @@ struct FD {
 
     static int close(int fd);
 
+    static long getdents64(int fd, u64 dirp, u32 count);
+
     static int close_range(u32 start, u32 end, int flags);
 
     static int dup2(int old_fd, int new_fd);

--- a/src/felix86/hle/filesystem.cpp
+++ b/src/felix86/hle/filesystem.cpp
@@ -554,6 +554,22 @@ std::filesystem::path create_unique_mount_path() {
     return dir;
 }
 
+void Filesystem::SetRootfs(const std::filesystem::path& path) {
+    auto guard = g_process_globals.states_lock.lock();
+    g_config.rootfs_path = path;
+    g_process_globals.mount_paths.push_back(g_config.rootfs_path);
+    int old_rootfs_fd = g_rootfs_fd;
+    g_rootfs_fd = open(path.c_str(), O_PATH | O_DIRECTORY);
+    FD::unprotectAndClose(old_rootfs_fd);
+    ASSERT_MSG(g_rootfs_fd > 0, "Failed to open new rootfs dir: %s", path.c_str());
+    g_rootfs_fd = FD::moveToHighNumber(g_rootfs_fd);
+    FD::protect(g_rootfs_fd);
+    if (g_process_globals.vfork_rootfs) {
+        strncpy(g_process_globals.vfork_rootfs, path.c_str(), PATH_MAX - 1);
+        g_process_globals.vfork_rootfs[PATH_MAX - 1] = 0;
+    }
+}
+
 int Filesystem::Chroot(const char* path) {
     WARN("chroot(%s)", path);
     if (g_config.no_rootfs) {
@@ -594,15 +610,7 @@ int Filesystem::Chroot(const char* path) {
     }
 
     // TODO: setting rootfs_path is most likely thread unsafe?
-    auto guard = g_process_globals.states_lock.lock();
-    g_config.rootfs_path = final_path;
-    g_process_globals.mount_paths.push_back(g_config.rootfs_path);
-    int old_rootfs_fd = g_rootfs_fd;
-    g_rootfs_fd = open(final_path.c_str(), O_PATH | O_DIRECTORY);
-    FD::unprotectAndClose(old_rootfs_fd);
-    ASSERT_MSG(g_rootfs_fd > 0, "Failed to open new rootfs dir: %s", final_path.c_str());
-    g_rootfs_fd = FD::moveToHighNumber(g_rootfs_fd);
-    FD::protect(g_rootfs_fd);
+    SetRootfs(final_path);
     return 0;
 }
 
@@ -645,16 +653,7 @@ int Filesystem::PivotRoot(const char* new_root, const char* put_old) {
         WARN("Failed to move mount during pivot_root %s -> %s, error: %s", new_root_full, path.c_str(), strerror(errno));
         return -errno;
     } else {
-        auto lock = g_process_globals.states_lock.lock();
-        int old_rootfs_fd = g_rootfs_fd;
-        g_rootfs_fd = open(path.c_str(), O_PATH | O_DIRECTORY);
-        FD::unprotectAndClose(old_rootfs_fd);
-        ASSERT_MSG(g_rootfs_fd > 0, "Failed to open new rootfs dir: %s", path.c_str());
-        g_rootfs_fd = FD::moveToHighNumber(g_rootfs_fd);
-        FD::protect(g_rootfs_fd);
-        g_config.rootfs_path = path;
-
-        g_process_globals.mount_paths.push_back(g_config.rootfs_path);
+        SetRootfs(path);
     }
 
     // TODO: Super HACK: when there's a pivot_root(".", "."), don't mount the old directory

--- a/src/felix86/hle/filesystem.hpp
+++ b/src/felix86/hle/filesystem.hpp
@@ -184,6 +184,8 @@ struct Filesystem {
 
     static bool FakeMount(const std::filesystem::path& mount_me, const std::filesystem::path& dst);
 
+    static void SetRootfs(const std::filesystem::path& path);
+
     // Emulated syscall functions
     int OpenAt(bool mode32, int fd, const char* filename, int flags, u64 mode);
 

--- a/src/felix86/hle/syscall.cpp
+++ b/src/felix86/hle/syscall.cpp
@@ -775,7 +775,7 @@ static Result felix86_syscall_common(felix86_frame* frame, int rv_syscall, u64 a
         break;
     }
     case felix86_riscv64_getdents64: {
-        result = SYSCALL(getdents64, arg1, arg2, arg3, arg4, arg5, arg6);
+        result = FD::getdents64(arg1, arg2, arg3);
         break;
     }
     case felix86_riscv64_lgetxattr: {
@@ -2121,7 +2121,7 @@ void felix86_syscall(felix86_frame* frame) {
             u64 dirp = arg2;
             u32 count = arg3;
 
-            result = SYSCALL(getdents64, fd, dirp, count);
+            result = FD::getdents64(fd, dirp, count);
             if (result > 0) {
                 size_t bytes = result;
                 for (size_t i = 0; i < bytes;) {
@@ -3082,7 +3082,7 @@ void felix86_syscall32(felix86_frame* frame, u32 rip_next) {
             u64 dirp = arg2;
             u32 count = arg3;
 
-            result = SYSCALL(getdents64, fd, dirp, count);
+            result = FD::getdents64(fd, dirp, count);
             if (result >= 0) {
                 size_t bytes = result;
                 size_t num = 0;

--- a/src/felix86/hle/thread.cpp
+++ b/src/felix86/hle/thread.cpp
@@ -16,6 +16,7 @@
 #include "felix86/common/types.hpp"
 #include "felix86/common/utility.hpp"
 #include "felix86/hle/fd.hpp"
+#include "felix86/hle/filesystem.hpp"
 #include "felix86/hle/mmap.hpp"
 #include "felix86/hle/signals.hpp"
 #include "felix86/hle/thread.hpp"
@@ -376,6 +377,12 @@ static long VForkMe(CloneArgs& args) {
     int pipes[2];
     ASSERT(pipe2(pipes, O_CLOEXEC) != -1);
 
+    char* shared_rootfs = nullptr;
+    if ((args.guest_flags & CLONE_FS) && !g_config.no_rootfs) {
+        shared_rootfs = (char*)mmap(nullptr, PATH_MAX, PROT_READ | PROT_WRITE, MAP_SHARED | MAP_ANONYMOUS, -1, 0);
+        ASSERT(shared_rootfs != MAP_FAILED);
+    }
+
     ThreadState* state = ThreadState::Get();
     u64 parent_flags = state->ptrace_data.constants.flags;
     bool trace_vfork = parent_flags & PTRACE_O_TRACEVFORK;
@@ -394,6 +401,7 @@ static long VForkMe(CloneArgs& args) {
         int pid = getpid();
         SIGLOG("%d vforked to %d", parent_pid, pid);
         ThreadState* state = ThreadState::Get();
+        g_process_globals.vfork_rootfs = shared_rootfs;
 
         // TODO: probably clean up states here, but it doesn't matter cus it gets execve'd anyway
         if (args.new_rsp) {
@@ -463,6 +471,16 @@ static long VForkMe(CloneArgs& args) {
 
         // Close the read end now.
         close(pipes[0]);
+
+        // HACK: Chromium will vfork and change the rootfs. We don't CLONE_VM so g_config.rootfs won't be updated here
+        // but also g_rootfs_fd wouldn't be updated because the clone happens without CLONE_FILES. For now, allow chroot
+        // to propagate through vfork like this
+        if (shared_rootfs) {
+            if (shared_rootfs[0]) {
+                Filesystem::SetRootfs(shared_rootfs);
+            }
+            ::munmap(shared_rootfs, PATH_MAX);
+        }
 
         if (Ptrace::is_traced(state) && trace_vfork_done) {
             int sig = SIGTRAP;


### PR DESCRIPTION
Fixes two issues with Chromium sandbox, where it will vfork+chroot and expect the parent to be chrooted and another where it will check /proc/self/fd and if its not empty then crash.