### PR TITLE
Linux: Make /proc/self/auxv emulation configurable

### DIFF
--- a/src/felix86/common/config.inc
+++ b/src/felix86/common/config.inc
@@ -64,6 +64,7 @@ X(Debugging, bool, dump_seccomp, false, FELIX86_DUMP_SECCOMP, "Dump installed se
 X(Debugging, bool, seccomp_always_allow, false, FELIX86_SECCOMP_ALWAYS_ALLOW, "Don't run seccomp programs at all, allow all syscalls")
 X(Debugging, bool, ptrace_enabled, true, FELIX86_PTRACE_ENABLED, "Enable ptrace(), allowing programs to debug other programs")
 X(Debugging, bool, stats_enabled, false, FELIX86_STATS_ENABLED, "Enable JIT stats")
+X(Debugging, bool, proc_self_auxv, true, FELIX86_PROC_SELF_AUXV, "Enable /proc/self/auxv emulation, breaks host gdb attaching to felix86, disable if you need to attach")
 
 X(Performance, bool, link, true, FELIX86_LINK, "Enable basic block linking, important for performance")
 X(Performance, u64, max_block_size, 300, FELIX86_MAX_BLOCK_SIZE, "Maximum x86 instructions per block")

--- a/src/felix86/emulator.cpp
+++ b/src/felix86/emulator.cpp
@@ -273,8 +273,13 @@ static void setupMainStack(ThreadState* state) {
         map.arg_end = arg_end;
         map.env_start = env_start;
         map.env_end = env_end;
-        map.auxv = (__u64*)g_guest_auxv;
-        map.auxv_size = g_guest_auxv_size;
+        if (g_config.proc_self_auxv) {
+            // Breaks gdb, so we make this configurable
+            // TODO: if we ever emulate proc self exe to outside felix86 processes correctly, we could
+            // reuse that code to emulate proc self auxv and leave the host visible /proc/self/auxv untouched
+            map.auxv = (__u64*)g_guest_auxv;
+            map.auxv_size = g_guest_auxv_size;
+        }
         int result = prctl(PR_SET_MM, PR_SET_MM_MAP, &map, sizeof(prctl_mm_map), 0L);
         if (result != 0) {
             WARN("Failed to run PR_SET_MM_MAP");

--- a/src/felix86/hle/signals.cpp
+++ b/src/felix86/hle/signals.cpp
@@ -1178,8 +1178,11 @@ static void defer_signal(ThreadState* state, int sig, siginfo_t* info, void* ctx
                 node = node->next;
                 count++;
             }
-            ASSERT_MSG(count <= 32, "Too many realtime signals of SIGRT%d", sig);
-            node->next = new_node;
+            if (count <= 32) {
+                node->next = new_node;
+            } else {
+                IMPORTANT("Too many realtime signals of SIGRT%d, dropping signal", sig);
+            }
         }
     }
     // Make our safepoints fault


### PR DESCRIPTION
gdb would break when we emulate /proc/self/auxv, so allow it to be turned off for debugging purposes.

Also don't assert on too many realtime signals, allows dotnet applications to continue working as they queue too many signals and solving it perfectly is far from easy. Their realtime signals seem to only be used to trigger GC so skipping some is fine in that case.