### PR TITLE
Recompiler: Optimize push/pop chains

### DIFF
--- a/src/felix86/repl.cpp
+++ b/src/felix86/repl.cpp
@@ -135,18 +135,23 @@ static void compile(const std::string& input) {
         end += instr.riscv_instructions_size;
     }
 
-    // Remove compiled UNDEF instructions off the end, if any
-    u16* fin = (u16*)(end - 2);
-    while (*fin == 0) {
-        end -= 2;
-        fin = (u16*)(end - 2);
+    u64 spans_end = end + 4;
+    u64 code_end = (u64)rec->getEndOfCodeCache();
+    if (spans_end == code_end) {
+        // Remove compiled UNDEF instructions off the end, if any
+        u16* fin = (u16*)(end - 2);
+        while (*fin == 0) {
+            end -= 2;
+            fin = (u16*)(end - 2);
+        }
+
+        // Also remove a store to zero and a hint used to emulate ud2
+        end -= 8;
     }
 
     // TODO: can we make this less hacky
     // Skip the safepoint at the start of the sequence
     start += 4;
-    // Also remove a store to zero and a hint used to emulate ud2
-    end -= 8;
 
     size_t span_index = 0;
     u64 address = start;

--- a/src/felix86/tools/generate_instruction_count.cpp
+++ b/src/felix86/tools/generate_instruction_count.cpp
@@ -123,6 +123,7 @@ static void gen(Recompiler& rec, nlohmann::ordered_json& json, void (*func)(Xbya
     rec.compileInstruction(zinstruction, zoperands, rip);
     rec.resetScratch();
     rec.flushX87();
+    rec.flushPushpop();
     auto after = rec.getAssembler().GetCursorPointer();
     int count = 0;
     Instruction inst;

--- a/src/felix86/v2/handlers.cpp
+++ b/src/felix86/v2/handlers.cpp
@@ -2071,7 +2071,37 @@ FAST_HANDLE(IRETQ) {
     rec.stopCompiling();
 }
 
+static bool pushpop_should_chain(Recompiler& rec) {
+    auto next = rec.getNextInstruction();
+    return next && (next->first->mnemonic == ZYDIS_MNEMONIC_PUSH || next->first->mnemonic == ZYDIS_MNEMONIC_POP);
+}
+
+static bool pushpop_fast_path(Recompiler& rec, ZydisDecodedOperand* operands) {
+    return operands[0].type == ZYDIS_OPERAND_TYPE_REGISTER && operands[0].size >= 32 && !is_segment(operands[0]) &&
+           rec.zydisToRef(operands[0].reg.value) != X86_REF_RSP;
+}
+
 FAST_HANDLE(PUSH) {
+    if (g_config.no_tso_stack) {
+        if (pushpop_fast_path(rec, operands)) {
+            bool pushpop_chain = pushpop_should_chain(rec);
+            int size = size_to_bytes(instruction.operand_width);
+            if (!IsValidSigned12BitImm(rec.getCurrentPushpopOffset() - size)) {
+                rec.flushPushpop();
+            }
+            int imm = rec.getCurrentPushpopOffset() - size;
+            biscuit::GPR src = rec.getGPR(&operands[0]);
+            biscuit::GPR rsp = rec.getGPR(X86_REF_RSP, rec.stackWidth());
+            rec.writeMemory(src, rsp, imm, rec.zydisToSize(instruction.operand_width));
+            rec.setCurrentPushpopOffset(imm);
+            if (!pushpop_chain) {
+                rec.flushPushpop();
+            }
+            return;
+        }
+        rec.flushPushpop();
+    }
+
     biscuit::GPR src;
     if (is_segment(operands[0])) {
         biscuit::GPR seg = rec.scratch();
@@ -2121,6 +2151,27 @@ FAST_HANDLE(PUSH) {
 }
 
 FAST_HANDLE(POP) {
+    if (g_config.no_tso_stack) {
+        if (pushpop_fast_path(rec, operands)) {
+            bool pushpop_chain = pushpop_should_chain(rec);
+            int size = size_to_bytes(instruction.operand_width);
+            if (!IsValidSigned12BitImm(rec.getCurrentPushpopOffset() + size)) {
+                rec.flushPushpop();
+            }
+            int imm = rec.getCurrentPushpopOffset();
+            biscuit::GPR rsp = rec.getGPR(X86_REF_RSP, rec.stackWidth());
+            biscuit::GPR reg = rec.getGPR(&operands[0], X86_SIZE_QWORD);
+            rec.readMemory(reg, rsp, imm, rec.zydisToSize(instruction.operand_width));
+            rec.setGPR(operands[0].reg.value, X86_SIZE_QWORD, reg);
+            rec.setCurrentPushpopOffset(imm + size);
+            if (!pushpop_chain) {
+                rec.flushPushpop();
+            }
+            return;
+        }
+        rec.flushPushpop();
+    }
+
     if (is_segment(operands[0])) {
         ASSERT_MSG(MODE32, "Popping segment not in 32-bit mode?");
         ASSERT(operands[0].reg.value != ZYDIS_REGISTER_CS);

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -640,6 +640,7 @@ u64 Recompiler::compileSequence(bool mode32, u64 rip) {
 
     current_ripreg_value = rip; // may change in a syscall to check for safepoints, or after a set amount of instructions in the future
     current_instruction_index = 0;
+    current_pushpop_offset = 0;
 
     bool ran_mmx_once = false;
 
@@ -665,13 +666,15 @@ u64 Recompiler::compileSequence(bool mode32, u64 rip) {
                       (operands[1].type == ZYDIS_OPERAND_TYPE_REGISTER && operands[1].reg.value >= ZYDIS_REGISTER_YMM0 &&
                        operands[1].reg.value <= ZYDIS_REGISTER_YMM15);
 
+        bool push_pop_reg = (instruction.mnemonic == ZYDIS_MNEMONIC_PUSH || instruction.mnemonic == ZYDIS_MNEMONIC_POP) &&
+                            operands[0].type == ZYDIS_OPERAND_TYPE_REGISTER;
         bool op1_on_stack = operands[0].type == ZYDIS_OPERAND_TYPE_MEMORY && operands[0].mem.base != ZYDIS_REGISTER_NONE &&
                             zydisToRef(operands[0].mem.base) == X86_REF_RSP;
         bool op2_on_stack = operands[1].type == ZYDIS_OPERAND_TYPE_MEMORY && operands[1].mem.base != ZYDIS_REGISTER_NONE &&
                             zydisToRef(operands[1].mem.base) == X86_REF_RSP;
         bool op3_on_stack = operands[2].type == ZYDIS_OPERAND_TYPE_MEMORY && operands[2].mem.base != ZYDIS_REGISTER_NONE &&
                             zydisToRef(operands[2].mem.base) == X86_REF_RSP;
-        current_instruction_on_stack = op1_on_stack || op2_on_stack || op3_on_stack;
+        current_instruction_on_stack = push_pop_reg || op1_on_stack || op2_on_stack || op3_on_stack;
 
         if (instruction.mnemonic == ZYDIS_MNEMONIC_EMMS) {
             ran_mmx_once = false; // if we run another mmx instruction, set tag to valid again
@@ -762,6 +765,7 @@ u64 Recompiler::compileSequence(bool mode32, u64 rip) {
 
         if (is_single_step && compiling) {
             resetScratch();
+            flushPushpop();
             flushX87();
             biscuit::GPR ripreg = allocatedGPR(X86_REF_RIP);
             u64 offset = rip - getCurrentRipregValue();
@@ -806,6 +810,7 @@ u64 Recompiler::compileSequence(bool mode32, u64 rip) {
     if (current_block_big) {
         VERBOSE("Block at %lx exceeded max instruction count", start_rip);
         resetScratch();
+        flushPushpop(); // should be redundant here but w/e
         flushX87();
         biscuit::GPR ripreg = allocatedGPR(X86_REF_RIP);
         u64 offset = rip - getCurrentRipregValue();
@@ -834,7 +839,6 @@ u64 Recompiler::compileSequence(bool mode32, u64 rip) {
 }
 
 std::optional<std::pair<ZydisDecodedInstruction*, ZydisDecodedOperand*>> Recompiler::getNextInstruction() {
-    ASSERT(instructions.size() > current_instruction_index + 1);
     if (current_instruction_index + 1 < instructions.size()) {
         auto& [instruction, operands] = instructions[current_instruction_index + 1];
         return std::make_pair(&instruction, operands);
@@ -2075,6 +2079,7 @@ void Recompiler::writebackState() {
     v0Modified();
     resetVectorState();
 
+    flushPushpop();
     flushX87();
 
     biscuit::GPR rip = allocatedGPR(X86_REF_RIP);

--- a/src/felix86/v2/recompiler.hpp
+++ b/src/felix86/v2/recompiler.hpp
@@ -771,6 +771,25 @@ struct Recompiler {
 
     std::optional<std::pair<ZydisDecodedInstruction*, ZydisDecodedOperand*>> getNextInstruction();
 
+    i16 getCurrentPushpopOffset() {
+        return current_pushpop_offset;
+    }
+
+    void setCurrentPushpopOffset(i16 value) {
+        current_pushpop_offset = value;
+    }
+
+    void flushPushpop() {
+        i16 pushpop_offset = getCurrentPushpopOffset();
+        if (pushpop_offset != 0) {
+            ASSERT(IsValidSigned12BitImm(pushpop_offset));
+            setCurrentPushpopOffset(0);
+            biscuit::GPR rsp = getGPR(X86_REF_RSP, stackWidth());
+            as.ADDI(rsp, rsp, pushpop_offset);
+            setGPR(X86_REF_RSP, stackWidth(), rsp);
+        }
+    }
+
 private:
     void emitNecessaryStuff();
 
@@ -835,6 +854,7 @@ private:
     u64 current_rip;
     u64 current_ripreg_value;
     u64 current_instruction_index = 0;
+    i16 current_pushpop_offset = 0;
     bool current_instruction_on_stack = false;
     bool current_block_big = false;
     FlagAccessData current_flag_access{};


### PR DESCRIPTION
Also don't emit fences on push/pop with no_tso_stack