### PR TITLE
Recompiler: Longjmp if scan ahead faults

### DIFF
--- a/src/felix86/common/state.hpp
+++ b/src/felix86/common/state.hpp
@@ -379,6 +379,7 @@ struct ThreadState {
     bool force_defer_synchronous = false;
     sigjmp_buf force_defer_buffer{};
     bool in_scan_ahead = false;
+    u64 scan_ahead_address = 0;
     sigjmp_buf scan_ahead_buffer{};
 
     // For storing generated risc-v or x86 code that needs to outlive code cache clears

--- a/src/felix86/common/state.hpp
+++ b/src/felix86/common/state.hpp
@@ -378,6 +378,8 @@ struct ThreadState {
 
     bool force_defer_synchronous = false;
     sigjmp_buf force_defer_buffer{};
+    bool in_scan_ahead = false;
+    sigjmp_buf scan_ahead_buffer{};
 
     // For storing generated risc-v or x86 code that needs to outlive code cache clears
     u8* riscv_trampoline_storage_start = nullptr;

--- a/src/felix86/hle/signals.cpp
+++ b/src/felix86/hle/signals.cpp
@@ -1303,7 +1303,7 @@ static bool handle_scan_ahead_fault(ThreadState* current_state, siginfo_t* info,
     }
 
     u64 fault_addr = (u64)info->si_addr;
-    if (fault_addr < current_state->scan_ahead_address || fault_addr > current_state->scan_ahead_address + ZYDIS_MAX_INSTRUCTION_LENGTH) {
+    if (fault_addr < current_state->scan_ahead_address || fault_addr >= current_state->scan_ahead_address + ZYDIS_MAX_INSTRUCTION_LENGTH) {
         // Unrelated fault?
         return false;
     }

--- a/src/felix86/hle/signals.cpp
+++ b/src/felix86/hle/signals.cpp
@@ -1297,14 +1297,13 @@ static bool handle_scan_ahead_fault(ThreadState* current_state, siginfo_t* info,
         return false;
     }
 
-    if (info->si_code < 0) {
+    if (info->si_code <= 0) {
         // Asynchronous sigsegv?
         return false;
     }
 
     u64 fault_addr = (u64)info->si_addr;
-    if (fault_addr < current_state->scan_ahead_address ||
-        fault_addr > current_state->scan_ahead_address + ZYDIS_MAX_INSTRUCTION_LENGTH * scan_ahead_count) {
+    if (fault_addr < current_state->scan_ahead_address || fault_addr > current_state->scan_ahead_address + ZYDIS_MAX_INSTRUCTION_LENGTH) {
         // Unrelated fault?
         return false;
     }

--- a/src/felix86/hle/signals.cpp
+++ b/src/felix86/hle/signals.cpp
@@ -1292,6 +1292,18 @@ static void defer_signal(ThreadState* state, int sig, siginfo_t* info, void* ctx
     state->effective_deferred_signals = effective_deferred_signals;
     SIGLOG("Deferring signal %s (%d) during RIP=%lx", sigdescr_np(sig), sig, state->GetRip());
 }
+static bool handle_scan_ahead_fault(ThreadState* current_state, siginfo_t* info, ucontext_t* context, u64 pc) {
+    if (!current_state->in_scan_ahead) {
+        return false;
+    }
+
+    // If a SIGSEGV happens during scan ahead, that means the address we are scanning is not valid. While there
+    // are other ways of checking (e.g. via /proc/self/maps or our mapper) they are slower than just assuming
+    // we won't segfault and long jumping out in the extraordinarily rare chance it happens
+    IMPORTANT("Scan ahead faulted at RIP=%lx with target=%lx", current_state->ctx.rip, (u64)info->si_addr);
+    siglongjmp(current_state->scan_ahead_buffer, SIGSEGV);
+    UNREACHABLE();
+}
 
 static bool handle_safepoint(ThreadState* current_state, siginfo_t* info, ucontext_t* context, u64 pc) {
     // First we need to check if we are a safepoint
@@ -1690,7 +1702,8 @@ static bool handle_sigptrace(ThreadState* current_state, siginfo_t* info, uconte
     }
 }
 
-constexpr static std::array<RegisteredHostSignal, 7> host_signals = {{
+constexpr static std::array<RegisteredHostSignal, 8> host_signals = {{
+    {SIGSEGV, 0, handle_scan_ahead_fault},
     {SIGSEGV, SEGV_ACCERR, handle_safepoint},
     {SIGSEGV, SEGV_ACCERR, handle_smc},
     {SIGSEGV, SEGV_MAPERR, handle_synchronous},

--- a/src/felix86/hle/signals.cpp
+++ b/src/felix86/hle/signals.cpp
@@ -1297,10 +1297,22 @@ static bool handle_scan_ahead_fault(ThreadState* current_state, siginfo_t* info,
         return false;
     }
 
+    if (info->si_code < 0) {
+        // Asynchronous sigsegv?
+        return false;
+    }
+
+    u64 fault_addr = (u64)info->si_addr;
+    if (fault_addr < current_state->scan_ahead_address ||
+        fault_addr > current_state->scan_ahead_address + ZYDIS_MAX_INSTRUCTION_LENGTH * scan_ahead_count) {
+        // Unrelated fault?
+        return false;
+    }
+
     // If a SIGSEGV happens during scan ahead, that means the address we are scanning is not valid. While there
     // are other ways of checking (e.g. via /proc/self/maps or our mapper) they are slower than just assuming
     // we won't segfault and long jumping out in the extraordinarily rare chance it happens
-    IMPORTANT("Scan ahead faulted at RIP=%lx with target=%lx", current_state->ctx.rip, (u64)info->si_addr);
+    IMPORTANT("Scan ahead faulted at RIP=%lx with target=%lx", current_state->ctx.rip, fault_addr);
     siglongjmp(current_state->scan_ahead_buffer, SIGSEGV);
     UNREACHABLE();
 }

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -2321,120 +2321,136 @@ void Recompiler::scanAhead(u64 rip) {
 
         if (is_jump || is_ret || is_call || is_illegal || is_hlt || is_int3) {
             if (g_config.scan_ahead_multi && !g_config.paranoid) {
-                // We need to see where the jump will land, and scan some of its instructions
-                // If all the landing places overwrite the flags (1 landing spot for jmp, 2 for jcc)
-                // then we can skip those flag calculations
-                if (is_jump && operands[0].type == ZYDIS_OPERAND_TYPE_IMMEDIATE) {
-                    auto scan_landing_block = [&](u64 rip_ahead) {
-                        bool jump_to_self = rip_ahead == initial_rip;
-                        ZydisDecodedInstruction instruction_ahead;
-                        ZydisDecodedOperand operands_ahead_storage[10];
-                        ZydisDecodedOperand* operands_ahead = operands_ahead_storage;
-                        u32 changed_this_block = 0;
-                        u32 used_this_block = 0;
-                        u32 flags_we_care_about = ALL_CPUFLAGS;
-                        // 64 is heuristically picked, some games have a big slide of SSE instructions that follow a cmp/jcc
-                        // and usually this big of a number is good enough
-                        // If we go too high we risk messing our performance
-                        // TODO: some benchmarking may be in order
-                        for (size_t i = 0; i < 64; i++) {
-                            ZydisMnemonic mnemonic;
-                            if (jump_to_self) {
-                                // Jump to self, we already decoded the instructions
-                                ASSERT(i < instructions.size());
-                                instruction_ahead = instructions[i].first;
-                                operands_ahead = instructions[i].second;
-                                mnemonic = instruction_ahead.mnemonic;
-                            } else {
-                                mnemonic = decode(rip_ahead, instruction_ahead, operands_ahead, true);
-                                if (mnemonic == ZYDIS_MNEMONIC_INVALID) {
-                                    // If this path is hit the instructions will be invalid
-                                    // One may assume this means that we can assume flags won't be used in this path
-                                    // But in reality it could be the case this path gets self-modified to use the flags
-                                    // Since this scenario that one path contains invalid instructions is very rare, we just emit
-                                    // all the flags to be safe
-                                    return 0u;
+                // In some cases, the program may deliberately jump to a bad location
+                // This was seen in a Ubisoft installer, for example. Now, we could use Mapper::is_guest_address,
+                // but these cases are so exceptionally rare that it is not worth the locked semaphore
+                // So instead, set a jump buffer so that if our scan ahead faults we skip it.
+                ThreadState* state = ThreadState::Get();
+                int ret = sigsetjmp(state->scan_ahead_buffer, 1);
+                if (ret == 0) {
+                    // We need to see where the jump will land, and scan some of its instructions
+                    // If all the landing places overwrite the flags (1 landing spot for jmp, 2 for jcc)
+                    // then we can skip those flag calculations
+                    if (is_jump && operands[0].type == ZYDIS_OPERAND_TYPE_IMMEDIATE) {
+                        auto scan_landing_block = [&](u64 rip_ahead) {
+                            bool jump_to_self = rip_ahead == initial_rip;
+                            ZydisDecodedInstruction instruction_ahead;
+                            ZydisDecodedOperand operands_ahead_storage[10];
+                            ZydisDecodedOperand* operands_ahead = operands_ahead_storage;
+                            u32 changed_this_block = 0;
+                            u32 used_this_block = 0;
+                            u32 flags_we_care_about = ALL_CPUFLAGS;
+                            // 64 is heuristically picked, some games have a big slide of SSE instructions that follow a cmp/jcc
+                            // and usually this big of a number is good enough
+                            // If we go too high we risk messing our performance
+                            // TODO: some benchmarking may be in order
+                            for (size_t i = 0; i < 64; i++) {
+                                ZydisMnemonic mnemonic;
+                                if (jump_to_self) {
+                                    // Jump to self, we already decoded the instructions
+                                    ASSERT(i < instructions.size());
+                                    instruction_ahead = instructions[i].first;
+                                    operands_ahead = instructions[i].second;
+                                    mnemonic = instruction_ahead.mnemonic;
+                                } else {
+                                    mnemonic = decode(rip_ahead, instruction_ahead, operands_ahead, true);
+                                    if (mnemonic == ZYDIS_MNEMONIC_INVALID) {
+                                        // If this path is hit the instructions will be invalid
+                                        // One may assume this means that we can assume flags won't be used in this path
+                                        // But in reality it could be the case this path gets self-modified to use the flags
+                                        // Since this scenario that one path contains invalid instructions is very rare, we just emit
+                                        // all the flags to be safe
+                                        return 0u;
+                                    }
                                 }
-                            }
-                            bool is_jump = instruction_ahead.meta.branch_type != ZYDIS_BRANCH_TYPE_NONE;
-                            bool is_ret = mnemonic == ZYDIS_MNEMONIC_RET || mnemonic == ZYDIS_MNEMONIC_IRETD || mnemonic == ZYDIS_MNEMONIC_IRETQ;
-                            bool is_call = mnemonic == ZYDIS_MNEMONIC_CALL;
-                            bool is_illegal = mnemonic == ZYDIS_MNEMONIC_UD2 || mnemonic == ZYDIS_MNEMONIC_OUTSB ||
-                                              mnemonic == ZYDIS_MNEMONIC_OUTSW || mnemonic == ZYDIS_MNEMONIC_OUTSD ||
-                                              mnemonic == ZYDIS_MNEMONIC_INSB || mnemonic == ZYDIS_MNEMONIC_INSW || mnemonic == ZYDIS_MNEMONIC_INSD;
-                            bool is_hlt = mnemonic == ZYDIS_MNEMONIC_HLT;
-                            bool is_int3 = mnemonic == ZYDIS_MNEMONIC_INT3;
+                                bool is_jump = instruction_ahead.meta.branch_type != ZYDIS_BRANCH_TYPE_NONE;
+                                bool is_ret = mnemonic == ZYDIS_MNEMONIC_RET || mnemonic == ZYDIS_MNEMONIC_IRETD || mnemonic == ZYDIS_MNEMONIC_IRETQ;
+                                bool is_call = mnemonic == ZYDIS_MNEMONIC_CALL;
+                                bool is_illegal = mnemonic == ZYDIS_MNEMONIC_UD2 || mnemonic == ZYDIS_MNEMONIC_OUTSB ||
+                                                  mnemonic == ZYDIS_MNEMONIC_OUTSW || mnemonic == ZYDIS_MNEMONIC_OUTSD ||
+                                                  mnemonic == ZYDIS_MNEMONIC_INSB || mnemonic == ZYDIS_MNEMONIC_INSW ||
+                                                  mnemonic == ZYDIS_MNEMONIC_INSD;
+                                bool is_hlt = mnemonic == ZYDIS_MNEMONIC_HLT;
+                                bool is_int3 = mnemonic == ZYDIS_MNEMONIC_INT3;
 
-                            u32 changed = instruction_ahead.cpu_flags->modified | instruction_ahead.cpu_flags->set_0 |
-                                          instruction_ahead.cpu_flags->set_1 | instruction_ahead.cpu_flags->undefined;
-                            u32 used = instruction_ahead.cpu_flags->tested;
-                            if (flag_passthrough(instruction_ahead)) {
-                                // Act as if this instruction didn't change any flags, since it may not if shift == 0
-                                changed = 0;
-                            }
-
-                            u32 used_not_previously_changed = used & ~changed_this_block;
-                            used_this_block |= used_not_previously_changed;
-                            changed_this_block |= changed;
-
-                            u32 changed_and_not_used = changed_this_block & ~used_this_block;
-                            if (changed_and_not_used == flags_we_care_about) {
-                                // All flags changed already, break early
-                                break;
-                            }
-
-                            if (is_call || is_ret) {
-                                if (g_config.unsafe_flags && !g_config.paranoid) {
-                                    // Pretend call and ret overwrites all flags
-                                    changed_this_block = ALL_CPUFLAGS;
+                                u32 changed = instruction_ahead.cpu_flags->modified | instruction_ahead.cpu_flags->set_0 |
+                                              instruction_ahead.cpu_flags->set_1 | instruction_ahead.cpu_flags->undefined;
+                                u32 used = instruction_ahead.cpu_flags->tested;
+                                if (flag_passthrough(instruction_ahead)) {
+                                    // Act as if this instruction didn't change any flags, since it may not if shift == 0
+                                    changed = 0;
                                 }
 
-                                break;
-                            }
+                                u32 used_not_previously_changed = used & ~changed_this_block;
+                                used_this_block |= used_not_previously_changed;
+                                changed_this_block |= changed;
 
-                            if (is_jump || is_illegal || is_hlt || is_int3) {
-                                // Check if we can follow the jump trivially
-                                if (is_jump && mnemonic == ZYDIS_MNEMONIC_JMP && operands_ahead[0].type == ZYDIS_OPERAND_TYPE_IMMEDIATE) {
-                                    u64 displacement = sextImmediate(getImmediate(&operands_ahead[0]), operands_ahead[0].imm.size);
-                                    rip_ahead += instruction_ahead.length + displacement;
-                                    jump_to_self = false; // stop using our cached instructions
-                                    continue;
+                                u32 changed_and_not_used = changed_this_block & ~used_this_block;
+                                if (changed_and_not_used == flags_we_care_about) {
+                                    // All flags changed already, break early
+                                    break;
                                 }
 
-                                // Block ahead ended in <= 10 instructions so let's break
-                                break;
+                                if (is_call || is_ret) {
+                                    if (g_config.unsafe_flags && !g_config.paranoid) {
+                                        // Pretend call and ret overwrites all flags
+                                        changed_this_block = ALL_CPUFLAGS;
+                                    }
+
+                                    break;
+                                }
+
+                                if (is_jump || is_illegal || is_hlt || is_int3) {
+                                    // Check if we can follow the jump trivially
+                                    if (is_jump && mnemonic == ZYDIS_MNEMONIC_JMP && operands_ahead[0].type == ZYDIS_OPERAND_TYPE_IMMEDIATE) {
+                                        u64 displacement = sextImmediate(getImmediate(&operands_ahead[0]), operands_ahead[0].imm.size);
+                                        rip_ahead += instruction_ahead.length + displacement;
+                                        jump_to_self = false; // stop using our cached instructions
+                                        continue;
+                                    }
+
+                                    // Block ahead ended in <= 10 instructions so let's break
+                                    break;
+                                }
+
+                                rip_ahead += instruction_ahead.length;
                             }
 
-                            rip_ahead += instruction_ahead.length;
+                            // Now every flag in the changed_this_block set but not in the used_this_block set
+                            // doesn't have to be calculated, return this
+                            return changed_this_block & ~used_this_block;
+                        };
+
+                        u32 thrashed_ahead;
+                        if (mnemonic == ZYDIS_MNEMONIC_JMP) {
+                            u64 immediate = sextImmediate(getImmediate(&operands[0]), operands[0].imm.size);
+                            u64 rip_ahead = rip + instruction.length + immediate;
+                            state->in_scan_ahead = true;
+                            thrashed_ahead = scan_landing_block(rip_ahead);
+                            state->in_scan_ahead = false;
+                        } else if (instruction.mnemonic >= ZYDIS_MNEMONIC_JB && instruction.mnemonic <= ZYDIS_MNEMONIC_JZ) {
+                            ASSERT(instruction.mnemonic != ZYDIS_MNEMONIC_JKZD);
+                            ASSERT(instruction.mnemonic != ZYDIS_MNEMONIC_JKNZD);
+                            u64 immediate = sextImmediate(getImmediate(&operands[0]), operands[0].imm.size);
+                            u64 rip_ahead_false = rip + instruction.length;
+                            u64 rip_ahead_true = rip_ahead_false + immediate;
+                            // For the flags to not be calculated they need to be overwritten in both paths
+                            state->in_scan_ahead = true;
+                            thrashed_ahead = scan_landing_block(rip_ahead_false) & scan_landing_block(rip_ahead_true);
+                            state->in_scan_ahead = false;
+                        } else {
+                            break;
                         }
 
-                        // Now every flag in the changed_this_block set but not in the used_this_block set
-                        // doesn't have to be calculated, return this
-                        return changed_this_block & ~used_this_block;
-                    };
-
-                    u32 thrashed_ahead;
-                    if (mnemonic == ZYDIS_MNEMONIC_JMP) {
-                        u64 immediate = sextImmediate(getImmediate(&operands[0]), operands[0].imm.size);
-                        u64 rip_ahead = rip + instruction.length + immediate;
-                        thrashed_ahead = scan_landing_block(rip_ahead);
-                    } else if (instruction.mnemonic >= ZYDIS_MNEMONIC_JB && instruction.mnemonic <= ZYDIS_MNEMONIC_JZ) {
-                        ASSERT(instruction.mnemonic != ZYDIS_MNEMONIC_JKZD);
-                        ASSERT(instruction.mnemonic != ZYDIS_MNEMONIC_JKNZD);
-                        u64 immediate = sextImmediate(getImmediate(&operands[0]), operands[0].imm.size);
-                        u64 rip_ahead_false = rip + instruction.length;
-                        u64 rip_ahead_true = rip_ahead_false + immediate;
-                        // For the flags to not be calculated they need to be overwritten in both paths
-                        thrashed_ahead = scan_landing_block(rip_ahead_false) & scan_landing_block(rip_ahead_true);
-                    } else {
-                        break;
+                        // Now for each flag that is thrashed ahead add a flag overwrite access to
+                        // trick the instruction handlers into not emitting this flag
+                        // If the JCC actually uses the flag, that's fine because the flag access will be after the usage
+                        // so the instruction handler will emit that flag
+                        scan_entries.push_back({.rip = rip, .flags_used = 0, .flags_changed = (thrashed_ahead & ALL_CPUFLAGS)});
                     }
-
-                    // Now for each flag that is thrashed ahead add a flag overwrite access to
-                    // trick the instruction handlers into not emitting this flag
-                    // If the JCC actually uses the flag, that's fine because the flag access will be after the usage
-                    // so the instruction handler will emit that flag
-                    scan_entries.push_back({.rip = rip, .flags_used = 0, .flags_changed = (thrashed_ahead & ALL_CPUFLAGS)});
+                } else {
+                    // The scan ahead faulted
+                    state->in_scan_ahead = false;
                 }
             }
 

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -2320,144 +2320,143 @@ void Recompiler::scanAhead(u64 rip) {
         }
 
         if (is_jump || is_ret || is_call || is_illegal || is_hlt || is_int3) {
-            if (g_config.scan_ahead_multi && !g_config.paranoid && !is_ret && !is_call && !is_illegal && !is_hlt && !is_int3) {
+            if (g_config.scan_ahead_multi && !g_config.paranoid && !is_ret && !is_call && !is_illegal && !is_hlt && !is_int3 &&
+                operands[0].type == ZYDIS_OPERAND_TYPE_IMMEDIATE) {
                 // In some cases, the program may deliberately jump to a bad location
                 // This was seen in a Ubisoft installer, for example. Now, we could use Mapper::is_guest_address,
                 // but these cases are so exceptionally rare that it is not worth the locked semaphore
                 // So instead, set a jump buffer so that if our scan ahead faults we skip it.
                 ThreadState* state = ThreadState::Get();
-                int ret = sigsetjmp(state->scan_ahead_buffer, 1);
+                int ret = sigsetjmp(state->scan_ahead_buffer, 0);
                 if (ret == 0) {
                     // We need to see where the jump will land, and scan some of its instructions
                     // If all the landing places overwrite the flags (1 landing spot for jmp, 2 for jcc)
                     // then we can skip those flag calculations
-                    if (is_jump && operands[0].type == ZYDIS_OPERAND_TYPE_IMMEDIATE) {
-                        auto scan_landing_block = [&](u64 rip_ahead) {
-                            bool jump_to_self = rip_ahead == initial_rip;
-                            ZydisDecodedInstruction instruction_ahead;
-                            ZydisDecodedOperand operands_ahead_storage[10];
-                            ZydisDecodedOperand* operands_ahead = operands_ahead_storage;
-                            u32 changed_this_block = 0;
-                            u32 used_this_block = 0;
-                            u32 flags_we_care_about = ALL_CPUFLAGS;
-                            // 64 is heuristically picked, some games have a big slide of SSE instructions that follow a cmp/jcc
-                            // and usually this big of a number is good enough
-                            // If we go too high we risk messing our performance
-                            // TODO: some benchmarking may be in order
-                            for (size_t i = 0; i < scan_ahead_count; i++) {
-                                ZydisMnemonic mnemonic;
-                                if (jump_to_self) {
-                                    // Jump to self, we already decoded the instructions
-                                    ASSERT(i < instructions.size());
-                                    instruction_ahead = instructions[i].first;
-                                    operands_ahead = instructions[i].second;
-                                    mnemonic = instruction_ahead.mnemonic;
-                                } else {
-                                    mnemonic = decode(rip_ahead, instruction_ahead, operands_ahead, true);
-                                    if (mnemonic == ZYDIS_MNEMONIC_INVALID) {
-                                        // If this path is hit the instructions will be invalid
-                                        // One may assume this means that we can assume flags won't be used in this path
-                                        // But in reality it could be the case this path gets self-modified to use the flags
-                                        // Since this scenario that one path contains invalid instructions is very rare, we just emit
-                                        // all the flags to be safe
-                                        return 0u;
-                                    }
+                    auto scan_landing_block = [&](u64 rip_ahead) {
+                        bool jump_to_self = rip_ahead == initial_rip;
+                        ZydisDecodedInstruction instruction_ahead;
+                        ZydisDecodedOperand operands_ahead_storage[10];
+                        ZydisDecodedOperand* operands_ahead = operands_ahead_storage;
+                        u32 changed_this_block = 0;
+                        u32 used_this_block = 0;
+                        u32 flags_we_care_about = ALL_CPUFLAGS;
+                        // 64 is heuristically picked, some games have a big slide of SSE instructions that follow a cmp/jcc
+                        // and usually this big of a number is good enough
+                        // If we go too high we risk messing our performance
+                        // TODO: some benchmarking may be in order
+                        for (size_t i = 0; i < scan_ahead_count; i++) {
+                            ZydisMnemonic mnemonic;
+                            state->scan_ahead_address = rip_ahead;
+                            if (jump_to_self) {
+                                // Jump to self, we already decoded the instructions
+                                ASSERT(i < instructions.size());
+                                instruction_ahead = instructions[i].first;
+                                operands_ahead = instructions[i].second;
+                                mnemonic = instruction_ahead.mnemonic;
+                            } else {
+                                mnemonic = decode(rip_ahead, instruction_ahead, operands_ahead, true);
+                                if (mnemonic == ZYDIS_MNEMONIC_INVALID) {
+                                    // If this path is hit the instructions will be invalid
+                                    // One may assume this means that we can assume flags won't be used in this path
+                                    // But in reality it could be the case this path gets self-modified to use the flags
+                                    // Since this scenario that one path contains invalid instructions is very rare, we just emit
+                                    // all the flags to be safe
+                                    return 0u;
                                 }
-                                bool is_jump = instruction_ahead.meta.branch_type != ZYDIS_BRANCH_TYPE_NONE;
-                                bool is_ret = mnemonic == ZYDIS_MNEMONIC_RET || mnemonic == ZYDIS_MNEMONIC_IRETD || mnemonic == ZYDIS_MNEMONIC_IRETQ;
-                                bool is_call = mnemonic == ZYDIS_MNEMONIC_CALL;
-                                bool is_illegal = mnemonic == ZYDIS_MNEMONIC_UD2 || mnemonic == ZYDIS_MNEMONIC_OUTSB ||
-                                                  mnemonic == ZYDIS_MNEMONIC_OUTSW || mnemonic == ZYDIS_MNEMONIC_OUTSD ||
-                                                  mnemonic == ZYDIS_MNEMONIC_INSB || mnemonic == ZYDIS_MNEMONIC_INSW ||
-                                                  mnemonic == ZYDIS_MNEMONIC_INSD;
-                                bool is_hlt = mnemonic == ZYDIS_MNEMONIC_HLT;
-                                bool is_int3 = mnemonic == ZYDIS_MNEMONIC_INT3;
+                            }
+                            bool is_jump = instruction_ahead.meta.branch_type != ZYDIS_BRANCH_TYPE_NONE;
+                            bool is_ret = mnemonic == ZYDIS_MNEMONIC_RET || mnemonic == ZYDIS_MNEMONIC_IRETD || mnemonic == ZYDIS_MNEMONIC_IRETQ;
+                            bool is_call = mnemonic == ZYDIS_MNEMONIC_CALL;
+                            bool is_illegal = mnemonic == ZYDIS_MNEMONIC_UD2 || mnemonic == ZYDIS_MNEMONIC_OUTSB ||
+                                              mnemonic == ZYDIS_MNEMONIC_OUTSW || mnemonic == ZYDIS_MNEMONIC_OUTSD ||
+                                              mnemonic == ZYDIS_MNEMONIC_INSB || mnemonic == ZYDIS_MNEMONIC_INSW || mnemonic == ZYDIS_MNEMONIC_INSD;
+                            bool is_hlt = mnemonic == ZYDIS_MNEMONIC_HLT;
+                            bool is_int3 = mnemonic == ZYDIS_MNEMONIC_INT3;
 
-                                u32 changed = instruction_ahead.cpu_flags->modified | instruction_ahead.cpu_flags->set_0 |
-                                              instruction_ahead.cpu_flags->set_1 | instruction_ahead.cpu_flags->undefined;
-                                u32 used = instruction_ahead.cpu_flags->tested;
-                                if (flag_passthrough(instruction_ahead)) {
-                                    // Act as if this instruction didn't change any flags, since it may not if shift == 0
-                                    changed = 0;
-                                }
-
-                                u32 used_not_previously_changed = used & ~changed_this_block;
-                                used_this_block |= used_not_previously_changed;
-                                changed_this_block |= changed;
-
-                                u32 changed_and_not_used = changed_this_block & ~used_this_block;
-                                if (changed_and_not_used == flags_we_care_about) {
-                                    // All flags changed already, break early
-                                    break;
-                                }
-
-                                if (is_call || is_ret) {
-                                    if (g_config.unsafe_flags && !g_config.paranoid) {
-                                        // Pretend call and ret overwrites all flags
-                                        changed_this_block = ALL_CPUFLAGS;
-                                    }
-
-                                    break;
-                                }
-
-                                if (is_jump || is_illegal || is_hlt || is_int3) {
-                                    // Check if we can follow the jump trivially
-                                    if (is_jump && mnemonic == ZYDIS_MNEMONIC_JMP && operands_ahead[0].type == ZYDIS_OPERAND_TYPE_IMMEDIATE) {
-                                        u64 displacement = sextImmediate(getImmediate(&operands_ahead[0]), operands_ahead[0].imm.size);
-                                        rip_ahead += instruction_ahead.length + displacement;
-                                        jump_to_self = false; // stop using our cached instructions
-                                        continue;
-                                    }
-
-                                    // Block ahead ended in <= 10 instructions so let's break
-                                    break;
-                                }
-
-                                rip_ahead += instruction_ahead.length;
+                            u32 changed = instruction_ahead.cpu_flags->modified | instruction_ahead.cpu_flags->set_0 |
+                                          instruction_ahead.cpu_flags->set_1 | instruction_ahead.cpu_flags->undefined;
+                            u32 used = instruction_ahead.cpu_flags->tested;
+                            if (flag_passthrough(instruction_ahead)) {
+                                // Act as if this instruction didn't change any flags, since it may not if shift == 0
+                                changed = 0;
                             }
 
-                            // Now every flag in the changed_this_block set but not in the used_this_block set
-                            // doesn't have to be calculated, return this
-                            return changed_this_block & ~used_this_block;
-                        };
+                            u32 used_not_previously_changed = used & ~changed_this_block;
+                            used_this_block |= used_not_previously_changed;
+                            changed_this_block |= changed;
 
-                        u32 thrashed_ahead;
-                        if (mnemonic == ZYDIS_MNEMONIC_JMP) {
-                            u64 immediate = sextImmediate(getImmediate(&operands[0]), operands[0].imm.size);
-                            u64 rip_ahead = rip + instruction.length + immediate;
-                            state->in_scan_ahead = true;
-                            state->scan_ahead_address = rip_ahead;
-                            thrashed_ahead = scan_landing_block(rip_ahead);
-                            state->scan_ahead_address = 0;
-                            state->in_scan_ahead = false;
-                        } else if (instruction.mnemonic >= ZYDIS_MNEMONIC_JB && instruction.mnemonic <= ZYDIS_MNEMONIC_JZ) {
-                            ASSERT(instruction.mnemonic != ZYDIS_MNEMONIC_JKZD);
-                            ASSERT(instruction.mnemonic != ZYDIS_MNEMONIC_JKNZD);
-                            u64 immediate = sextImmediate(getImmediate(&operands[0]), operands[0].imm.size);
-                            u64 rip_ahead_false = rip + instruction.length;
-                            u64 rip_ahead_true = rip_ahead_false + immediate;
-                            // For the flags to not be calculated they need to be overwritten in both paths
-                            state->in_scan_ahead = true;
-                            state->scan_ahead_address = rip_ahead_false;
-                            u32 false_flags = scan_landing_block(rip_ahead_false);
-                            state->scan_ahead_address = rip_ahead_true;
-                            u32 true_flags = scan_landing_block(rip_ahead_true);
-                            state->scan_ahead_address = 0;
-                            state->in_scan_ahead = false;
-                            thrashed_ahead = false_flags & true_flags;
-                        } else {
-                            break;
+                            u32 changed_and_not_used = changed_this_block & ~used_this_block;
+                            if (changed_and_not_used == flags_we_care_about) {
+                                // All flags changed already, break early
+                                break;
+                            }
+
+                            if (is_call || is_ret) {
+                                if (g_config.unsafe_flags && !g_config.paranoid) {
+                                    // Pretend call and ret overwrites all flags
+                                    changed_this_block = ALL_CPUFLAGS;
+                                }
+
+                                break;
+                            }
+
+                            if (is_jump || is_illegal || is_hlt || is_int3) {
+                                // Check if we can follow the jump trivially
+                                if (is_jump && mnemonic == ZYDIS_MNEMONIC_JMP && operands_ahead[0].type == ZYDIS_OPERAND_TYPE_IMMEDIATE) {
+                                    u64 displacement = sextImmediate(getImmediate(&operands_ahead[0]), operands_ahead[0].imm.size);
+                                    rip_ahead += instruction_ahead.length + displacement;
+                                    jump_to_self = false; // stop using our cached instructions
+                                    continue;
+                                }
+
+                                // Block ahead ended in <= 10 instructions so let's break
+                                break;
+                            }
+
+                            rip_ahead += instruction_ahead.length;
                         }
 
-                        // Now for each flag that is thrashed ahead add a flag overwrite access to
-                        // trick the instruction handlers into not emitting this flag
-                        // If the JCC actually uses the flag, that's fine because the flag access will be after the usage
-                        // so the instruction handler will emit that flag
-                        scan_entries.push_back({.rip = rip, .flags_used = 0, .flags_changed = (thrashed_ahead & ALL_CPUFLAGS)});
+                        // Now every flag in the changed_this_block set but not in the used_this_block set
+                        // doesn't have to be calculated, return this
+                        return changed_this_block & ~used_this_block;
+                    };
+
+                    u32 thrashed_ahead;
+                    if (mnemonic == ZYDIS_MNEMONIC_JMP) {
+                        u64 immediate = sextImmediate(getImmediate(&operands[0]), operands[0].imm.size);
+                        u64 rip_ahead = rip + instruction.length + immediate;
+                        state->in_scan_ahead = true;
+                        thrashed_ahead = scan_landing_block(rip_ahead);
+                        state->scan_ahead_address = 0;
+                        state->in_scan_ahead = false;
+                    } else if (instruction.mnemonic >= ZYDIS_MNEMONIC_JB && instruction.mnemonic <= ZYDIS_MNEMONIC_JZ) {
+                        ASSERT(instruction.mnemonic != ZYDIS_MNEMONIC_JKZD);
+                        ASSERT(instruction.mnemonic != ZYDIS_MNEMONIC_JKNZD);
+                        u64 immediate = sextImmediate(getImmediate(&operands[0]), operands[0].imm.size);
+                        u64 rip_ahead_false = rip + instruction.length;
+                        u64 rip_ahead_true = rip_ahead_false + immediate;
+                        // For the flags to not be calculated they need to be overwritten in both paths
+                        state->in_scan_ahead = true;
+                        thrashed_ahead = scan_landing_block(rip_ahead_false) & scan_landing_block(rip_ahead_true);
+                        state->scan_ahead_address = 0;
+                        state->in_scan_ahead = false;
+                    } else {
+                        break;
                     }
+
+                    // Now for each flag that is thrashed ahead add a flag overwrite access to
+                    // trick the instruction handlers into not emitting this flag
+                    // If the JCC actually uses the flag, that's fine because the flag access will be after the usage
+                    // so the instruction handler will emit that flag
+                    scan_entries.push_back({.rip = rip, .flags_used = 0, .flags_changed = (thrashed_ahead & ALL_CPUFLAGS)});
                 } else {
                     // The scan ahead faulted
                     state->in_scan_ahead = false;
+                    state->scan_ahead_address = 0;
+                    u64 sigsegv = 1 << (SIGSEGV - 1);
+                    // We don't save signal mask in sigsetjmp as it would cost a syscall per block, we just
+                    // unblock the SIGSEGV signal that the signal handler blocked on fault
+                    ASSERT(syscall(SYS_rt_sigprocmask, SIG_UNBLOCK, &sigsegv, nullptr, sizeof(u64)) == 0);
                 }
             }
 

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -2320,7 +2320,7 @@ void Recompiler::scanAhead(u64 rip) {
         }
 
         if (is_jump || is_ret || is_call || is_illegal || is_hlt || is_int3) {
-            if (g_config.scan_ahead_multi && !g_config.paranoid) {
+            if (g_config.scan_ahead_multi && !g_config.paranoid && !is_ret && !is_call && !is_illegal && !is_hlt && !is_int3) {
                 // In some cases, the program may deliberately jump to a bad location
                 // This was seen in a Ubisoft installer, for example. Now, we could use Mapper::is_guest_address,
                 // but these cases are so exceptionally rare that it is not worth the locked semaphore
@@ -2344,7 +2344,7 @@ void Recompiler::scanAhead(u64 rip) {
                             // and usually this big of a number is good enough
                             // If we go too high we risk messing our performance
                             // TODO: some benchmarking may be in order
-                            for (size_t i = 0; i < 64; i++) {
+                            for (size_t i = 0; i < scan_ahead_count; i++) {
                                 ZydisMnemonic mnemonic;
                                 if (jump_to_self) {
                                     // Jump to self, we already decoded the instructions
@@ -2426,7 +2426,9 @@ void Recompiler::scanAhead(u64 rip) {
                             u64 immediate = sextImmediate(getImmediate(&operands[0]), operands[0].imm.size);
                             u64 rip_ahead = rip + instruction.length + immediate;
                             state->in_scan_ahead = true;
+                            state->scan_ahead_address = rip_ahead;
                             thrashed_ahead = scan_landing_block(rip_ahead);
+                            state->scan_ahead_address = 0;
                             state->in_scan_ahead = false;
                         } else if (instruction.mnemonic >= ZYDIS_MNEMONIC_JB && instruction.mnemonic <= ZYDIS_MNEMONIC_JZ) {
                             ASSERT(instruction.mnemonic != ZYDIS_MNEMONIC_JKZD);
@@ -2436,8 +2438,13 @@ void Recompiler::scanAhead(u64 rip) {
                             u64 rip_ahead_true = rip_ahead_false + immediate;
                             // For the flags to not be calculated they need to be overwritten in both paths
                             state->in_scan_ahead = true;
-                            thrashed_ahead = scan_landing_block(rip_ahead_false) & scan_landing_block(rip_ahead_true);
+                            state->scan_ahead_address = rip_ahead_false;
+                            u32 false_flags = scan_landing_block(rip_ahead_false);
+                            state->scan_ahead_address = rip_ahead_true;
+                            u32 true_flags = scan_landing_block(rip_ahead_true);
+                            state->scan_ahead_address = 0;
                             state->in_scan_ahead = false;
+                            thrashed_ahead = false_flags & true_flags;
                         } else {
                             break;
                         }

--- a/src/felix86/v2/recompiler.hpp
+++ b/src/felix86/v2/recompiler.hpp
@@ -20,6 +20,7 @@
 #define FELIX86_HINT_UD2 0xd2
 #define FELIX86_HINT_TF 0x7f
 
+constexpr int scan_ahead_count = 64;
 constexpr int address_cache_bits = 16;
 
 struct AddressCacheEntry {


### PR DESCRIPTION
Some programs may jump to a valid block that has a path that will never be taken at runtime that jumps to a bogus address. For example

```
block:
mov eax, 1
test eax, eax
jz 0x12345678
jmp other_block
```

Those cases are rare and typically only found in software that tries to confuse decompilers. For that reason we don't want to incur the cost of locking Mapper or reading /proc/self/maps on every block compilation, so we instead assume it won't fault and jump out if it does, skipping the scan ahead if so.