### PR TITLE
Linux: Fix getcwd returning bad size

### DIFF
--- a/src/felix86/hle/filesystem.cpp
+++ b/src/felix86/hle/filesystem.cpp
@@ -268,7 +268,7 @@ int Filesystem::Getcwd(char* buf, size_t size) {
         std::string str = buf;
         removeRootfsPrefix(str);
         strncpy(buf, str.c_str(), size);
-        return strlen(buf);
+        return str.size() + 1;
     }
 
     return result;

--- a/src/felix86/v2/handlers.cpp
+++ b/src/felix86/v2/handlers.cpp
@@ -977,6 +977,7 @@ FAST_HANDLE(SUB) {
         }
         case 32: {
             biscuit::Label loop, good_alignment, best_alignment, end;
+            rec.flushX87();
             as.LI(dst, 4);
             as.ANDI(result, address, 0b111);
             as.BEQZ(result, &best_alignment);

--- a/src/felix86/v2/recompiler.cpp
+++ b/src/felix86/v2/recompiler.cpp
@@ -962,6 +962,7 @@ void Recompiler::compileInstruction(ZydisDecodedInstruction& instruction, ZydisD
                 u8 bytes = size / 8;
                 u8 alignment_bits = log2(bytes);
                 u64 mask = (1 << alignment_bits) - 1;
+                flushX87();
                 biscuit::GPR address = lea(&operands[0]);
                 biscuit::GPR temp = scratch();
                 biscuit::Label ok;


### PR DESCRIPTION
Also flushX87 before calling a function in a branch