### PR TITLE
Recompiler: Revert "Avoid unnecessary mprotect calls (#721)" 

### DIFF
--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -2858,6 +2858,10 @@ void Recompiler::expirePendingLinks(u64 rip) {
     u64 min = -1ull;
     u64 max = 0;
     auto& links = getBlockMetadata(rip).pending_links;
+    if (links.empty()) {
+        return;
+    }
+
     for (u8* link : links) {
         u8* cursor = as.GetCursorPointer();
         as.SetCursorPointer(link);

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -471,7 +471,7 @@ u64 Recompiler::compile(ThreadState* state, u64 rip) {
         u64 start_masked = start_rip & ~0xFFFull;
         u64 end_masked = (end_rip - 1) & ~0xFFFull;
         for (u64 page = start_masked; page <= end_masked; page += 0x1000) {
-            page_map[page].blocks.push_back(&block_meta);
+            page_map[page].push_back(&block_meta);
         }
     }
 
@@ -554,31 +554,8 @@ void Recompiler::markPagesAsReadOnly(u64 start, u64 end) {
         return;
     }
 
-    u64 first_page = start & ~0xFFFull;
-    u64 last_page = (end - 1) & ~0xFFFull;
-
-    u64 start_page = UINT64_MAX;
-    u64 end_page = 0;
-    {
-        auto guard = page_map_lock.lock();
-        for (u64 page = first_page; page <= last_page; page += 0x1000) {
-            PageMetadata& page_meta = page_map[page];
-            if (page_meta.read_only) {
-                continue;
-            }
-
-            page_meta.read_only = true;
-            if (start_page == UINT64_MAX) {
-                start_page = page;
-            }
-            end_page = page + 0x1000;
-        }
-    }
-
-    if (start_page == UINT64_MAX) {
-        return;
-    }
-
+    u64 start_page = start & ~0xFFFull;
+    u64 end_page = (end + 0xFFF) & ~0xFFFull;
     u64 size = end_page - start_page;
     int result = mprotect((void*)start_page, size, PROT_READ);
     if (result != 0) {
@@ -2881,10 +2858,6 @@ void Recompiler::expirePendingLinks(u64 rip) {
     u64 min = -1ull;
     u64 max = 0;
     auto& links = getBlockMetadata(rip).pending_links;
-    if (links.empty()) {
-        return;
-    }
-
     for (u8* link : links) {
         u8* cursor = as.GetCursorPointer();
         as.SetCursorPointer(link);
@@ -3543,13 +3516,12 @@ int Recompiler::invalidateRange(u64 start, u64 end) {
 
     int blocks = 0;
     for (auto it = lower; it != upper; it++) {
-        auto& page_meta = it->second;
-        for (BlockMetadata* block : page_meta.blocks) {
+        auto& blocks_in_page = it->second;
+        for (BlockMetadata* block : blocks_in_page) {
             invalidateBlock(block);
             blocks++;
         }
-        page_meta.blocks.clear();
-        page_meta.read_only = false;
+        blocks_in_page.clear();
     }
     return blocks;
 }

--- a/src/felix86/v2/recompiler.hpp
+++ b/src/felix86/v2/recompiler.hpp
@@ -75,11 +75,6 @@ struct BlockMetadata {
     std::vector<u8*> pending_links{};
 };
 
-struct PageMetadata {
-    std::vector<BlockMetadata*> blocks{};
-    bool read_only{};
-};
-
 // WARN: don't allocate this struct on the stack as it's quite big due to address_cache and can lead to stack overflow
 struct Recompiler {
     // Relocatable means only emit position independent code
@@ -872,7 +867,7 @@ private:
     std::unordered_map<u64, BlockMetadata> block_metadata{};
 
     Semaphore page_map_lock;
-    std::map<u64, PageMetadata> page_map{};
+    std::map<u64, std::vector<BlockMetadata*>> page_map{};
 
     // For fast host pc -> block metadata lookup (binary search vs looking up one by one)
     // on signal handlers


### PR DESCRIPTION
This reverts commit https://github.com/OFFTKP/felix86/commit/9757a16bfe38614f3618a2d3c45f750eeb3c6aaa.

There was a big oversight in this logic, the page protections are
vm global while we keep a thread local array of them which would
cause all sorts of rare issues in JIT apps. 